### PR TITLE
chore(cli): surface resolved parent zone + warn on second-level wildcard TLS

### DIFF
--- a/miuops
+++ b/miuops
@@ -12,6 +12,15 @@ NC='\033[0m'
 die()  { echo -e "${RED}error:${NC} $1" >&2; exit 1; }
 info() { echo -e "${GREEN}=>${NC} $1"; }
 warn() { echo -e "${YELLOW}=>${NC} $1"; }
+# Warn when $1 is itself a subdomain: the auto-created *.<domain> wildcard is a
+# second-level wildcard that Cloudflare's free Universal SSL does NOT cover, so
+# HTTPS to *.<domain> hosts needs Advanced Certificate Manager. The host itself
+# and other first-level names under the apex stay covered.
+acm_wildcard_note() {
+    case "$1" in
+        *.*.*) warn "${1} is a subdomain — its wildcard '*.${1}' needs Cloudflare Advanced Certificate Manager for HTTPS ('${1}' itself is covered by Universal SSL)." ;;
+    esac
+}
 dry()  { echo -e "  ${YELLOW}[dry-run]${NC} $1"; }
 
 DRY_RUN=false
@@ -80,8 +89,10 @@ domain_owner() {
 cf_zone_id() {
     # Cloudflare zones live at the registered-domain level. For a subdomain
     # (e.g. dev.example.com) walk up the labels to find the parent zone, so a
-    # subdomain can be pointed at a different server than its apex.
-    local domain="$1" candidate="$1" resp http zid
+    # subdomain can be pointed at a different server than its apex. The walk
+    # tries the most-specific name first and stops at the two-label apex; the
+    # first existing zone wins.
+    local domain="$1" candidate="$1" resp http zid zname
     while :; do
         resp=$(curl -s -w "\n%{http_code}" \
             "https://api.cloudflare.com/client/v4/zones?name=${candidate}" \
@@ -97,7 +108,14 @@ cf_zone_id() {
   Response: $(echo "$resp" | jq -r '.errors[0].message // empty' 2>/dev/null || echo 'unknown')" ;;
         esac
         zid=$(echo "$resp" | jq -r '.result[0].id // empty')
-        [[ -n "$zid" ]] && { echo "$zid"; return 0; }
+        if [[ -n "$zid" ]]; then
+            # On walk-up, surface the matched zone name so the operator can
+            # confirm which zone the records land in (the ID alone is opaque).
+            zname=$(echo "$resp" | jq -r '.result[0].name // empty')
+            [[ "$candidate" != "$domain" ]] && \
+                echo -e "${GREEN}=>${NC} ${domain}: records will be created in parent zone '${zname:-$candidate}'" >&2
+            echo "$zid"; return 0
+        fi
         # Not a zone at this level — try the parent (strip the leftmost label),
         # stopping once we're down to a bare apex (two labels).
         case "$candidate" in
@@ -487,6 +505,7 @@ ${existing}
         zid="${zone_id_list[$i]}"
         cf_create_cname "$zid" "${domain}" "$tunnel_id"
         cf_create_cname "$zid" "*.${domain}" "$tunnel_id"
+        acm_wildcard_note "$domain"
     done
 
     # ── Step 5: Write config + converge ────────────────────────────
@@ -552,6 +571,7 @@ cmd_add_domain() {
         zid="$(cf_zone_id "$dd")"
         cf_create_cname "$zid" "$dd" "$tid"
         cf_create_cname "$zid" "*.${dd}" "$tid"
+        acm_wildcard_note "$dd"
         current+=("$dd"); added=true
     done
 

--- a/miuops
+++ b/miuops
@@ -18,7 +18,7 @@ warn() { echo -e "${YELLOW}=>${NC} $1"; }
 # and other first-level names under the apex stay covered.
 acm_wildcard_note() {
     case "$1" in
-        *.*.*) warn "${1} is a subdomain — its wildcard '*.${1}' needs Cloudflare Advanced Certificate Manager for HTTPS ('${1}' itself is covered by Universal SSL)." ;;
+        *.*.*) warn "if '${1}' is a subdomain (not a registrable apex), its wildcard '*.${1}' is second-level and free Universal SSL won't cover it — HTTPS to *.${1} hosts would need Advanced Certificate Manager." ;;
     esac
 }
 dry()  { echo -e "  ${YELLOW}[dry-run]${NC} $1"; }
@@ -111,6 +111,8 @@ cf_zone_id() {
         if [[ -n "$zid" ]]; then
             # On walk-up, surface the matched zone name so the operator can
             # confirm which zone the records land in (the ID alone is opaque).
+            # NOTE: stderr (>&2), NOT info() — info() writes to stdout and would
+            # corrupt the zone id captured by zid=$(cf_zone_id ...) in callers.
             zname=$(echo "$resp" | jq -r '.result[0].name // empty')
             [[ "$candidate" != "$domain" ]] && \
                 echo -e "${GREEN}=>${NC} ${domain}: records will be created in parent zone '${zname:-$candidate}'" >&2

--- a/tests/cli_test.sh
+++ b/tests/cli_test.sh
@@ -119,7 +119,7 @@ out="$( ( export CF_API_TOKEN=x; curl() { printf '{"success":false,"errors":[{"m
 echo "$out" | grep -qi 'Failed to create' || fail "cf_create_cname must die on an API failure"
 
 # cf_zone_id walks up to the parent zone for a subdomain (dev.example.com -> example.com)
-out="$( export CF_API_TOKEN=x; curl() { if printf '%s' "$*" | grep -q 'name=dev.example.com'; then printf '{"success":true,"result":[]}\n200'; elif printf '%s' "$*" | grep -q 'name=example.com'; then printf '{"success":true,"result":[{"id":"ZONE1"}]}\n200'; else printf '{"success":true,"result":[]}\n200'; fi; }; cf_zone_id dev.example.com )"
+out="$( export CF_API_TOKEN=x; curl() { if printf '%s' "$*" | grep -q 'name=dev.example.com'; then printf '{"success":true,"result":[]}\n200'; elif printf '%s' "$*" | grep -q 'name=example.com'; then printf '{"success":true,"result":[{"id":"ZONE1","name":"example.com"}]}\n200'; else printf '{"success":true,"result":[]}\n200'; fi; }; cf_zone_id dev.example.com 2>/dev/null )"
 echo "$out" | grep -qx ZONE1 || fail "cf_zone_id should resolve a subdomain to its parent zone"
 
 # cf_zone_id resolves an apex directly (regression)
@@ -129,6 +129,16 @@ echo "$out" | grep -qx ZONE2 || fail "cf_zone_id should resolve an apex domain d
 # cf_zone_id dies when neither the name nor any parent is a zone
 out="$( ( export CF_API_TOKEN=x; curl() { printf '{"success":true,"result":[]}\n200'; }; cf_zone_id sub.unknown.example ) 2>&1 || true )"
 echo "$out" | grep -qi 'Zone not found' || fail "cf_zone_id must die when no parent zone matches"
+
+# cf_zone_id surfaces the matched parent zone name on walk-up (stderr, not stdout)
+err="$( export CF_API_TOKEN=x; curl() { if printf '%s' "$*" | grep -q 'name=dev.example.com'; then printf '{"success":true,"result":[]}\n200'; else printf '{"success":true,"result":[{"id":"ZONE1","name":"example.com"}]}\n200'; fi; }; cf_zone_id dev.example.com 2>&1 >/dev/null )"
+echo "$err" | grep -qi "parent zone 'example.com'" || fail "cf_zone_id should surface the parent zone name on walk-up"
+
+# acm_wildcard_note warns for a subdomain's 2nd-level wildcard, not for an apex
+out="$( acm_wildcard_note dev.example.com 2>&1 )"
+echo "$out" | grep -qi 'Advanced Certificate Manager' || fail "acm_wildcard_note should warn for a subdomain"
+out="$( acm_wildcard_note example.com 2>&1 )"
+[[ -z "$out" ]] || fail "acm_wildcard_note should not warn for an apex domain"
 
 # cf_delete_cname: a failed delete -> hard error (not a warning)
 out="$( ( export CF_API_TOKEN=x; curl() { if printf '%s' "$*" | grep -q DELETE; then printf '{"success":false,"errors":[{"message":"boom"}]}'; else printf '{"success":true,"result":[{"id":"R1","content":"TUN1.cfargotunnel.com"}]}'; fi; }; cf_delete_cname z1 app.example.com TUN1 ) 2>&1 || true )"


### PR DESCRIPTION
Follow-up hardening for the subdomain zone-resolution fix (review-driven, all non-blocking improvements):

1. **Zone transparency** — when `cf_zone_id` walks up to a subdomain's parent zone, it now prints the matched **zone name** (e.g. `dev.example.com: records will be created in parent zone 'example.com'`), so the operator can confirm which zone the records land in instead of seeing only an opaque ID.
2. **Second-level wildcard TLS warning** — `add-domain`/`up` warn when a domain is itself a subdomain, because the auto-created `*.<subdomain>` wildcard is a **second-level** wildcard that Cloudflare's free Universal SSL does **not** cover (needs Advanced Certificate Manager). The subdomain host itself and other first-level names stay covered.
3. **Comment fix** — `cf_zone_id`'s comment now describes the walk's stop condition accurately.

Tests added for all three; `bash tests/cli_test.sh` passes. PSL-aware walk bounding is deferred (inputs are operator-controlled, and the resolved zone is now surfaced).