### PR TITLE
Phase 2: Clean up Docker and cloudflared roles

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,7 +31,7 @@ miuOps provisions a server with Docker, Traefik, Cloudflare Tunnel, and an iptab
 
 - Traffic flows through Cloudflare's network for DDoS protection and WAF
 - No ports are exposed to the internet (all ingress via Cloudflare Tunnel)
-- Services get automatic TLS certificates via Let's Encrypt DNS challenge
+- Traefik reverse proxy handles TLS termination and service routing
 - System and Docker networking are secured with iptables rules
 
 ## Prerequisites

--- a/docs/STRUCTURE.md
+++ b/docs/STRUCTURE.md
@@ -24,6 +24,6 @@
 ## Roles
 
 - **firewall** — Configures iptables with nft backend. INPUT chain (rate-limited SSH, management networks, whitelisted ports) and DOCKER-USER chain (blocks all direct container access, allows only loopback for cloudflared).
-- **docker** — Installs Docker CE + Compose plugin from official repos. Hardens daemon (ICC disabled, userland proxy disabled).
+- **docker** — Installs Docker CE + Compose plugin via signed apt repo. Hardens daemon (ICC disabled, userland proxy disabled).
 - **traefik** — Bootstraps Traefik directories and Docker network. Pulls latest image when stack is deployed.
-- **cloudflared** — Installs cloudflared binary, deploys tunnel credentials and config, creates wildcard + root CNAME DNS records, runs as systemd service.
+- **cloudflared** — Installs cloudflared via apt repo, deploys tunnel credentials and config, creates wildcard + root CNAME DNS records, runs as systemd service.

--- a/group_vars/all.yml.template
+++ b/group_vars/all.yml.template
@@ -21,7 +21,6 @@ cf_api_token: ""  # Cloudflare API Token with DNS edit permissions
 tunnel_id: ""     # UUID of your Cloudflare Tunnel
 credentials_file: "/opt/cloudflared/{{ tunnel_id }}.json"
 
-# Traefik configuration
-# Directories
-traefik_dir: /opt/traefik
-cloudflared_dir: /opt/cloudflared
+# Directories (override role defaults if needed)
+# traefik_dir: /opt/traefik
+# cloudflared_dir: /opt/cloudflared

--- a/roles/cloudflared/defaults/main.yml
+++ b/roles/cloudflared/defaults/main.yml
@@ -1,7 +1,5 @@
 ---
 # cloudflared default variables
 cloudflared_dir: "/opt/cloudflared"
-cloudflared_version: "latest"
-cloudflared_arch: "amd64"
-cloudflared_binary_url: "https://github.com/cloudflare/cloudflared/releases/{{ cloudflared_version }}/download/cloudflared-linux-{{ cloudflared_arch }}"
-cloudflared_systemd_service: true 
+cloudflared_gpg_key_url: "https://pkg.cloudflare.com/cloudflare-main.gpg"
+cloudflared_apt_repository: "deb [signed-by=/etc/apt/keyrings/cloudflare-main.gpg] https://pkg.cloudflare.com/cloudflared {{ ansible_facts['distribution_release'] }} main"

--- a/roles/cloudflared/handlers/main.yml
+++ b/roles/cloudflared/handlers/main.yml
@@ -1,8 +1,11 @@
 ---
 # Handlers for cloudflared
 
+- name: Reload systemd
+  systemd:
+    daemon_reload: yes
+
 - name: Restart cloudflared
   systemd:
     name: cloudflared
     state: restarted
-  when: ansible_os_family == 'Debian' 

--- a/roles/cloudflared/tasks/main.yml
+++ b/roles/cloudflared/tasks/main.yml
@@ -1,37 +1,39 @@
 ---
-# Deploy cloudflared
+# Install cloudflared, deploy tunnel credentials and config, create DNS records
 
 - name: Create cloudflared directory
   file:
     path: "{{ cloudflared_dir }}"
     state: directory
     mode: '0755'
+  tags: ['cloudflared']
 
-- name: Download cloudflared binary (Linux)
+- name: Add Cloudflare GPG key
   get_url:
-    url: "{{ cloudflared_binary_url }}"
-    dest: "/usr/local/bin/cloudflared"
-    mode: '0755'
-  when: ansible_os_family == 'Debian'
+    url: "{{ cloudflared_gpg_key_url }}"
+    dest: /etc/apt/keyrings/cloudflare-main.gpg
+    mode: '0644'
+  tags: ['cloudflared']
 
-# For macOS, uncomment and adapt as needed
-#- name: Install cloudflared (macOS)
-#  homebrew:
-#    name: cloudflare/cloudflare/cloudflared
-#    state: present
-#  when: ansible_os_family == 'Darwin'
+- name: Add Cloudflare apt repository
+  apt_repository:
+    repo: "{{ cloudflared_apt_repository }}"
+    state: present
+  tags: ['cloudflared']
+
+- name: Install cloudflared
+  apt:
+    name: cloudflared
+    state: latest
+    update_cache: yes
+  notify: Restart cloudflared
+  tags: ['cloudflared']
 
 - name: Check if credentials file exists
   stat:
     path: "{{ credentials_file }}"
   register: cf_credentials
