### PR TITLE
chore(security): hardening sweep from full-project audit

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -9,6 +9,11 @@ concurrency:
   group: ansible-dev
   cancel-in-progress: true
 
+# Least privilege: the job only checks out code and SSHes out to the dev server;
+# it never uses GITHUB_TOKEN to write back to the repo.
+permissions:
+  contents: read
+
 jobs:
   ansible:
     runs-on: ubuntu-latest
@@ -103,6 +108,7 @@ jobs:
             echo "$v4" | grep -q -- "--rcheck"               || { echo "FAIL: SSH rate-limit not using --rcheck (self-extending ban risk)"; exit 1; }
             echo "$v4" | grep -q -- "--update"               && { echo "FAIL: SSH rate-limit reintroduced self-extending --update"; exit 1; }
             echo "$v4" | grep -q "^-A DOCKER-USER -j DROP"   || { echo "FAIL: DOCKER-USER missing final DROP"; exit 1; }
+            echo "$v4" | grep -qE "DOCKER-USER.*ctstate INVALID.*-j DROP" || { echo "FAIL: DOCKER-USER missing INVALID drop"; exit 1; }
             echo "$v4" | grep -q -- "-A FORWARD -j DOCKER-USER" || { echo "FAIL: IPv4 FORWARD does not jump to DOCKER-USER (published ports unguarded)"; exit 1; }
             echo "$v6" | grep -q "^-P INPUT DROP"            || { echo "FAIL: IPv6 INPUT policy is not DROP"; exit 1; }
             echo "$v6" | grep -q "^-P FORWARD DROP"          || { echo "FAIL: IPv6 FORWARD policy is not DROP"; exit 1; }
@@ -111,6 +117,7 @@ jobs:
             echo "$v6" | grep -q -- "--rcheck"               || { echo "FAIL: IPv6 SSH rate-limit not using --rcheck"; exit 1; }
             echo "$v6" | grep -q -- "--update"               && { echo "FAIL: IPv6 SSH rate-limit reintroduced self-extending --update"; exit 1; }
             echo "$v6" | grep -q "^-A DOCKER-USER -j DROP"   || { echo "FAIL: IPv6 DOCKER-USER missing final DROP"; exit 1; }
+            echo "$v6" | grep -qE "DOCKER-USER.*ctstate INVALID.*-j DROP" || { echo "FAIL: IPv6 DOCKER-USER missing INVALID drop"; exit 1; }
             echo "$v6" | grep -q -- "-A FORWARD -j DOCKER-USER" || { echo "FAIL: IPv6 FORWARD does not jump to DOCKER-USER (published ports unguarded)"; exit 1; }
             echo "ALL FIREWALL SECURITY ASSERTIONS PASSED"
           '

--- a/docs/SCALING.md
+++ b/docs/SCALING.md
@@ -22,7 +22,7 @@ each server's `files/<tunnel_id>.json`, then retire the old clones.
 ## Per-server firewall posture
 
 Each server's exposure is data in its `host_vars`. Defaults are generic-safe (SSH
-rate-limited, 6 attempts / 60s). To harden a specific server:
+rate-limited, 10 attempts / 60s). To harden a specific server:
 
 ```yaml
 # host_vars/prod-a.yml
@@ -40,6 +40,29 @@ no per-domain tokens. It is **bootstrap-only**: `up`/`add-domain`/`remove-domain
 use it for DNS; day-2 `apply` does not need it (tunnels run from the on-server
 `<tunnel_id>.json`). The token is an env var and never enters `host_vars`, the
 inventory, or anything committed. Prefer a scoped token over the Global API Key.
+
+## Co-hosting multiple projects on one server (shared dev)
+
+One server can host several projects at once (e.g. a shared dev box). Each project
+deploys its own compose stack on its own per-stack networks; Traefik routes by
+`Host()`. Add each project's domain with `miuops add-domain <host> dev.projectX.example`.
+
+**Prefix every project's environment variables with the project handle.** All
+stacks on a server share one `/opt/stacks/.env`, so unprefixed names collide —
+project A's `DB_PASSWORD` would silently overwrite project B's. Namespace them:
+
+```dotenv
+# /opt/stacks/.env — one shared file, namespaced per project
+APP1_DB_PASSWORD=...
+APP1_API_KEY=...
+APP2_DB_PASSWORD=...
+APP2_API_KEY=...
+```
+
+Reference the prefixed name in each stack's compose (`${APP1_DB_PASSWORD}`). This
+stops projects from clobbering each other's values and makes it obvious which secret
+belongs to which project. For stronger isolation, give each stack its own file via
+compose `env_file:` instead of the shared `.env`.
 
 ## Optional advanced patterns
 

