### PR TITLE
fix(observability): cAdvisor container metrics on Docker 29 (overlayfs)

### DIFF
--- a/docs/OBSERVABILITY.md
+++ b/docs/OBSERVABILITY.md
@@ -60,9 +60,13 @@ Grafana Cloud **Docker / Linux Node** integrations for ready-made dashboards.
 - If `observability_enabled` is true but any required value is unset, the play
   **fails fast and prints the exact env var names** to export — so a forgotten or
   misspelled variable is caught with a clear hint, not a half-started agent.
-- **Known benign log noise:** cadvisor may log `failed to identify the read-write
-  layer ID` for some containers. This only affects the per-container writable-layer
-  *size* metric; container CPU/memory/network metrics are collected normally.
+- **Docker 29+ (overlayfs):** Docker 29 made `overlayfs` the default storage driver,
+  which dropped the on-disk layer layout the old cAdvisor read. cAdvisor v0.54+
+  (bundled in Alloy >= v1.14) instead resolves each container's read-write layer
+  through containerd, so this role pins a new-enough Alloy image and mounts the host
+  `containerd.sock` into the Alloy container. On older Alloy the agent logs
+  `failed to identify the read-write layer ID` and drops **all** per-container
+  metrics (not just writable-layer size).
 - **Follow-ups (not yet wired):** Traefik Prometheus metrics (requires enabling
   Traefik's metrics endpoint), host/systemd (journald) logs, CI deployment, and
   alert rules.

--- a/roles/observability/defaults/main.yml
+++ b/roles/observability/defaults/main.yml
@@ -4,7 +4,12 @@
 observability_enabled: false
 
 # Pin the Alloy image (supply chain). Verify/bump at hub.docker.com/r/grafana/alloy/tags
-observability_alloy_image: "grafana/alloy:v1.5.1"
+# Must be >= v1.14.0: that release bundles the cAdvisor v0.54.x fork which reads
+# per-container metrics through containerd. Docker 29 switched the default storage
+# driver to overlayfs and dropped the image/<driver>/layerdb/mounts layout the old
+# cAdvisor relied on; older Alloy fails container registration ("failed to identify
+# the read-write layer ID") and silently ships zero per-container metrics.
+observability_alloy_image: "grafana/alloy:v1.17.0"
 
 observability_scrape_interval: "60s"
 

--- a/roles/observability/tasks/main.yml
+++ b/roles/observability/tasks/main.yml
@@ -54,6 +54,9 @@
     volumes:
       - "/etc/alloy/config.alloy:/etc/alloy/config.alloy:ro"
       - "/var/run/docker.sock:/var/run/docker.sock:ro"
+      # cAdvisor reads overlayfs (Docker 29+) container layers via containerd, not
+      # /var/lib/docker. Without this socket per-container metrics are dropped.
+      - "/run/containerd/containerd.sock:/run/containerd/containerd.sock:ro"
       - "/:/rootfs:ro"
       - "/proc:/host/proc:ro"
       - "/sys:/host/sys:ro"

--- a/roles/observability/templates/config.alloy.j2
+++ b/roles/observability/templates/config.alloy.j2
@@ -10,9 +10,14 @@ prometheus.exporter.unix "host" {
   sysfs_path  = "/host/sys"
 }
 
-// Per-container metrics.
+// Per-container metrics. On Docker 29+ the default storage driver is overlayfs;
+// cAdvisor (v0.54+, bundled in Alloy >= v1.14) resolves each container's read-write
+// layer through containerd rather than /var/lib/docker, so the host containerd
+// socket is mounted into this container (see roles/observability/tasks/main.yml).
+// containerd_host below matches the containerd.io package installed by roles/docker.
 prometheus.exporter.cadvisor "containers" {
   docker_host      = "unix:///var/run/docker.sock"
+  containerd_host  = "/run/containerd/containerd.sock"
   storage_duration = "5m"
 }
 


### PR DESCRIPTION
On Docker 29 the default storage driver became overlayfs, dropping the `image/<driver>/layerdb/mounts` layout the bundled cAdvisor used; older Alloy logged `failed to identify the read-write layer ID` and shipped **zero per-container metrics** (node/cloudflared metrics were unaffected).

Fix:
- Bump Alloy `v1.5.1` → `v1.17.0` (>= v1.14 bundles the cAdvisor v0.54.x fork that resolves the read-write layer via containerd).
- Mount the host containerd socket `/run/containerd/containerd.sock` (ro) into the Alloy container and set `containerd_host` on the cadvisor exporter.

Opt-in role (`observability_enabled` defaults false), so only enabled hosts are affected. Takes effect on re-converge of those hosts.