### PR TITLE
refactor(observability): run Grafana Alloy as a host systemd service, not a container

### DIFF
--- a/docs/OBSERVABILITY.md
+++ b/docs/OBSERVABILITY.md
@@ -1,8 +1,8 @@
 # Observability — Grafana Alloy → Grafana Cloud
 
-Optional, opt-in per host. Each enabled server runs a **Grafana Alloy** container that
-ships **metrics + logs** to **Grafana Cloud**. It is egress-only (no inbound port; the
-agent pushes out), so it fits the tunnel-only model.
+Optional, opt-in per host. Each enabled server runs **Grafana Alloy** as a host systemd
+service that ships **metrics + logs** to **Grafana Cloud**. It is egress-only (no inbound
+port; the agent pushes out), so it fits the tunnel-only model.
 
 **Collected:** host metrics (CPU/mem/disk/net), per-container metrics (cAdvisor),
 cloudflared metrics (`127.0.0.1:2000`), and all Docker container logs (apps + Traefik).
@@ -62,11 +62,11 @@ Grafana Cloud **Docker / Linux Node** integrations for ready-made dashboards.
   misspelled variable is caught with a clear hint, not a half-started agent.
 - **Docker 29+ (overlayfs):** Docker 29 made `overlayfs` the default storage driver,
   which dropped the on-disk layer layout the old cAdvisor read. cAdvisor v0.54+
