### PR TITLE
fix(firewall): fail-closed jump auto-restore + re-validate host firewall on every Docker start

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -221,20 +221,38 @@ jobs:
             echo "FAIL: DOCKER-USER not repopulated after docker restart"; iptables -S DOCKER-USER; exit 1
           '
 
-      # The FORWARD->DOCKER-USER jump is Docker-owned; if it goes missing (the
-      # shared-prod corruption class) the applier must fail loudly, not silently
-      # leave published ports unguarded. Then the documented repair restores it.
-      - name: Verify applier detects Docker-chain corruption (missing FORWARD jump)
+      # The FORWARD->DOCKER-USER jump is Docker-owned; if it goes missing (the shared-prod
+      # corruption class) the applier must FAIL-CLOSED: emergency-restore the jump at the TOP
+      # of FORWARD so published ports stay guarded, not just alert and wait for a human.
+      - name: Verify applier auto-restores a missing FORWARD jump (fail-closed)
         run: |
           set -e
           SSH="ssh -o StrictHostKeyChecking=no -i ~/.ssh/id_ed25519 ${{ secrets.DEV_SERVER_USER }}@${{ secrets.DEV_SERVER_HOST }}"
-          $SSH 'iptables -D FORWARD -j DOCKER-USER'
-          if $SSH '/usr/local/sbin/miuops-firewall.sh docker-user'; then
-            echo "FAIL: applier did not detect the missing FORWARD->DOCKER-USER jump"; exit 1
-          fi
-          echo "applier correctly failed loudly on missing jump ✅"
-          $SSH 'systemctl restart docker; sleep 5'   # documented repair
-          $SSH 'iptables -S FORWARD | grep -q -- "-A FORWARD -j DOCKER-USER" && echo "jump restored by docker restart ✅"'
+          $SSH 'iptables -D FORWARD -j DOCKER-USER'   # simulate corruption: drop the jump
+          $SSH 'iptables -S FORWARD | grep -q -- "-A FORWARD -j DOCKER-USER" && { echo "precondition FAIL: jump still present"; exit 1; }; echo "jump removed (corruption simulated)"'
+          $SSH '/usr/local/sbin/miuops-firewall.sh docker-user'   # must RECOVER (rc=0) + restore the jump
+          $SSH '
+            set -e
+            iptables -S FORWARD | grep -q -- "-A FORWARD -j DOCKER-USER" || { echo "FAIL: applier did not restore the FORWARD->DOCKER-USER jump"; exit 1; }
+            ln_u=$(iptables -S FORWARD | grep -n -- "-A FORWARD -j DOCKER-USER"    | head -1 | cut -d: -f1)
+            ln_f=$(iptables -S FORWARD | grep -n -- "-A FORWARD -j DOCKER-FORWARD" | head -1 | cut -d: -f1)
+            { [ -z "$ln_f" ] || [ "$ln_u" -lt "$ln_f" ]; } || { echo "FAIL: restored jump sits after DOCKER-FORWARD (too late to guard ports)"; exit 1; }
+            echo "applier emergency-restored the jump at FORWARD top (fail-closed) ✅"
+          '
+          $SSH 'systemctl restart docker; sleep 5'   # back to a clean Docker-owned state
+          $SSH 'iptables -S FORWARD | grep -q -- "-A FORWARD -j DOCKER-USER" && echo "jump present after docker restart ✅"'
+
+      # P2: Docker's drop-in ExecStartPre re-applies the host firewall on EVERY start, so a
+      # runtime INPUT drift is corrected at docker restart (host.service is RemainAfterExit,
+      # so Requires= alone would not re-validate). Prove a stray INPUT rule is wiped on restart.
+      - name: Verify Docker restart re-applies the host firewall (ExecStartPre)
+        run: |
+          set -e
+          SSH="ssh -o StrictHostKeyChecking=no -i ~/.ssh/id_ed25519 ${{ secrets.DEV_SERVER_USER }}@${{ secrets.DEV_SERVER_HOST }}"
+          $SSH 'systemctl show docker.service -p ExecStartPre | grep -q miuops-firewall.sh || { echo "FAIL: docker ExecStartPre does not run the firewall applier"; exit 1; }'
+          $SSH 'iptables -I INPUT 1 -p tcp --dport 65001 -j ACCEPT'   # inject runtime INPUT drift
+          $SSH 'systemctl restart docker; sleep 5'
+          $SSH 'if iptables -S INPUT | grep -q -- "--dport 65001"; then echo "FAIL: stray INPUT rule survived docker restart (host firewall not re-applied)"; exit 1; fi; echo "host firewall re-applied on docker restart -- stray rule wiped ✅"'
 
       # The v6 INPUT chain used to drop ICMPv6, which silently broke NDP and thus
       # all IPv6 connectivity (critical for IPv6-only-public-IP servers). Assert

--- a/roles/firewall/README.md
+++ b/roles/firewall/README.md
@@ -37,13 +37,15 @@ three systemd units:
   drift (a no-op when already correct).
 
 The applier asserts the Docker-owned `FORWARD → DOCKER-USER` jump is present and ordered