-
-- name: Create credential directory if needed
-  file:
-    path: "{{ cloudflared_dir }}"
-    state: directory
-    mode: '0755'
-  when: not cf_credentials.stat.exists
+  tags: ['cloudflared']
 
 - name: Copy tunnel credentials if provided
   copy:
@@ -41,6 +43,7 @@
   when: not cf_credentials.stat.exists
   ignore_errors: true
   register: credentials_copy
+  tags: ['cloudflared']
 
 - name: Warning about missing credentials file
   debug:
@@ -49,8 +52,9 @@
       You need to run 'cloudflared tunnel login' and 'cloudflared tunnel create <name>'
       manually on this server, then copy the JSON credentials to {{ credentials_file }}.
   when: not cf_credentials.stat.exists and (credentials_copy is failed or credentials_copy is skipped)
+  tags: ['cloudflared']
 
-# Set up DNS records for all domains
+# DNS records — 400 means record already exists (idempotent)
 - name: Set up wildcard CNAME records for all domains
   uri:
     url: "https://api.cloudflare.com/client/v4/zones/{{ item.zone_id }}/dns_records"
@@ -65,11 +69,12 @@
       content: "{{ tunnel_id }}.cfargotunnel.com"
       ttl: 1
       proxied: true
-    status_code: [200, 201, 400]  # 400 might happen if record already exists
+    status_code: [200, 201, 400]
   loop: "{{ domains }}"
   when: cf_api_token != "" and item.zone_id is defined and item.zone_id != ""
   register: dns_result_wildcard
   ignore_errors: true
+  tags: ['cloudflared']
 
 - name: Set up root domain CNAME records for all domains
   uri:
@@ -85,11 +90,12 @@
       content: "{{ tunnel_id }}.cfargotunnel.com"
       ttl: 1
       proxied: true
-    status_code: [200, 201, 400]  # 400 might happen if record already exists
+    status_code: [200, 201, 400]
   loop: "{{ domains }}"
   when: cf_api_token != "" and item.zone_id is defined and item.zone_id != ""
   register: dns_result_root
   ignore_errors: true
+  tags: ['cloudflared']
 
 - name: Deploy cloudflared config
   template:
@@ -97,29 +103,24 @@
     dest: "{{ cloudflared_dir }}/config.yml"
     mode: '0644'
   notify: Restart cloudflared
-  when: ansible_os_family == 'Debian'
+  tags: ['cloudflared']
 
 - name: Create systemd service for cloudflared
   template:
     src: cloudflared.service.j2
     dest: /etc/systemd/system/cloudflared.service
     mode: '0644'
-  when: cloudflared_systemd_service and ansible_os_family == 'Debian'
-  register: systemd_service
-  notify: Restart cloudflared
-
-- name: Reload systemd
-  systemd:
-    daemon_reload: yes
-  when: systemd_service is changed and ansible_os_family == 'Debian'
+  notify:
+    - Reload systemd
+    - Restart cloudflared
+  tags: ['cloudflared']
 
 - name: Enable and start cloudflared service
   systemd:
     name: cloudflared
     enabled: yes
     state: started
-  when: cloudflared_systemd_service and ansible_os_family == 'Debian'
+  tags: ['cloudflared']
 
-# Handlers
 - name: Flush handlers
   meta: flush_handlers

--- a/roles/docker/defaults/main.yml
+++ b/roles/docker/defaults/main.yml
@@ -1,4 +1,4 @@
 ---
 # Docker role default variables
-docker_apt_key_url: "https://download.docker.com/linux/{{'debian' if ansible_distribution == 'Debian' else 'ubuntu'}}/gpg"
-docker_apt_repository: "deb [arch=amd64] https://download.docker.com/linux/{{'debian' if ansible_distribution == 'Debian' else 'ubuntu'}} {{ ansible_distribution_release }} stable" 
+docker_gpg_key_url: "https://download.docker.com/linux/{{ 'debian' if ansible_facts['distribution'] == 'Debian' else 'ubuntu' }}/gpg"
+docker_apt_repository: "deb [arch=amd64 signed-by=/etc/apt/keyrings/docker.asc] https://download.docker.com/linux/{{ 'debian' if ansible_facts['distribution'] == 'Debian' else 'ubuntu' }} {{ ansible_facts['distribution_release'] }} stable"

--- a/roles/docker/handlers/main.yml
+++ b/roles/docker/handlers/main.yml
@@ -1,0 +1,7 @@
+---
+# Handlers for Docker
+
+- name: Restart Docker
+  systemd:
+    name: docker
+    state: restarted

--- a/roles/docker/tasks/main.yml
+++ b/roles/docker/tasks/main.yml
@@ -7,22 +7,30 @@
       - apt-transport-https
       - ca-certificates
       - curl
-      - software-properties-common
+      - gnupg
     state: present
     update_cache: yes
