### PR TITLE
fix(observability): stamp source host on metrics and logs

### DIFF
--- a/roles/observability/templates/config.alloy.j2
+++ b/roles/observability/templates/config.alloy.j2
@@ -36,6 +36,14 @@ prometheus.scrape "cloudflared" {
 {% endif %}
 
 prometheus.remote_write "grafana_cloud" {
+  // Stamp the source host on every metric. Some scrape targets have an identity
+  // that is identical across hosts (e.g. cloudflared at the fixed 127.0.0.1:2000
+  // address yields instance="127.0.0.1:2000" everywhere). Without a distinguishing
+  // label those series collide in Mimir and overwrite each other (out-of-order /
+  // dropped samples). node/cadvisor already get a host-unique instance (the unix
+  // exporter defaults instance to the machine hostname), so this is additive there.
+  external_labels = { host = constants.hostname }
+
   endpoint {
     url = "{{ grafana_cloud_prometheus_url }}"
     basic_auth {
@@ -73,6 +81,10 @@ loki.source.docker "containers" {
 }
 
 loki.write "grafana_cloud" {
+  // Stamp the source host on every log line so identically-named containers on
+  // different hosts (e.g. traefik) stay distinguishable in Loki.
+  external_labels = { host = constants.hostname }
+
   endpoint {
     url = "{{ grafana_cloud_loki_url }}"
     basic_auth {


### PR DESCRIPTION
## Problem

The Grafana Alloy agent (`roles/observability`) ships metrics and logs from each enabled host (`observability_enabled: true`) to Grafana Cloud. Two classes of series are not distinguishable by source host:

- **cloudflared metrics collide.** The cloudflared scrape target uses a fixed `__address__` (`127.0.0.1:2000`), so its series resolve to `{job="cloudflared", instance="127.0.0.1:2000"}` on *every* enabled host. cloudflared's own metrics expose no host identity, and `prometheus.remote_write "grafana_cloud"` had no `external_labels`, so nothing stamped the source. Identical series from different hosts overwrite each other in Mimir — out-of-order / dropped samples.
- **logs are container-only labeled.** The logs pipeline labels lines by `container` (and `stream`) but not by host, so identically-named containers on different hosts (e.g. `traefik`) are indistinguishable in Loki.

## Root cause

No host-identifying label on the egress components. `node`/`cadvisor` metrics are *not* affected: the unix exporter defaults `instance` to the machine hostname, and the Alloy container runs with host networking and no `--hostname`, so that resolves to the host's hostname — unique per host. cloudflared's fixed address bypasses this.

## Fix

Add `external_labels = { host = constants.hostname }` to both egress components in `roles/observability/templates/config.alloy.j2`:

- `prometheus.remote_write "grafana_cloud"` — disambiguates cloudflared (and stamps `host` on all metrics; additive for node/cadvisor which already have a unique `instance`).
- `loki.write "grafana_cloud"` — stamps `host` on every log line.

`constants.hostname` is Alloy stdlib resolving to the host's hostname (host networking, no `--hostname` override). Changes are additive — no existing `instance` / `job` / `container` labels are modified.

Validated with `alloy fmt` (v1.5.1, the pinned image) against a Jinja-substituted render: valid River syntax.

## Verification (requires a re-converge — not done here)

Re-converge **each enabled host** with the `GRAFANA_CLOUD_*` env vars exported (this PR is implementation only; no hosts were deployed/converged). Then, in Grafana Cloud:

- **Metrics** — `count by (host) (up{job="cloudflared"})` should return one series per enabled host (was effectively one colliding series before). Confirm cloudflared samples are no longer dropped/out-of-order.
- `count by (host) (up)` — every host present; node/cadvisor series unchanged apart from the new additive `host` label.
- **Logs** — `{container="traefik"}` should now carry a distinct `host` label per source host; `sum by (host) (count_over_time({container="traefik"}[5m]))` returns one series per host.