### PR TITLE
ci(deps): add Renovate config for dependency updates

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -1,0 +1,32 @@
+{
+  "$schema": "https://docs.renovatebot.com/renovate-schema.json",
+  "extends": [
+    "config:recommended",
+    ":semanticCommits",
+    "schedule:weekly",
+    "helpers:pinGitHubActionDigests"
+  ],
+  "labels": ["dependencies"],
+  "dependencyDashboard": true,
+  "customManagers": [
+    {
+      "customType": "regex",
+      "description": "Grafana Alloy image pinned in the observability role defaults",
+      "fileMatch": ["^roles/observability/defaults/main\\.yml$"],
+      "matchStrings": [
+        "observability_alloy_image:\\s*\"(?<depName>[^:\"]+):(?<currentValue>[^\"]+)\""
+      ],
+      "datasourceTemplate": "docker"
+    },
+    {
+      "customType": "regex",
+      "description": "WAL-G release pinned in the postgres-walg image",
+      "fileMatch": ["^images/postgres-walg/Dockerfile$"],
+      "matchStrings": [
+        "ARG WALG_VERSION=(?<currentValue>v[0-9][0-9.]*)"
+      ],
+      "depNameTemplate": "wal-g/wal-g",
+      "datasourceTemplate": "github-releases"
+    }
+  ]
+}

--- a/renovate.json
+++ b/renovate.json
@@ -12,7 +12,7 @@
     {
       "customType": "regex",
       "description": "Grafana Alloy image pinned in the observability role defaults",
-      "fileMatch": ["^roles/observability/defaults/main\\.yml$"],
+      "managerFilePatterns": ["/^roles/observability/defaults/main\\.yml$/"],
       "matchStrings": [
         "observability_alloy_image:\\s*\"(?<depName>[^:\"]+):(?<currentValue>[^\"]+)\""
       ],
@@ -21,7 +21,7 @@
     {
       "customType": "regex",
       "description": "WAL-G release pinned in the postgres-walg image",
-      "fileMatch": ["^images/postgres-walg/Dockerfile$"],
+      "managerFilePatterns": ["/^images/postgres-walg/Dockerfile$/"],
       "matchStrings": [
         "ARG WALG_VERSION=(?<currentValue>v[0-9][0-9.]*)"
       ],


### PR DESCRIPTION
Adds `renovate.json` to automate dependency update PRs (you review + merge — updates stay deliberate, not auto-applied).

**Covered:**
- **Grafana Alloy image** (`grafana/alloy:vX.Y.Z` in the observability role) — custom regex manager, docker datasource.
- **GitHub Actions** — pinned to commit SHA and kept updated (`helpers:pinGitHubActionDigests`).
- **Ansible Galaxy collections** (`requirements.yml`) — native ansible-galaxy manager.
- **postgres base image** (`images/postgres-walg/Dockerfile` `FROM postgres:17`) — native dockerfile manager.
- **WAL-G** (`ARG WALG_VERSION` in the Dockerfile) — custom regex manager, github-releases datasource.

Weekly schedule, semantic-commit messages, a dependency-dashboard issue, `dependencies` label.

**Not covered (by design):** apt packages (handled at runtime by the playbook's `apt upgrade full` — deliberate, see ops notes) and the Docker/Cloudflare GPG keys (TOFU).

**Manual step after merge:** install the Renovate GitHub App on the repo (github.com/apps/renovate) for it to run. With this config present, Renovate skips onboarding and uses it directly.