### PR TITLE
fix(firewall): harden SSH rate-limit (mgmt-net exempt + no self-extending ban)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -100,12 +100,16 @@ jobs:
             echo "$v4" | grep -q "^-P FORWARD DROP"          || { echo "FAIL: IPv4 FORWARD policy is not DROP"; exit 1; }
             echo "$v4" | grep -qE "INPUT.*ctstate.*ESTABLISHED" || { echo "FAIL: no ESTABLISHED/RELATED accept on INPUT"; exit 1; }
             echo "$v4" | grep -q -- "--name ssh"             || { echo "FAIL: SSH protection rule missing"; exit 1; }
+            echo "$v4" | grep -q -- "--rcheck"               || { echo "FAIL: SSH rate-limit not using --rcheck (self-extending ban risk)"; exit 1; }
+            echo "$v4" | grep -q -- "--update"               && { echo "FAIL: SSH rate-limit reintroduced self-extending --update"; exit 1; }
             echo "$v4" | grep -q "^-A DOCKER-USER -j DROP"   || { echo "FAIL: DOCKER-USER missing final DROP"; exit 1; }
             echo "$v4" | grep -q -- "-A FORWARD -j DOCKER-USER" || { echo "FAIL: IPv4 FORWARD does not jump to DOCKER-USER (published ports unguarded)"; exit 1; }
             echo "$v6" | grep -q "^-P INPUT DROP"            || { echo "FAIL: IPv6 INPUT policy is not DROP"; exit 1; }
             echo "$v6" | grep -q "^-P FORWARD DROP"          || { echo "FAIL: IPv6 FORWARD policy is not DROP"; exit 1; }
             echo "$v6" | grep -qE "INPUT.*ctstate.*ESTABLISHED" || { echo "FAIL: no ESTABLISHED/RELATED accept on IPv6 INPUT"; exit 1; }
             echo "$v6" | grep -q -- "--name ssh"             || { echo "FAIL: IPv6 SSH protection rule missing"; exit 1; }
+            echo "$v6" | grep -q -- "--rcheck"               || { echo "FAIL: IPv6 SSH rate-limit not using --rcheck"; exit 1; }
+            echo "$v6" | grep -q -- "--update"               && { echo "FAIL: IPv6 SSH rate-limit reintroduced self-extending --update"; exit 1; }
             echo "$v6" | grep -q "^-A DOCKER-USER -j DROP"   || { echo "FAIL: IPv6 DOCKER-USER missing final DROP"; exit 1; }
             echo "$v6" | grep -q -- "-A FORWARD -j DOCKER-USER" || { echo "FAIL: IPv6 FORWARD does not jump to DOCKER-USER (published ports unguarded)"; exit 1; }
             echo "ALL FIREWALL SECURITY ASSERTIONS PASSED"

--- a/roles/firewall/defaults/main.yml
+++ b/roles/firewall/defaults/main.yml
@@ -25,8 +25,10 @@ firewall_whitelist_ports_v6: []
 ssh_port: "22"
 
 # SSH brute-force protection. Default on (the only protection for users without a
-# fixed source IP). Operators who allowlist firewall_management_networks_* may
-# set firewall_ssh_ratelimit_enabled: false in that host's host_vars.
+# fixed source IP). Management networks (firewall_management_networks_*) are
+# allowed before this rule, so they bypass it; an operator who allowlists may also
+# set firewall_ssh_ratelimit_enabled: false. The default 10 new conns / 60s is
+# forgiving for scp/rsync/CI bursts while still throttling brute force.
 firewall_ssh_ratelimit_enabled: true
-firewall_ssh_ratelimit_hits: 6
+firewall_ssh_ratelimit_hits: 10
 firewall_ssh_ratelimit_seconds: 60

--- a/roles/firewall/templates/rules.v4.j2
+++ b/roles/firewall/templates/rules.v4.j2
@@ -20,19 +20,22 @@
 # block at this position that is REQUIRED. Keep the two templates in sync with
 # that asymmetry in mind.
 
-# 4. SSH
+# 4. management nets — trusted sources fully allowed, and (being before the SSH
+#    rule) exempt from the SSH rate-limit below
+{% for cidr in firewall_management_networks_v4|default([]) %}
+-A INPUT -s {{ cidr }} -j ACCEPT
+{% endfor %}
+
+# 5. SSH
 {% if firewall_ssh_ratelimit_enabled | bool %}
