### PR TITLE
fix(docker): use ansible_facts['distribution_version'] (deprecation)

### DIFF
--- a/roles/docker/tasks/main.yml
+++ b/roles/docker/tasks/main.yml
@@ -110,6 +110,6 @@
   apt:
     # Ubuntu 25.04+ makes qemu-user-static a virtual package with multiple providers
     # (apt can't install it directly); use the concrete qemu-user-binfmt package instead.
-    name: "{{ 'qemu-user-binfmt' if ansible_distribution_version is version('25.04', '>=') else 'qemu-user-static' }}"
+    name: "{{ 'qemu-user-binfmt' if ansible_facts['distribution_version'] is version('25.04', '>=') else 'qemu-user-static' }}"
     state: present
   tags: ['docker']


### PR DESCRIPTION
Fixes the Ansible deprecation warning seen during converge:

> INJECT_FACTS_AS_VARS default to `True` is deprecated … removed in ansible-core 2.24

The qemu-install task (`roles/docker/tasks/main.yml`) used the auto-injected top-level fact var `ansible_distribution_version`. Switched to `ansible_facts['distribution_version']` (non-deprecated form). Only occurrence in the repo — cloudflared already uses `ansible_facts[...]`.

Verified: `--syntax-check` ✓; version logic unchanged (24.04→qemu-user-static, 25.04/26.04→qemu-user-binfmt).