### PR TITLE
refactor: migrate apt repos to deb822_repository

### DIFF
--- a/roles/cloudflared/defaults/main.yml
+++ b/roles/cloudflared/defaults/main.yml
@@ -15,4 +15,3 @@ cloudflared_supported_releases:
   - bullseye   # Debian 11
   - bookworm   # Debian 12
 cloudflared_apt_release: "{{ ansible_facts['distribution_release'] if ansible_facts['distribution_release'] in cloudflared_supported_releases else ('bookworm' if ansible_facts['distribution'] == 'Debian' else 'noble') }}"
-cloudflared_apt_repository: "deb [arch={{ ansible_facts['architecture'] | replace('x86_64', 'amd64') | replace('aarch64', 'arm64') }} signed-by=/etc/apt/keyrings/cloudflare-main.gpg] https://pkg.cloudflare.com/cloudflared {{ cloudflared_apt_release }} main"

--- a/roles/cloudflared/tasks/main.yml
+++ b/roles/cloudflared/tasks/main.yml
@@ -16,9 +16,39 @@
     mode: '0644'
   tags: ['cloudflared']
 
+- name: Install python3-debian (required by the deb822_repository module)
+  apt:
+    name: python3-debian
+    state: present
+    update_cache: yes
+  tags: ['cloudflared']
+
+- name: Remove legacy Cloudflare .list repo (migrated to deb822 .sources)
+  find:
+    paths: /etc/apt/sources.list.d
+    patterns: '*.list'
+    contains: 'pkg\.cloudflare\.com'
+  register: cloudflared_legacy_list
+  tags: ['cloudflared']
+
+- name: Delete legacy Cloudflare .list repo files
+  file:
+    path: "{{ item.path }}"
+    state: absent
+  loop: "{{ cloudflared_legacy_list.files }}"
+  loop_control:
+    label: "{{ item.path }}"
+  tags: ['cloudflared']
+
 - name: Add Cloudflare apt repository
-  apt_repository:
-    repo: "{{ cloudflared_apt_repository }}"
+  deb822_repository:
+    name: cloudflared
+    types: deb
+    uris: https://pkg.cloudflare.com/cloudflared
+    suites: "{{ cloudflared_apt_release }}"
+    components: main
+    architectures: "{{ ansible_facts['architecture'] | replace('x86_64', 'amd64') | replace('aarch64', 'arm64') }}"
+    signed_by: /etc/apt/keyrings/cloudflare-main.gpg
     state: present
   tags: ['cloudflared']
 

--- a/roles/docker/defaults/main.yml
+++ b/roles/docker/defaults/main.yml
@@ -1,4 +1,3 @@
 ---
 # Docker role default variables
 docker_gpg_key_url: "https://download.docker.com/linux/{{ 'debian' if ansible_facts['distribution'] == 'Debian' else 'ubuntu' }}/gpg"
-docker_apt_repository: "deb [arch={{ ansible_facts['architecture'] | replace('x86_64', 'amd64') | replace('aarch64', 'arm64') }} signed-by=/etc/apt/keyrings/docker.asc] https://download.docker.com/linux/{{ 'debian' if ansible_facts['distribution'] == 'Debian' else 'ubuntu' }} {{ ansible_facts['distribution_release'] }} stable"

--- a/roles/docker/tasks/main.yml
+++ b/roles/docker/tasks/main.yml
@@ -8,6 +8,7 @@
       - ca-certificates
       - curl
       - gnupg
+      - python3-debian  # required by the deb822_repository module
     state: present
     update_cache: yes
   tags: ['docker']
@@ -26,9 +27,32 @@
     mode: '0644'
   tags: ['docker']
 
+- name: Remove legacy Docker .list repo (migrated to deb822 .sources)
+  find:
+    paths: /etc/apt/sources.list.d
+    patterns: '*.list'
+    contains: 'download\.docker\.com'
+  register: docker_legacy_list
+  tags: ['docker']
+
+- name: Delete legacy Docker .list repo files
+  file:
+    path: "{{ item.path }}"
+    state: absent
+  loop: "{{ docker_legacy_list.files }}"
+  loop_control:
+    label: "{{ item.path }}"
+  tags: ['docker']
+
 - name: Add Docker repository
-  apt_repository:
-    repo: "{{ docker_apt_repository }}"
+  deb822_repository:
+    name: docker
+    types: deb
+    uris: "https://download.docker.com/linux/{{ 'debian' if ansible_facts['distribution'] == 'Debian' else 'ubuntu' }}"
+    suites: "{{ ansible_facts['distribution_release'] }}"
+    components: stable
+    architectures: "{{ ansible_facts['architecture'] | replace('x86_64', 'amd64') | replace('aarch64', 'arm64') }}"
+    signed_by: /etc/apt/keyrings/docker.asc
     state: present
   tags: ['docker']
 


### PR DESCRIPTION
## Summary

`apt_repository` is deprecated and will be **removed in ansible-core 2.25** (it already emits a deprecation warning on every run). This migrates the Docker and Cloudflare apt repos to the `deb822_repository` module (modern `.sources` format), with explicit guards so it does not regress fresh installs or already-provisioned servers.

## Changes
- `roles/docker/tasks/main.yml` — Docker repo via `deb822_repository`; add `python3-debian` to prerequisites.
- `roles/cloudflared/tasks/main.yml` — Cloudflare repo via `deb822_repository`; add a `python3-debian` task (role stays independently runnable via `--tags cloudflared`).
- Both roles — remove any **legacy `.list`** file for the repo before writing the `.sources` (content-matched on the repo host).
- `roles/*/defaults/main.yml` — drop the now-unused `*_apt_repository` deb-string vars; cloudflared keeps its codename-fallback `cloudflared_apt_release`.

## Why these guards (regression safety)
1. **`python3-debian` is a hard requirement** of `deb822_repository` (`ansible-doc`: `REQUIREMENTS: python3-debian / python-debian`). A fresh server lacks it, so the module would fail — installed up-front in each role.
2. **No duplicate repos on existing hosts.** Migrating leaves the old auto-named `.list` alongside the new `.sources` → apt "configured multiple times" warning. A `find` (matching `download.docker.com` / `pkg.cloudflare.com`) + remove handles this regardless of the legacy filename.
3. **Behavior unchanged** — identical URIs, suite/codename (incl. cloudflared's 26.04 fallback), components, `arch=`, and `signed_by` keyring paths.

## Idempotency
- First apply: install `python3-debian`, remove legacy `.list`, write `.sources` (changed).
- Second apply: package present, no `.list` to find, `.sources` already correct → **changed=0**.

## Testing
- `ansible-playbook --syntax-check playbook.yml` → exit 0.
- Verified no remaining `apt_repository` usage and no dangling references to the removed vars.
- Rendered the `deb822_repository` inputs via Ansible across distros: Ubuntu→`ubuntu`/native codename, Debian→`debian`/native codename; `arch=` maps `x86_64`→`amd64`, `aarch64`→`arm64`.
- Full apt-level execution is validated by **CI** (applies the playbook twice against the dev server + idempotency check + verifies docker/cloudflared active) — macOS has no container runtime for local apt execution.

## Notes
- `.sources` files land at `/etc/apt/sources.list.d/{docker,cloudflared}.sources`.