-# rate-limited (default): drop sources over the burst, else accept + track
--A INPUT -p tcp --dport {{ ssh_port }} -m recent --name ssh --update --seconds {{ firewall_ssh_ratelimit_seconds }} --hitcount {{ firewall_ssh_ratelimit_hits }} -j DROP
+# rate-limited (default): drop sources over the burst, else accept + track.
+# Use --rcheck (not the timestamp-refreshing variant) so a blocked attempt does
+# NOT extend the window — the ban self-clears instead of self-extending under load.
+-A INPUT -p tcp --dport {{ ssh_port }} -m recent --name ssh --rcheck --seconds {{ firewall_ssh_ratelimit_seconds }} --hitcount {{ firewall_ssh_ratelimit_hits }} -j DROP
 -A INPUT -p tcp --dport {{ ssh_port }} -m recent --name ssh --set -j ACCEPT
 {% else %}
 -A INPUT -p tcp --dport {{ ssh_port }} -j ACCEPT
 {% endif %}
-
-# 5. management nets
-{% for cidr in firewall_management_networks_v4|default([]) %}
--A INPUT -s {{ cidr }} -j ACCEPT
-{% endfor %}
 
 # 6. whitelisted ports
 {% for port in firewall_whitelist_ports_v4|default([]) %}

--- a/roles/firewall/templates/rules.v6.j2
+++ b/roles/firewall/templates/rules.v6.j2
@@ -35,19 +35,22 @@
 -A INPUT -p ipv6-icmp --icmpv6-type neighbour-solicitation -m hl --hl-eq 255 -j ACCEPT
 -A INPUT -p ipv6-icmp --icmpv6-type neighbour-advertisement -m hl --hl-eq 255 -j ACCEPT
 
-# 4. SSH
+# 4. management nets — trusted sources fully allowed, and (being before the SSH
+#    rule) exempt from the SSH rate-limit below
+{% for cidr in firewall_management_networks_v6|default([]) %}
+-A INPUT -s {{ cidr }} -j ACCEPT
+{% endfor %}
+
+# 5. SSH
 {% if firewall_ssh_ratelimit_enabled | bool %}
-# rate-limited (default): drop sources over the burst, else accept + track
--A INPUT -p tcp --dport {{ ssh_port }} -m recent --name ssh --update --seconds {{ firewall_ssh_ratelimit_seconds }} --hitcount {{ firewall_ssh_ratelimit_hits }} -j DROP
+# rate-limited (default): drop sources over the burst, else accept + track.
+# Use --rcheck (not the timestamp-refreshing variant) so a blocked attempt does
+# NOT extend the window — the ban self-clears instead of self-extending under load.
+-A INPUT -p tcp --dport {{ ssh_port }} -m recent --name ssh --rcheck --seconds {{ firewall_ssh_ratelimit_seconds }} --hitcount {{ firewall_ssh_ratelimit_hits }} -j DROP
 -A INPUT -p tcp --dport {{ ssh_port }} -m recent --name ssh --set -j ACCEPT
 {% else %}
 -A INPUT -p tcp --dport {{ ssh_port }} -j ACCEPT
 {% endif %}
-
-# 5. management nets
-{% for cidr in firewall_management_networks_v6|default([]) %}
--A INPUT -s {{ cidr }} -j ACCEPT
-{% endfor %}
 
 # 6. whitelisted ports
 {% for port in firewall_whitelist_ports_v6|default([]) %}


### PR DESCRIPTION
Completes backlog item **#2** — the SSH rate-limit *parameterization* shipped in #36; this is the structural hardening.

## Changes
- **Management networks bypass the SSH rate-limit.** The `firewall_management_networks_*` allow now comes **before** the SSH rule (v4 + v6), so trusted sources are never throttled (previously the rate-limit was evaluated first).
- **No self-extending ban.** The SSH rate-limit uses `-m recent --rcheck` instead of `--update`, so a blocked attempt no longer refreshes the window — the ban self-clears after the window instead of extending under sustained load (the classic `-m recent` foot-gun).
- **More forgiving default.** `firewall_ssh_ratelimit_hits` 6 → 10 (per 60s): fewer false trips for scp/rsync/CI bursts, still throttles brute force (and SSH is key-only). Still fully tunable / disablable per host.

## Testing
- Rendered both templates, both branches: mgmt-net before SSH ✓; rule uses `--rcheck`, no `--update` anywhere ✓; `--name ssh` present (CI assertion) ✓; disabled branch = plain accept ✓; IPv6 ICMPv6/NDP block intact ✓.
- `ansible-playbook --syntax-check` ✓.
- CI exercises the firewall security assertions + change-path against the dev server.

Note: the first apply re-renders the ruleset (template changed) → one-time `changed=1`, idempotent afterward.