--- a/miuops
+++ b/miuops
@@ -47,6 +47,7 @@ write_host_vars() {
     { echo "---"; echo "domains:";
       local d; for d in "$@"; do echo "  - \"${d}\""; done
       echo ""; echo "tunnel_id: \"${tid}\""; } > "$tmp"
+    chmod 600 "$tmp"   # restrict before publishing (consistent with files/*.json)
     mv "$tmp" "$f"   # atomic — no half-written YAML if interrupted mid-write
 }
 

--- a/roles/cloudflared/tasks/main.yml
+++ b/roles/cloudflared/tasks/main.yml
@@ -66,23 +66,31 @@
   register: cf_credentials
   tags: ['cloudflared']
 
-- name: Copy tunnel credentials if provided
+- name: Check for the local tunnel credentials file
+  stat:
+    path: "{{ playbook_dir }}/files/{{ tunnel_id }}.json"
+  delegate_to: localhost
+  become: false
+  register: cf_local_credentials
+  tags: ['cloudflared']
+
+- name: Require tunnel credentials (on the server or in files/)
+  assert:
+    that: cf_credentials.stat.exists or cf_local_credentials.stat.exists
+    fail_msg: >-
+      No tunnel credentials for {{ tunnel_id }}: not on the server at
+      {{ credentials_file }} and not in files/{{ tunnel_id }}.json. Create the
+      tunnel and place its JSON in files/ (see docs/INSTALLATION.md), then re-run.
+    quiet: true
+  tags: ['cloudflared']
+
+- name: Copy tunnel credentials to the server
   copy:
     src: "files/{{ tunnel_id }}.json"
     dest: "{{ credentials_file }}"
     mode: '0600'
+  no_log: true
   when: not cf_credentials.stat.exists
-  ignore_errors: true
-  register: credentials_copy
-  tags: ['cloudflared']
-
-- name: Warning about missing credentials file
-  debug:
-    msg: |
-      WARNING: Tunnel credentials file wasn't found or couldn't be copied.
-      You need to run 'cloudflared tunnel login' and 'cloudflared tunnel create <name>'
-      manually on this server, then copy the JSON credentials to {{ credentials_file }}.
-  when: not cf_credentials.stat.exists and (credentials_copy is failed or credentials_copy is skipped)
   tags: ['cloudflared']
 
 - name: Deploy cloudflared config

--- a/roles/docker/tasks/main.yml
+++ b/roles/docker/tasks/main.yml
@@ -92,7 +92,12 @@
     content: |
       {
         "icc": false,
-        "userland-proxy": false
+        "userland-proxy": false,
+        "no-new-privileges": true,
+        "live-restore": true,
+        "log-driver": "json-file",
+        "log-opts": { "max-size": "10m", "max-file": "3" },
+        "default-ulimits": { "nofile": { "Name": "nofile", "Soft": 65536, "Hard": 65536 } }
       }
     dest: /etc/docker/daemon.json
     mode: '0644'

--- a/roles/firewall/templates/rules.v4.j2
+++ b/roles/firewall/templates/rules.v4.j2
@@ -46,17 +46,21 @@
 -A INPUT -j DROP
 
 ############ DOCKER-USER ############
-# 1. EST/REL
+# 1. drop invalid (mirror INPUT; keeps published ports protected even if an
+#    accept/return rule is ever added before the final DROP below)
+-A DOCKER-USER -m conntrack --ctstate INVALID -j DROP
+
+# 2. EST/REL
 -A DOCKER-USER -m conntrack --ctstate ESTABLISHED,RELATED -j RETURN
 
-# 2. containers -> any (outbound access, cross-host, cross-network)
+# 3. containers -> any (outbound access, cross-host, cross-network)
 # note: DOCKER-ISOLATION will be applied after DOCKER-USER for same-network isolation, so that the cross-network traffic will be blocked
 -A DOCKER-USER -i br+ -j RETURN
 