-  (bundled in Alloy >= v1.14) instead resolves each container's read-write layer
-  through containerd, so this role pins a new-enough Alloy image and mounts the host
-  `containerd.sock` into the Alloy container. On older Alloy the agent logs
-  `failed to identify the read-write layer ID` and drops **all** per-container
-  metrics (not just writable-layer size).
+  (bundled in Alloy >= 1.14) instead resolves each container's read-write layer
+  through containerd, so this role pins a new-enough Alloy package version. Alloy runs
+  as a host process (root) and reads the host `containerd.sock` directly. On older Alloy
+  the agent logs `failed to identify the read-write layer ID` and drops **all**
+  per-container metrics (not just writable-layer size).
 - **Follow-ups (not yet wired):** Traefik Prometheus metrics (requires enabling
   Traefik's metrics endpoint), host/systemd (journald) logs, CI deployment, and
   alert rules.

--- a/docs/STRUCTURE.md
+++ b/docs/STRUCTURE.md
@@ -28,7 +28,7 @@
 - **docker** — Installs Docker CE + Compose plugin via signed apt repo. Hardens daemon (ICC disabled, userland proxy disabled).
 - **traefik** — Bootstraps Traefik directories and Docker network. Pulls latest image when stack is deployed.
 - **cloudflared** — Installs cloudflared via apt repo, deploys tunnel credentials and config, creates wildcard + root CNAME DNS records, runs as systemd service.
-- **observability** *(opt-in, off by default)* — Deploys a Grafana Alloy container that ships host + container + cloudflared metrics and Docker container logs to Grafana Cloud. Enabled per host via `observability_enabled`; egress-only (no inbound port). See [OBSERVABILITY.md](OBSERVABILITY.md).
+- **observability** *(opt-in, off by default)* — Runs Grafana Alloy as a host systemd service that ships host + container + cloudflared metrics and Docker container logs to Grafana Cloud. Enabled per host via `observability_enabled`; egress-only (no inbound port). See [OBSERVABILITY.md](OBSERVABILITY.md).
 
 ## Images
 

--- a/roles/observability/defaults/main.yml
+++ b/roles/observability/defaults/main.yml
@@ -3,13 +3,13 @@
 # set `observability_enabled: true` in that host's host_vars.
 observability_enabled: false
 
-# Pin the Alloy image (supply chain). Verify/bump at hub.docker.com/r/grafana/alloy/tags
-# Must be >= v1.14.0: that release bundles the cAdvisor v0.54.x fork which reads
-# per-container metrics through containerd. Docker 29 switched the default storage
-# driver to overlayfs and dropped the image/<driver>/layerdb/mounts layout the old
-# cAdvisor relied on; older Alloy fails container registration ("failed to identify
-# the read-write layer ID") and silently ships zero per-container metrics.
-observability_alloy_image: "grafana/alloy:v1.17.0"
+# Pin the Alloy apt package version (supply chain). List available versions with
+# `apt-cache madison alloy` (Grafana apt repo). Must be >= 1.14: that release bundles the
+# cAdvisor v0.54.x fork which reads per-container metrics through containerd. Docker 29
+# switched the default storage driver to overlayfs and dropped the image/<driver>/layerdb/
+# mounts layout the old cAdvisor relied on; older Alloy fails container registration
+# ("failed to identify the read-write layer ID") and silently ships zero per-container metrics.
+observability_alloy_version: "1.17.0-1"
 
 observability_scrape_interval: "60s"
 

--- a/roles/observability/handlers/main.yml
+++ b/roles/observability/handlers/main.yml
@@ -1,6 +1,7 @@
 ---
 - name: Restart Alloy
-  community.docker.docker_container:
+  ansible.builtin.systemd:
     name: alloy
-    restart: true
+    state: restarted
+    daemon_reload: true
   when: observability_enabled | bool

--- a/roles/observability/tasks/main.yml
+++ b/roles/observability/tasks/main.yml
@@ -1,8 +1,9 @@
 ---
-# Grafana Alloy -> Grafana Cloud. Entire role is a no-op unless observability_enabled.
+# Grafana Alloy -> Grafana Cloud, run as a host systemd service.
+# No-op unless observability_enabled.
 
 - name: Ensure Grafana Cloud connection is configured
-  assert:
+  ansible.builtin.assert:
     that:
       - grafana_cloud_prometheus_url | length > 0
       - grafana_cloud_prometheus_user | length > 0
@@ -18,50 +19,129 @@
   when: observability_enabled | bool
   tags: ['observability']
 
-- name: Create Alloy config directory
-  file:
-    path: /etc/alloy
+# ---- Install Alloy from Grafana's apt repository -------------------------------------
+# Self-contained prerequisites (do not rely on the docker role having run first, so a
+# `--tags observability` run works on its own — mirrors the cloudflared role).
+- name: Install python3-debian (required by the deb822_repository module)
+  ansible.builtin.apt:
+    name: python3-debian
+    state: present
+    update_cache: true
+  when: observability_enabled | bool
+  tags: ['observability']
+
+- name: Create apt keyrings directory
+  ansible.builtin.file:
+    path: /etc/apt/keyrings
     state: directory
     mode: '0755'
   when: observability_enabled | bool
   tags: ['observability']
 
-- name: Deploy Alloy config (contains the Grafana Cloud token)
-  template:
-    src: config.alloy.j2
-    dest: /etc/alloy/config.alloy
-    mode: '0600'
-  no_log: true
-  notify: Restart Alloy
+- name: Add Grafana apt signing key
+  ansible.builtin.get_url:
+    url: https://apt.grafana.com/gpg-full.key
+    dest: /etc/apt/keyrings/grafana.asc
+    mode: '0644'
   when: observability_enabled | bool
   tags: ['observability']
 
-- name: Run Grafana Alloy container
-  community.docker.docker_container:
+- name: Add Grafana apt repository
+  ansible.builtin.deb822_repository:
+    name: grafana
+    types: deb
+    uris: https://apt.grafana.com
+    suites: stable
+    components: main
+    signed_by: /etc/apt/keyrings/grafana.asc
+    state: present
+  when: observability_enabled | bool
+  tags: ['observability']
+
+- name: Install Alloy (pinned)
+  ansible.builtin.apt:
+    name: "alloy={{ observability_alloy_version }}"
+    state: present
+    update_cache: true
+  when: observability_enabled | bool
+  tags: ['observability']
+
+# ---- Run Alloy as root ----------------------------------------------------------------
+# Per-container cAdvisor metrics (Docker 29 overlayfs) require reading the root-owned
+# containerd socket, which the package's unprivileged `alloy` user cannot. Override the unit
+# to root; Alloy then reads the containerd + docker sockets and the host /proc //sys directly.
+- name: Create Alloy systemd drop-in directory
+  ansible.builtin.file:
+    path: /etc/systemd/system/alloy.service.d
+    state: directory
+    mode: '0755'
+  when: observability_enabled | bool
+  tags: ['observability']
+
+- name: Run Alloy as root, constrained by a systemd sandbox
+  # Root is needed to read the root-owned containerd socket (per-container cAdvisor metrics).
+  # The sandbox blunts a compromised root process: no new privileges, read-only kernel
+  # tunables/cgroups, no module loading, restricted address families + syscalls. Verified
+  # on-host that none of these block Alloy's socket / /proc / /sys / cgroup reads.
+  ansible.builtin.copy:
+    dest: /etc/systemd/system/alloy.service.d/10-miuops.conf
+    content: |
+      [Service]
+      User=root
+      Group=root
+      NoNewPrivileges=true
+      ProtectKernelModules=true
+      ProtectKernelTunables=true
+      ProtectControlGroups=true
+      RestrictAddressFamilies=AF_INET AF_INET6 AF_UNIX
+      RestrictRealtime=true
+      RestrictSUIDSGID=true
+      LockPersonality=true
+      SystemCallFilter=@system-service
+      SystemCallErrorNumber=EPERM
+    mode: '0644'
+  when: observability_enabled | bool
+  notify: Restart Alloy
+  tags: ['observability']
+
+- name: Bind Alloy's HTTP server to loopback
+  ansible.builtin.lineinfile:
+    path: /etc/default/alloy
+    regexp: '^CUSTOM_ARGS='
+    line: 'CUSTOM_ARGS="--server.http.listen-addr=127.0.0.1:12345"'
+  when: observability_enabled | bool
+  notify: Restart Alloy
+  tags: ['observability']
+
+- name: Deploy Alloy config (contains the Grafana Cloud token)
+  ansible.builtin.template:
+    src: config.alloy.j2
+    dest: /etc/alloy/config.alloy
+    owner: root
+    group: root
+    mode: '0600'
+  no_log: true
+  when: observability_enabled | bool
+  notify: Restart Alloy
+  tags: ['observability']
+
+- name: Ensure Alloy data dir is owned by root (matches the User=root override)
+  # The package creates /var/lib/alloy{,/data} as alloy:alloy; align it with the root
+  # service so WAL/state ownership stays consistent.
+  ansible.builtin.file:
+    path: /var/lib/alloy/data
+    state: directory
+    owner: root
+    group: root
+    mode: '0770'
+  when: observability_enabled | bool
+  tags: ['observability']
+
+- name: Enable + start Alloy
+  ansible.builtin.systemd:
     name: alloy
-    image: "{{ observability_alloy_image }}"
+    enabled: true
     state: started
-    pull: true
-    restart_policy: unless-stopped
-    # host networking: reach cloudflared on 127.0.0.1:2000; Alloy listens on nothing
-    # inbound (its own HTTP server is bound to loopback below).
-    network_mode: host
-    command:
-      - run
-      - /etc/alloy/config.alloy
-      - --storage.path=/var/lib/alloy/data
-      - --server.http.listen-addr=127.0.0.1:12345
-    volumes:
-      - "/etc/alloy/config.alloy:/etc/alloy/config.alloy:ro"
-      - "/var/run/docker.sock:/var/run/docker.sock:ro"
-      # cAdvisor reads overlayfs (Docker 29+) container layers via containerd, not
-      # /var/lib/docker. Without this socket per-container metrics are dropped.
-      - "/run/containerd/containerd.sock:/run/containerd/containerd.sock:ro"
-      - "/:/rootfs:ro"
-      - "/proc:/host/proc:ro"
-      - "/sys:/host/sys:ro"
-      - "/sys/fs/cgroup:/sys/fs/cgroup:ro"
-      - "/var/lib/docker:/var/lib/docker:ro"
-      - "/run/udev:/run/udev:ro"
+    daemon_reload: true
   when: observability_enabled | bool
   tags: ['observability']

--- a/roles/observability/templates/config.alloy.j2
+++ b/roles/observability/templates/config.alloy.j2
@@ -5,16 +5,16 @@
 
 // Host metrics (CPU, memory, disk, network) — node_exporter equivalent.
 prometheus.exporter.unix "host" {
-  rootfs_path = "/rootfs"
-  procfs_path = "/host/proc"
-  sysfs_path  = "/host/sys"
+  rootfs_path = "/"
+  procfs_path = "/proc"
+  sysfs_path  = "/sys"
 }
 
 // Per-container metrics. On Docker 29+ the default storage driver is overlayfs;
 // cAdvisor (v0.54+, bundled in Alloy >= v1.14) resolves each container's read-write
-// layer through containerd rather than /var/lib/docker, so the host containerd
-// socket is mounted into this container (see roles/observability/tasks/main.yml).
-// containerd_host below matches the containerd.io package installed by roles/docker.
+// layer through containerd rather than /var/lib/docker. Alloy runs as a host process
+// (root) and reads the containerd + docker sockets directly. containerd_host matches the
+// containerd.io package installed by roles/docker.
 prometheus.exporter.cadvisor "containers" {
   docker_host      = "unix:///var/run/docker.sock"
   containerd_host  = "/run/containerd/containerd.sock"


### PR DESCRIPTION
Run Grafana Alloy as a host systemd service instead of a privileged container.

## Why
The old deployment ran Alloy as a `docker_container` with `network_mode: host`, a mounted `docker.sock`, `/:/rootfs`, and broad `/proc` `/sys` `/var/lib/docker` bind mounts — effectively host-root with a thin, escapable container wrapper. This removes that container-escape surface.

## What
- Install Alloy from Grafana's apt repo (deb822 + signing key), pinned to a specific version. The role is self-contained (installs `python3-debian`, creates `/etc/apt/keyrings`) so `--tags observability` works on its own.
- Run as a **root** systemd service constrained by a **systemd sandbox** (`NoNewPrivileges`, `ProtectKernelModules/Tunables/ControlGroups`, `RestrictAddressFamilies`, `SystemCallFilter=@system-service`, …). Root is required to read the root-owned `containerd.sock` (per-container cAdvisor metrics on Docker 29 overlayfs); the sandbox blunts a compromised root process.
- Config uses native host paths (`/`, `/proc`, `/sys`) and reads the containerd + docker sockets directly — no bind mounts, no `/rootfs`, no host-networking container.
- HTTP server bound to `127.0.0.1:12345` (egress-only to Grafana Cloud, no inbound).

## Validation
Verified on-host: the sandboxed root Alloy reads the sockets and cAdvisor registers per-container metrics (no `failed to identify the read-write layer ID`); no permission/seccomp errors from the sandbox. CI converges + restarts cleanly.

Fresh-hosts model: a host previously running the Alloy container is converted manually (no in-role migration).