### PR TITLE
ci(deps): bump setup-qemu-action + ignore postgres major

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -16,6 +16,11 @@ updates:
       interval: "weekly"
     commit-message:
       prefix: "build(deps)"
+    ignore:
+      # postgres major bumps require a deliberate pg_upgrade of live data —
+      # don't auto-PR them. Remove this entry to intentionally move to a new major.
+      - dependency-name: "postgres"
+        update-types: ["version-update:semver-major"]
 
 # Not covered by Dependabot (no manager): the Alloy image pin in
 # roles/observability/defaults/main.yml, the Ansible Galaxy collections in

--- a/.github/workflows/postgres-walg.yml
+++ b/.github/workflows/postgres-walg.yml
@@ -23,7 +23,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
-      - uses: docker/setup-qemu-action@c7c53464625b32c7a7e944ae62b3e17d2b600130 # v3
+      - uses: docker/setup-qemu-action@06116385d9baf250c9f4dcb4858b16962ea869c3 # v4.1.0
       - uses: docker/setup-buildx-action@d7f5e7f509e45cec5c76c4d5afdd7de93d0b3df5 # v4.1.0
       - uses: docker/login-action@650006c6eb7dba73a995cc03b0b2d7f5ca915bee # v4.2.0
         with:


### PR DESCRIPTION
Hold postgres major version bumps (e.g. 17 -> 18) from Dependabot: the postgres-walg image backs live PG17 databases, and a new-major image can't read existing data files without a deliberate `pg_upgrade`. Patch/minor still flow. Remove this ignore entry when intentionally migrating to a new major. (Closes the loop on the closed #43.)