-before `DOCKER-FORWARD`; if it's missing (Docker-chain corruption) it **fails loudly** —
-repair with `systemctl restart docker`.
+before `DOCKER-FORWARD`; if it's persistently missing (Docker-chain corruption) it is
+**fail-closed: it emergency-restores the jump at the top of `FORWARD`** (so published ports
+stay guarded by DOCKER-USER's DROP) and warns to repair with `systemctl restart docker`.
 
 Docker is coupled to the host firewall **fail-closed**: a `docker.service` drop-in
-(`Requires=`+`After=miuops-firewall-host.service`) means that if the host firewall can't
-be applied, Docker refuses to start — so a firewall failure takes the services offline
-rather than starting containers with their published ports unprotected.
+(`Requires=`+`After=miuops-firewall-host.service`, plus an `ExecStartPre` that re-applies
+the host firewall on every Docker start) means Docker refuses to start unless the firewall
+applies cleanly — re-validated on each start, not trusted once. A firewall failure takes
+the services offline rather than starting containers with their published ports unprotected.
 
 This role does not use `netfilter-persistent`; persistence is the systemd units above.
 (Migrating an older miuops box that used netfilter-persistent? Mask it and remove its

--- a/roles/firewall/templates/docker-firewall-dep.conf.j2
+++ b/roles/firewall/templates/docker-firewall-dep.conf.j2
@@ -8,3 +8,11 @@
 [Unit]
 Requires=miuops-firewall-host.service
 After=miuops-firewall-host.service
+
+[Service]
+# Re-validate + re-apply the host firewall on EVERY Docker (re)start. host.service is
+# RemainAfterExit (stays "active" after its first success), so Requires= alone only proves
+# the firewall applied ONCE -- not that it is still correct. This ExecStartPre re-runs the
+# applier before dockerd on each start; if the firewall can't be applied, Docker does not
+# start (fail-closed on every start), and any host-firewall drift is corrected at restart.
+ExecStartPre=/usr/local/sbin/miuops-firewall.sh host

--- a/roles/firewall/templates/miuops-firewall.sh.j2
+++ b/roles/firewall/templates/miuops-firewall.sh.j2
@@ -42,8 +42,18 @@ assert_forward_jump() {
     fi
     sleep 1
   done
-  echo "FATAL: $ipt FORWARD jump to DOCKER-USER missing/misordered after retries -- Docker chains corrupt." >&2
-  echo "       Repair: systemctl restart docker" >&2
+  # Persistent absence/misorder = Docker's chains are corrupt. Don't just alert (that would
+  # leave published ports reachable via DOCKER-FORWARD's per-port ACCEPTs until a human
+  # restarts Docker) -- emergency-restore FAIL-CLOSED: put OUR jump at the TOP of FORWARD so
+  # DOCKER-USER's catch-all DROP applies again. ADDITIVE only (one -I; never flushes Docker's
+  # chains, so it cannot reintroduce the whole-table-flush bug). Drop any stale/misordered
+  # copy first so we don't leave a too-late one.
+  while "$ipt" -w 30 -D FORWARD -j DOCKER-USER 2>/dev/null; do :; done
+  if "$ipt" -w 30 -I FORWARD 1 -j DOCKER-USER; then
+    echo "WARN: $ipt FORWARD->DOCKER-USER jump was missing/misordered; emergency-inserted at FORWARD top (fail-closed). Docker's chains are likely corrupt -- repair with: systemctl restart docker" >&2
+    return 0
+  fi
+  echo "FATAL: $ipt FORWARD->DOCKER-USER jump missing and emergency insert FAILED -- published ports may be EXPOSED. Repair: systemctl restart docker" >&2
   return 1
 }
 


### PR DESCRIPTION
## What

Two residual fail-open paths in the firewall role, hardened to fail-closed.

### 1. Auto-restore a missing FORWARD → DOCKER-USER jump
The jump is Docker-owned. The applier previously only *alerted* when it was persistently
missing/misordered (the "Docker chains corrupt" class) and returned failure — but left
published container ports reachable via DOCKER-FORWARD's per-port ACCEPTs until a human ran
`systemctl restart docker`. The reconcile timer just kept failing while exposure persisted.

Now the applier **emergency-restores the jump at the top of FORWARD** (`-I FORWARD 1 -j
DOCKER-USER`, after removing any stale/misordered copy). This is additive — it never flushes
Docker's chains, so it cannot reintroduce the whole-table-flush bug — and it makes
DOCKER-USER's catch-all DROP apply again immediately (fail-closed), while warning to run
`systemctl restart docker` for a clean Docker-owned state.

### 2. Re-validate the host firewall on every Docker start
The `docker.service` drop-in's `Requires=miuops-firewall-host.service` only proved the
firewall applied *once* — host.service is `RemainAfterExit`, so it stays "active" forever and
a runtime drift would not be caught when Docker restarts. Add
`ExecStartPre=/usr/local/sbin/miuops-firewall.sh host` so the host firewall is re-applied +
re-validated before dockerd on every start; if it can't be applied, Docker does not start.
Any runtime INPUT drift is corrected at restart.

## Tests
- CI: the missing-jump test now asserts the applier **auto-restores** the jump at the top of
  FORWARD (replacing the old "fails loudly" expectation); plus a new test that a stray INPUT
  rule is wiped on a Docker restart (proving the ExecStartPre re-apply).
- Verified on a live host: deleting the jump → the applier restores it fail-closed; a Docker
  restart re-applies the host firewall.
