### PR TITLE
fix(cli): resolve parent zone for subdomains in cf_zone_id

### DIFF
--- a/miuops
+++ b/miuops
@@ -78,25 +78,36 @@ domain_owner() {
 
 # ── Cloudflare DNS helpers ─────────────────────────────────────────
 cf_zone_id() {
-    local domain="$1" resp http
-    resp=$(curl -s -w "\n%{http_code}" \
-        "https://api.cloudflare.com/client/v4/zones?name=${domain}" \
-        -H "Authorization: Bearer ${CF_API_TOKEN}" -H "Content-Type: application/json") \
-        || die "Cloudflare API request failed — network error"
-    http=$(echo "$resp" | tail -1); resp=$(echo "$resp" | sed '$d')
-    case "$http" in
-        200) ;;
-        401|403) die "Cloudflare API returned ${http} (unauthorized)
+    # Cloudflare zones live at the registered-domain level. For a subdomain
+    # (e.g. dev.example.com) walk up the labels to find the parent zone, so a
+    # subdomain can be pointed at a different server than its apex.
+    local domain="$1" candidate="$1" resp http zid
+    while :; do
+        resp=$(curl -s -w "\n%{http_code}" \
+            "https://api.cloudflare.com/client/v4/zones?name=${candidate}" \
+            -H "Authorization: Bearer ${CF_API_TOKEN}" -H "Content-Type: application/json") \
+            || die "Cloudflare API request failed — network error"
+        http=$(echo "$resp" | tail -1); resp=$(echo "$resp" | sed '$d')
+        case "$http" in
+            200) ;;
+            401|403) die "Cloudflare API returned ${http} (unauthorized)
   - Is your CF_API_TOKEN valid?
   - Does it have Zone:Read and DNS:Edit permissions?" ;;
-        *) die "Cloudflare API returned HTTP ${http} for zone '${domain}'
+            *) die "Cloudflare API returned HTTP ${http} for zone '${candidate}'
   Response: $(echo "$resp" | jq -r '.errors[0].message // empty' 2>/dev/null || echo 'unknown')" ;;
-    esac
-    local zid; zid=$(echo "$resp" | jq -r '.result[0].id // empty')
-    [[ -n "$zid" ]] || die "Zone not found for '${domain}'
-  - Is the domain added to your Cloudflare account?
-  - Does your API token have access to this zone?"
-    echo "$zid"
+        esac
+        zid=$(echo "$resp" | jq -r '.result[0].id // empty')
+        [[ -n "$zid" ]] && { echo "$zid"; return 0; }
+        # Not a zone at this level — try the parent (strip the leftmost label),
+        # stopping once we're down to a bare apex (two labels).
+        case "$candidate" in
+            *.*.*) candidate="${candidate#*.}" ;;
+            *) break ;;
+        esac
+    done
+    die "Zone not found for '${domain}'
+  - Is the domain (or its parent zone) added to your Cloudflare account?
+  - Does your API token have access to that zone?"
 }
 
 # Echo "<id>\t<content>" of the CNAME named $2 in zone $1 (empty fields if none).

--- a/tests/cli_test.sh
+++ b/tests/cli_test.sh
@@ -118,6 +118,18 @@ echo "$out" | grep -qi 'already points here' || fail "cf_create_cname should acc
 out="$( ( export CF_API_TOKEN=x; curl() { printf '{"success":false,"errors":[{"message":"Invalid zone"}]}'; }; cf_create_cname z1 app.example.com TUN1 ) 2>&1 || true )"
 echo "$out" | grep -qi 'Failed to create' || fail "cf_create_cname must die on an API failure"
 
+# cf_zone_id walks up to the parent zone for a subdomain (dev.example.com -> example.com)
+out="$( export CF_API_TOKEN=x; curl() { if printf '%s' "$*" | grep -q 'name=dev.example.com'; then printf '{"success":true,"result":[]}\n200'; elif printf '%s' "$*" | grep -q 'name=example.com'; then printf '{"success":true,"result":[{"id":"ZONE1"}]}\n200'; else printf '{"success":true,"result":[]}\n200'; fi; }; cf_zone_id dev.example.com )"
+echo "$out" | grep -qx ZONE1 || fail "cf_zone_id should resolve a subdomain to its parent zone"
+
+# cf_zone_id resolves an apex directly (regression)
+out="$( export CF_API_TOKEN=x; curl() { printf '{"success":true,"result":[{"id":"ZONE2"}]}\n200'; }; cf_zone_id example.com )"
+echo "$out" | grep -qx ZONE2 || fail "cf_zone_id should resolve an apex domain directly"
+
+# cf_zone_id dies when neither the name nor any parent is a zone
+out="$( ( export CF_API_TOKEN=x; curl() { printf '{"success":true,"result":[]}\n200'; }; cf_zone_id sub.unknown.example ) 2>&1 || true )"
+echo "$out" | grep -qi 'Zone not found' || fail "cf_zone_id must die when no parent zone matches"
+
 # cf_delete_cname: a failed delete -> hard error (not a warning)
 out="$( ( export CF_API_TOKEN=x; curl() { if printf '%s' "$*" | grep -q DELETE; then printf '{"success":false,"errors":[{"message":"boom"}]}'; else printf '{"success":true,"result":[{"id":"R1","content":"TUN1.cfargotunnel.com"}]}'; fi; }; cf_delete_cname z1 app.example.com TUN1 ) 2>&1 || true )"
 echo "$out" | grep -qi 'did not confirm deletion' || fail "cf_delete_cname must die on a failed delete"


### PR DESCRIPTION
## Problem
`./miuops add-domain <host> dev.example.com` (or a subdomain in host_vars on `up`) failed with **`Zone not found for 'dev.example.com'`**. Cloudflare zones exist at the **registered-domain** level (`example.com`), so querying `zones?name=dev.example.com` returns nothing.

This blocked the documented prod/dev split (apex on one server, `dev.` subdomain on another).

## Fix
`cf_zone_id` now walks up the labels (`dev.example.com` → `example.com`) and returns the first/most-specific matching zone. The subdomain CNAMEs (`dev.example.com` + `*.dev.example.com`) are then created **in the parent zone**, which is how Cloudflare expects subdomain records. Apex behavior is unchanged. Auth/network errors still fail fast.

## Tests
Adds offline tests: subdomain→parent walk, apex regression, and die-when-no-parent-zone. `bash tests/cli_test.sh` → ALL PASS.