-  when: ansible_os_family == 'Debian'
+  tags: ['docker']
+
+- name: Create keyrings directory
+  file:
+    path: /etc/apt/keyrings
+    state: directory
+    mode: '0755'
+  tags: ['docker']
 
 - name: Add Docker GPG key
-  apt_key:
-    url: "{{ docker_apt_key_url }}"
-    state: present
-  when: ansible_os_family == 'Debian'
+  get_url:
+    url: "{{ docker_gpg_key_url }}"
+    dest: /etc/apt/keyrings/docker.asc
+    mode: '0644'
+  tags: ['docker']
 
 - name: Add Docker repository
   apt_repository:
     repo: "{{ docker_apt_repository }}"
     state: present
-  when: ansible_os_family == 'Debian'
+  tags: ['docker']
 
 - name: Install Docker & Compose plugin
   apt:
@@ -33,36 +41,28 @@
       - docker-compose-plugin
     state: present
     update_cache: yes
-  when: ansible_os_family == 'Debian'
-
-# macOS installation using Homebrew (commented out by default)
-#- name: Install Docker Desktop for macOS
-#  homebrew_cask:
-#    name: docker
-#    state: present
-#  when: ansible_os_family == 'Darwin'
+  tags: ['docker']
 
 - name: Create Docker user group
   group:
     name: docker
     state: present
-  when: ansible_os_family == 'Debian'
+  tags: ['docker']
 
 - name: Add the current user to the Docker group
   user:
     name: "{{ ansible_user }}"
     groups: docker
     append: yes
-  when: ansible_os_family == 'Debian'
+  tags: ['docker']
 
 - name: Create Docker daemon configuration directory
   file:
     path: /etc/docker
     state: directory
     mode: '0755'
-  when: ansible_os_family == 'Debian'
+  tags: ['docker']
 
-# Disable inter-container communication and userland proxy
 - name: Configure Docker daemon with security enhancements
   copy:
     content: |
@@ -72,18 +72,12 @@
       }
     dest: /etc/docker/daemon.json
     mode: '0644'
-  register: docker_daemon_config
-  when: ansible_os_family == 'Debian'
+  notify: Restart Docker
+  tags: ['docker']
 
 - name: Ensure Docker is enabled and started
-  service:
+  systemd:
     name: docker
     state: started
     enabled: yes
-  when: ansible_os_family == 'Debian'
-
-- name: Restart Docker if configuration changed
-  service:
-    name: docker
-    state: restarted
-  when: ansible_os_family == 'Debian' and docker_daemon_config.changed
+  tags: ['docker']


### PR DESCRIPTION
## Summary

- **Docker role**: Replace deprecated `apt_key` with modern signed apt repo (GPG key in `/etc/apt/keyrings/`), `service` module with `systemd`, convert inline restart to proper handler, remove dead macOS code and redundant `ansible_os_family` guards, add `[docker]` tags, fix deprecated `ansible_distribution` variable syntax
- **Cloudflared role**: Migrate from raw GitHub binary download to official Cloudflare apt repo (`pkg.cloudflare.com`) for proper upgrades via `state: latest`. Convert inline systemd reload to proper handler. Remove dead macOS code, duplicate directory creation, redundant `ansible_os_family` guards, and unused `cloudflared_systemd_service` variable. Add `[cloudflared]` tags
- **README**: Fix stale "Let's Encrypt DNS challenge" → "Traefik handles TLS termination"
- **group_vars template**: Comment out directory overrides (roles have defaults)

## Files changed

- `roles/docker/tasks/main.yml` — modernized (deprecated modules, dead code, tags)
- `roles/docker/defaults/main.yml` — `apt_key` URL → `gpg_key` URL with `signed-by`, fix deprecated var syntax
- `roles/docker/handlers/main.yml` — new: `Restart Docker` handler
- `roles/cloudflared/tasks/main.yml` — migrated to apt-based install, cleaned up dead code, added tags
- `roles/cloudflared/defaults/main.yml` — replaced `cloudflared_version`/`cloudflared_arch`/`cloudflared_binary_url` with `cloudflared_gpg_key_url` and `cloudflared_apt_repository`
- `roles/cloudflared/handlers/main.yml` — added `Reload systemd` handler, removed `ansible_os_family` guard
- `README.md` — fixed stale Let's Encrypt reference
- `docs/STRUCTURE.md` — updated docker and cloudflared role descriptions
- `group_vars/all.yml.template` — commented out directory overrides

## Test plan

All tests run against dev machine.

**Docker role:**
- [x] `ansible-playbook --syntax-check` passes
- [x] `ansible-playbook --list-tasks` — all 4 roles properly tagged
- [x] Fresh run with new GPG key approach (`changed=2` for key + repo migration)
- [x] Idempotent re-run (`changed=0`)
- [x] No deprecation warnings after fix

**Cloudflared role (apt migration):**
- [x] Fresh install: `changed=4` (GPG key, apt repo, apt install, restart handler)
- [x] Idempotent re-run: `changed=0`
- [x] `cloudflared --version` confirms binary installed correctly