### PR TITLE
fix: support Ubuntu 26.04 for cloudflared and QEMU packaging

### DIFF
--- a/roles/cloudflared/defaults/main.yml
+++ b/roles/cloudflared/defaults/main.yml
@@ -2,8 +2,17 @@
 # cloudflared default variables
 cloudflared_dir: "/opt/cloudflared"
 cloudflared_gpg_key_url: "https://pkg.cloudflare.com/cloudflare-main.gpg"
-# Cloudflare's apt repo is split per codename and lags new Ubuntu releases (no 26.04
-# "resolute" yet). Pin to the latest available LTS codename; cloudflared is a static Go
-# binary and works on newer releases. Override with -e cloudflared_apt_release=<codename>.
-cloudflared_apt_release: "noble"
+# Codenames Cloudflare publishes cloudflared packages for. New releases lag here
+# (e.g. Ubuntu 26.04 "resolute", Debian 13 "trixie"), so cloudflared_apt_release uses
+# the host's native codename when published and otherwise falls back to the newest
+# published LTS of the matching distro. cloudflared is a static Go binary, so an
+# older-codename package runs fine on newer releases. Override with
+# -e cloudflared_apt_release=<codename>.
+cloudflared_supported_releases:
+  - focal      # Ubuntu 20.04
+  - jammy      # Ubuntu 22.04
+  - noble      # Ubuntu 24.04
+  - bullseye   # Debian 11
+  - bookworm   # Debian 12
+cloudflared_apt_release: "{{ ansible_facts['distribution_release'] if ansible_facts['distribution_release'] in cloudflared_supported_releases else ('bookworm' if ansible_facts['distribution'] == 'Debian' else 'noble') }}"
 cloudflared_apt_repository: "deb [arch={{ ansible_facts['architecture'] | replace('x86_64', 'amd64') | replace('aarch64', 'arm64') }} signed-by=/etc/apt/keyrings/cloudflare-main.gpg] https://pkg.cloudflare.com/cloudflared {{ cloudflared_apt_release }} main"

--- a/roles/cloudflared/defaults/main.yml
+++ b/roles/cloudflared/defaults/main.yml
@@ -2,4 +2,8 @@
 # cloudflared default variables
 cloudflared_dir: "/opt/cloudflared"
 cloudflared_gpg_key_url: "https://pkg.cloudflare.com/cloudflare-main.gpg"
-cloudflared_apt_repository: "deb [signed-by=/etc/apt/keyrings/cloudflare-main.gpg] https://pkg.cloudflare.com/cloudflared {{ ansible_facts['distribution_release'] }} main"
+# Cloudflare's apt repo is split per codename and lags new Ubuntu releases (no 26.04
+# "resolute" yet). Pin to the latest available LTS codename; cloudflared is a static Go
+# binary and works on newer releases. Override with -e cloudflared_apt_release=<codename>.
+cloudflared_apt_release: "noble"
+cloudflared_apt_repository: "deb [arch={{ ansible_facts['architecture'] | replace('x86_64', 'amd64') | replace('aarch64', 'arm64') }} signed-by=/etc/apt/keyrings/cloudflare-main.gpg] https://pkg.cloudflare.com/cloudflared {{ cloudflared_apt_release }} main"

--- a/roles/docker/tasks/main.yml
+++ b/roles/docker/tasks/main.yml
@@ -84,6 +84,8 @@
 
 - name: Install QEMU user-mode emulation for cross-architecture containers
   apt:
-    name: qemu-user-static
+    # Ubuntu 25.04+ makes qemu-user-static a virtual package with multiple providers
+    # (apt can't install it directly); use the concrete qemu-user-binfmt package instead.
+    name: "{{ 'qemu-user-binfmt' if ansible_distribution_version is version('25.04', '>=') else 'qemu-user-static' }}"
     state: present
   tags: ['docker']


### PR DESCRIPTION
## Summary

Provisioning on Ubuntu 26.04 LTS (Resolute Raccoon) failed due to two upstream packaging changes. This PR fixes both **without regressing existing Debian/Ubuntu releases**.

## Changes

### cloudflared — codename-aware apt repo
- Cloudflare's apt repo (`pkg.cloudflare.com/cloudflared`) is split per codename and lags new releases. Direct probe: published = `focal`/`jammy`/`noble` (Ubuntu) + `bullseye`/`bookworm` (Debian); **404** = `resolute` (26.04), `oracular` (24.10), `plucky` (25.04), `trixie` (Debian 13).
- New `cloudflared_apt_release` keeps the host's **native codename** when Cloudflare publishes it, and only falls back for unpublished codenames — to `noble` on Ubuntu, `bookworm` on Debian. Overridable via `-e cloudflared_apt_release=<codename>`. cloudflared is a static Go binary, so an older-codename package runs fine on newer releases.
- Added an `arch=` constraint to the repo line for consistency with the `docker` role.

### docker / QEMU — handle virtual package
- On Ubuntu 25.04+, `qemu-user-static` became a **virtual package** provided by multiple packages (`qemu-user-binfmt` + `qemu-user-binfmt-hwe`), so `apt install qemu-user-static` errors out and demands an explicit provider.
- Install the concrete `qemu-user-binfmt` on `>= 25.04`, keeping `qemu-user-static` (a real package) below.

## Regression safety
Rendered via Ansible's engine with simulated facts:

| Host | codename used | QEMU pkg |
|---|---|---|
| Ubuntu 24.04 noble | `noble` (native) | `qemu-user-static` |
| Ubuntu 22.04 jammy | `jammy` (native) | `qemu-user-static` |
| Ubuntu 20.04 focal | `focal` (native) | `qemu-user-static` |
| Debian 11/12 | `bullseye`/`bookworm` (native) | `qemu-user-static` |
| Ubuntu 26.04 resolute | `noble` (fallback) | `qemu-user-binfmt` |
| Debian 13 trixie | `bookworm` (fallback) | `qemu-user-static` |

All currently-working systems keep their previous behavior; only unpublished/new releases change.

## Testing
- `ansible-playbook --syntax-check playbook.yml` -> passes (exit 0).
- Rendered `cloudflared_apt_repository` and the QEMU package expression through Ansible with simulated facts (see table); `arch=` maps `x86_64`->`amd64`, `aarch64`->`arm64`.

## Notes
- GPG signature verification (`signed-by=`) is unchanged.
- The `apt_repository` deprecation (-> `deb822_repository`) is pre-existing across both roles and out of scope.