-# 3. loopback -> Docker bridge (for cloudflared via 127.0.0.1)
+# 4. loopback -> Docker bridge (for cloudflared via 127.0.0.1)
 -A DOCKER-USER -i lo -o br+ -j RETURN
 
-# 4. drop all other traffic (block inbound)
+# 5. drop all other traffic (block inbound)
 -A DOCKER-USER -j DROP
 
 COMMIT

--- a/roles/firewall/templates/rules.v6.j2
+++ b/roles/firewall/templates/rules.v6.j2
@@ -61,17 +61,21 @@
 -A INPUT -j DROP
 
 ############ DOCKER-USER ############
-# 1. EST/REL
+# 1. drop invalid (mirror INPUT; keeps published ports protected even if an
+#    accept/return rule is ever added before the final DROP below)
+-A DOCKER-USER -m conntrack --ctstate INVALID -j DROP
+
+# 2. EST/REL
 -A DOCKER-USER -m conntrack --ctstate ESTABLISHED,RELATED -j RETURN
 
-# 2. containers -> any (outbound access, cross-host, cross-network)
+# 3. containers -> any (outbound access, cross-host, cross-network)
 # note: DOCKER-ISOLATION will be applied after DOCKER-USER for same-network isolation, so that the cross-network traffic will be blocked
 -A DOCKER-USER -i br+ -j RETURN
 
-# 3. loopback -> Docker bridge (for cloudflared via 127.0.0.1)
+# 4. loopback -> Docker bridge (for cloudflared via 127.0.0.1)
 -A DOCKER-USER -i lo -o br+ -j RETURN
 
-# 4. drop all other traffic (block inbound)
+# 5. drop all other traffic (block inbound)
 -A DOCKER-USER -j DROP
 
 COMMIT

--- a/tests/cli_test.sh
+++ b/tests/cli_test.sh
@@ -14,6 +14,9 @@ source "$ROOT/miuops" --source-only
 mkdir -p "$TMP/host_vars"
 write_host_vars server-a tunnelA example.com example.org
 [ -f "$TMP/host_vars/server-a.yml" ] || fail "host_vars not written"
+# host_vars must be written 0600 (portable: Linux `stat -c`, macOS `stat -f`)
+hvperm="$(stat -c '%a' "$TMP/host_vars/server-a.yml" 2>/dev/null || stat -f '%Lp' "$TMP/host_vars/server-a.yml")"
+[ "$hvperm" = "600" ] || fail "host_vars not written 0600 (got $hvperm)"
 hv_tunnel server-a | grep -qx tunnelA      || fail "tunnel_id wrong"
 hv_domains server-a | grep -qx example.com || fail "domain example.com missing"
 hv_domains server-a | grep -qx example.org || fail "domain example.org missing"


### PR DESCRIPTION
Low-risk, high-value security hardening.

- **firewall**: DOCKER-USER drops INVALID-state packets first (mirroring the INPUT chain), so published container ports stay protected even if an accept rule is ever added before the final DROP. Locked in with a CI assertion (v4 + v6).
- **docker**: `daemon.json` adds `no-new-privileges`, `live-restore`, json-file log rotation (10m × 3), and default nofile ulimits.
- **cloudflared**: tunnel-credential handling is fail-closed — it asserts the credential is present (on the server or in `files/`) and aborts otherwise, instead of silently bootstrapping a credential-less server; the copy drops `ignore_errors` and adds `no_log`.
- **ci**: least-privilege `permissions: contents: read`.
- **cli**: `host_vars/*.yml` written `0600` (consistent with `files/*.json`) + a portable perms test.
- **docs**: per-project environment-variable naming convention for shared servers (SCALING.md); fixed a stale SSH rate-limit default in the docs (now 10 / 60s).

Verified locally: `ansible-playbook --syntax-check`, `shellcheck -S error miuops`, `bash tests/cli_test.sh`, plus daemon.json JSON and ci.yml YAML validation.

Follow-ups (deferred, higher-risk): run cloudflared as a non-root user with systemd sandboxing; move the Cloudflare API token off the curl command line.