### PR TITLE
feat(backup): host-side stop-consistent volume backup role (no docker.sock)

### DIFF
--- a/README.md
+++ b/README.md
@@ -144,7 +144,7 @@ ansible-playbook playbook.yml --tags docker
 - `scripts/setup-s3-backup.sh` — Create an S3 bucket (Object Lock + lifecycle) and IAM user for backups
 - `images/postgres-walg/` — Custom PostgreSQL 17 + WAL-G image for continuous WAL archiving to S3
 
-The setup script creates a single `{project}-backup` bucket used by both offen (volume tarballs under `vol/`) and WAL-G (database backups under `db/`). Object Lock (Governance, 30 days) prevents deletion; S3 lifecycle transitions to Glacier at 30 days and expires at 90 days.
+The setup script creates a single `{project}-backup` bucket used by both the host-side `backup` role (volume tarballs under `vol/`) and WAL-G (database backups under `db/`). The volume backup is a host `systemd` timer — no container, no `docker.sock` mount; see [roles/backup/README.md](roles/backup/README.md). Object Lock (Governance, 30 days) prevents deletion; S3 lifecycle transitions to Glacier at 30 days and expires at 90 days.
 
 ## Security
 

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -11,6 +11,7 @@ Design rationale and internal architecture of miuOps.
 | Cloudflare Tunnel | Zero exposed ports | All ingress flows through Cloudflare. No public-facing ports on the server. |
 | Traefik | Stateless reverse proxy | Label-based service discovery, no config files to manage per-service. |
 | WAL-G | PostgreSQL backup | Physical backup + continuous WAL archiving to S3, baked into a custom PG image. |
+| Host-side volume backup | Docker volume backup | A host `systemd` timer (Ansible `backup` role) tars each volume and streams it to S3. No container, no `docker.sock` mount — the daemon socket is root-equivalent, so nothing gets it. |
 | Single S3 bucket | Backup storage | One bucket, one IAM user, prefixes separate data types. Simplifies lifecycle and Object Lock config. |
 | Two repos | Public tool + private config | miuOps is open-source; user infrastructure is private. Different lifecycles, different audiences. |
 | Registry auth | Stack repo deploy workflow, not Ansible | Registry credentials are deployment-specific (which registries, which tokens). The bootstrap layer shouldn't know about private image registries. Credentials live in `.env` on the server. |
@@ -33,7 +34,8 @@ miuOps/
 │   ├── docker/               #   Docker engine
 │   ├── firewall/             #   iptables (IPv4 + IPv6)
 │   ├── cloudflared/          #   Cloudflare Tunnel + systemd + DNS
-│   └── traefik/              #   Bootstrap (dirs, network) + upgrades
+│   ├── traefik/              #   Bootstrap (dirs, network) + upgrades
+│   └── backup/               #   Host-side Docker volume backup (systemd timer)
 ├── playbook.yml
 ├── scripts/
 │   └── setup-s3-backup.sh
@@ -83,12 +85,13 @@ my-infra/
 │  - GH Actions  ───────▶  ├─ Traefik (compose)              │
 │  - .env (secrets)  │SSH│  ├─ App containers                 │
 │                    │  │  ├─ PG + WAL-G ──────┐              │
-│                    │  │  ├─ Backup sidecar ──┤              │
-└────────────────────┘  │  └─ Docker volumes   │              │
-                        │                      ▼              │
+│                    │  │  ├─ volume backup ───┤  (systemd    │
+│                    │  │  │                   │   timer,     │
+│                    │  │  └─ Docker volumes   │   host-side) │
+└────────────────────┘  │                      ▼              │
                         │        S3: {project}-backup         │
                         │        ├─ db/* (WAL-G)              │
-                        │        └─ vol/* (offen)             │
+                        │        └─ vol/* (volume tarballs)   │
                         └────────────────────────────────────┘
 ```
 
@@ -155,15 +158,36 @@ Single S3 bucket, single IAM user. Prefixes separate data by type.
 
 ```
 s3://{project}-backup/
-  ├── db/{app-name}/    ← WAL-G (base backups + WAL segments)
-  └── vol/              ← offen/docker-volume-backup (volume tarballs)
+  ├── db/{app-name}/        ← WAL-G (base backups + WAL segments)
+  └── vol/{volume}/         ← host-side volume tarballs (backup role)
 ```
+
+**Volume backups run on the host, not in a container.** The Ansible `backup`
+role installs a `systemd` timer that runs a bash script directly on the host.
+For each configured volume it stops the volume's writing containers (so the
+on-disk data is at rest), tars the volume's `_data` directory, streams it
+through optional client-side encryption, and uploads it straight to S3, then
+restarts the containers.
+
+**Why host-side, no socket?** A backup container has to be told which volumes to
+read and when to stop the writers — historically by mounting the Docker socket
+into the container. The socket is root-equivalent: anything holding it can start
+a privileged container and own the host. Running the job as a host process using
+the host's own `docker` CLI keeps that authority on the host and grants it to no
+container. The job needs no inbound network and stages nothing on disk (it
+streams `tar → encrypt → S3`).
+
+**Consistency.** Stopping the writer before tarring yields an at-rest snapshot.
+Volumes whose writers tolerate a fuzzy copy (append-only logs, rebuildable
+caches) can be listed with an empty stop-set for a hot copy. PostgreSQL is best
+handled by WAL-G (continuous archiving) rather than a stop-the-world tar of its
+data volume.
 
 **Why one bucket?** All credentials live on the same server — separate buckets with separate IAM users don't improve security if the server is compromised (the attacker gets all credentials). One lifecycle policy, one Object Lock config, one bucket to manage. Adding a database means picking a new `WALG_S3_PREFIX`, no AWS operations needed.
 
-**Why one IAM user?** Same reasoning. The IAM user gets Put, Get, List permissions only — no Delete. Object Lock (Governance, 30 days) prevents deletion by anyone without the `s3:BypassGovernanceRetention` permission. Backups can optionally be encrypted client-side (GPG or Age) before upload — see [Backup Encryption](BACKUP_ENCRYPTION.md).
+**Why one IAM user?** Same reasoning. The IAM user gets Put, Get, List permissions only — no Delete. The backup job itself never deletes; retention is enforced entirely by S3 (Object Lock + lifecycle), so a compromised host cannot erase history. Object Lock (Governance, 30 days) prevents deletion by anyone without the `s3:BypassGovernanceRetention` permission. Volume backups can optionally be encrypted client-side (age) before upload — see [Backup Encryption](BACKUP_ENCRYPTION.md).
 
-For restore procedures, see [Disaster Recovery](DISASTER_RECOVERY.md).
+For role configuration see [roles/backup/README.md](../roles/backup/README.md); for restore procedures, see [Disaster Recovery](DISASTER_RECOVERY.md).
 
 ## Known Limitations
 

--- a/docs/BACKUP_ENCRYPTION.md
+++ b/docs/BACKUP_ENCRYPTION.md
@@ -1,294 +1,172 @@
 # Backup Encryption
 
-Client-side encryption for Docker volume backups. Encrypts the entire tarball **before** uploading to S3, so backups are unreadable even if AWS credentials are compromised.
+Client-side encryption for the host-side Docker volume backups (the Ansible
+`backup` role). The volume's tar stream is encrypted **before** it is uploaded to
+S3, so backups are unreadable even if AWS credentials — or the objects
+themselves — are compromised.
 
 ## Why encrypt backups?
 
-- **Defense in depth**: S3 has server-side encryption (SSE-S3), but a compromised AWS credential can still read objects. Client-side encryption adds a second layer.
-- **Secrets in backups**: The `.env` file (containing all credentials) is included in the backup tarball. Without encryption, anyone with S3 access can read every secret.
+- **Defense in depth**: S3 has server-side encryption (SSE-S3), but a compromised AWS credential can still read objects. Client-side encryption adds a second layer that the cloud provider's keys do not unlock.
+- **Secrets in backups**: A backed-up volume may contain secrets, tokens, or personal data. Without encryption, anyone with S3 read access sees it in the clear.
 - **Compliance**: Some environments require data-at-rest encryption under the application's control, not just the cloud provider's.
 
 ## How it works
 
-The backup sidecar ([offen/docker-volume-backup](https://github.com/offen/docker-volume-backup)) supports four encryption methods via environment variables. Set **exactly one** — they are mutually exclusive. Setting more than one will cause the backup to fail with an error. When none is set, backups are uploaded unencrypted.
+The backup script pipes the volume tar through an encryption stage before the
+upload: `tar → age → aws s3 cp`. Nothing is staged on disk and no plaintext copy
+is written anywhere. Encrypted objects get a `.age` extension; the object key is
+`vol/<volume>/backup-<UTC>.tar[.age]`.
 
-The sidecar encrypts the tarball after compression and before upload. Encrypted backups get a `.gpg` or `.age` file extension appended automatically.
+Encryption is selected with `backup_encryption` in host_vars (`none` | `age`).
+The `age` mode is **asymmetric (public-key) by design**: only a public key (the
+recipient) lives on the server, so a host compromise yields the backups but not
+the means to decrypt them. There is deliberately no passphrase-on-the-server
+mode — a key the server holds is a key an attacker who owns the server also
+holds.
 
-## Methods
+## age (`backup_encryption: age`)
 
-### GPG symmetric (`GPG_PASSPHRASE`)
+[age](https://github.com/FiloSottile/age) encrypts the tar stream to one or more
+recipients with ChaCha20-Poly1305. List every recipient that should be able to
+decrypt; the backup is readable by any **one** of them (so you can add a break-glass
+key alongside your day-to-day one). The role installs `age` on the host
+automatically when this mode is selected.
 
-Encrypts with AES-256 using a passphrase. Simplest to set up.
+A recipient can be any of:
 
-**Trade-off**: The passphrase lives on the server (in `.env`). If the server is compromised, the attacker has both the backups and the key to decrypt them. Still protects against S3-only credential leaks.
+- a **native age public key** (`age1...`), generated with `age-keygen`;
+- an **SSH public key** (`ssh-ed25519 ...` or `ssh-rsa ...`) — age accepts these
+  directly, and you decrypt with the matching SSH **private** key. Handy for teams
+  that already manage SSH keys and don't want a second key type;
+- a **hardware-backed key** via the
+  [`age-plugin-yubikey`](https://github.com/str4d/age-plugin-yubikey) plugin —
+  the recipient is an `age1yubikey1...` string and the private key never leaves
+  the YubiKey.
 
-**Setup**:
+Because age covers both SSH keys and YubiKey (hardware) keys, the SSH- and
+hardware-token workflows are supported here without needing gpg.
 
-```bash
-# Generate a strong passphrase
-openssl rand -base64 32
-```
+### Setup — native age key
 
-Add to your `.env`:
-
-```
-GPG_PASSPHRASE=your-generated-passphrase
-```
-
-**Decrypt**:
-
-```bash
-gpg --decrypt --batch --passphrase "your-passphrase" backup.tar.gz.gpg > backup.tar.gz
-```
-
-### GPG asymmetric (`GPG_PUBLIC_KEY_RING_FILE`)
-
-Encrypts with a GPG public key. The private key never touches the server — only someone with the private key can decrypt.
-
-**Best for**: Maximum security. Compatible with YubiKey and other hardware security keys for private key storage.
-
-**Note**: This method uses a key **file** (not an env var) because PGP keys are multiline and `.env` files don't support multiline values.
-
-**Setup**:
+Generate a key pair and keep the private half **off** the server:
 
 ```bash
-# Generate a key pair (if you don't already have one)
-gpg --full-generate-key
-
-# Export the public key to a file
-gpg --armor --export your-key-id > public_key.asc
-
-# Copy the key file to the server
-scp public_key.asc user@server:/opt/stacks/gpg-public-key.asc
+age-keygen -o key.txt
+# Public key: age1ql3z7hjy54pw3hyww5ayyfg7zqgvc7w3j2elw8zmrj2kg5sfn9aqmcac8p
 ```
 
-Then edit `stacks/backup/docker-compose.yml` in your stack repo to add the env var and volume mount:
+Store `key.txt` somewhere safe (password manager, offline media). Configure the
+public half in `host_vars/<host>.yml`:
 
 ```yaml
-services:
-  backup:
-    environment:
-      GPG_PUBLIC_KEY_RING_FILE: /keys/public_key.asc
-    volumes:
-      - /opt/stacks/gpg-public-key.asc:/keys/public_key.asc:ro
+backup_encryption: age
+backup_age_recipients:
+  - "age1ql3z7hjy54pw3hyww5ayyfg7zqgvc7w3j2elw8zmrj2kg5sfn9aqmcac8p"
 ```
 
-**Decrypt**:
+### Setup — SSH public key
+
+No new key material needed: use the public key you already have. Only the public
+key goes on the server; the matching private key decrypts.
+
+```yaml
+backup_encryption: age
+backup_age_recipients:
+  - "ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAA... you@laptop"
+```
+
+### Setup — YubiKey (hardware-backed key)
+
+Install the plugin and generate an identity that lives on the YubiKey, then use
+its recipient string on the server. The private key never exists as a file.
 
 ```bash
-# With the private key in your local GPG keyring
-gpg --decrypt backup.tar.gz.gpg > backup.tar.gz
-
-# With a YubiKey (private key on hardware)
-gpg --decrypt backup.tar.gz.gpg > backup.tar.gz
-# GPG will prompt for the YubiKey PIN
+# On your workstation, YubiKey plugged in
+age-plugin-yubikey            # interactive: creates an identity on the key
+age-plugin-yubikey --list     # prints the recipient: age1yubikey1q...
 ```
 
-### Age symmetric (`AGE_PASSPHRASE`)
+```yaml
+backup_encryption: age
+backup_age_recipients:
+  - "age1yubikey1qwt50d05nh5vutpdzmlg5wn80xq8aysptv7n8q6jvncxw3kn9x6qzhgz4n"
+```
 
-Encrypts with ChaCha20-Poly1305 using a passphrase. Modern alternative to GPG symmetric.
+Decryption later requires the YubiKey (and `age-plugin-yubikey` installed on the
+machine doing the restore).
 
-**Trade-off**: Same as GPG symmetric — passphrase lives on the server.
+## Decrypt
 
-**Setup**:
+Run on a machine that holds the matching identity:
 
 ```bash
-# Generate a strong passphrase
-openssl rand -base64 32
+# native age identity file
+age --decrypt -i key.txt -o backup.tar backup.tar.age
+
+# SSH private key
+age --decrypt -i ~/.ssh/id_ed25519 -o backup.tar backup.tar.age
+
+# YubiKey-backed identity (age-plugin-yubikey installed; touch/PIN as configured)
+age --decrypt -i <(age-plugin-yubikey --identity) -o backup.tar backup.tar.age
 ```
 
-Add to your `.env`:
+If you lose the only identity that can decrypt a backup, **that backup is
+unrecoverable**. Keep a second recipient (a break-glass age key, or a printed
+copy of `key.txt`) in a secure offline location, and add it to
+`backup_age_recipients` so every object is encrypted to both.
 
-```
-AGE_PASSPHRASE=your-generated-passphrase
-```
+## Restoring on a large volume
 
-**Decrypt**:
+For a big backup, avoid round-tripping it through your laptop. Two options:
 
-```bash
-age --decrypt -o backup.tar.gz backup.tar.gz.age
-# age will prompt for the passphrase
-```
+- **Decrypt on the server with a transferred identity.** Copy the age identity
+  file (or SSH private key) to the server temporarily, decrypt in place, then
+  remove it. Simple, but the key briefly lives on the host.
+- **Decrypt on your laptop, stream to the server.** If the identity must never
+  touch the server (e.g. a YubiKey), pull the object to your laptop, decrypt
+  there, and pipe the plaintext tar back over SSH:
 
-### Age asymmetric (`AGE_PUBLIC_KEYS`)
+  ```bash
+  aws s3 cp s3://PROJECT-backup/vol/VOLUME/backup-TS.tar.age - --region REGION \
+    | age --decrypt -i ~/.ssh/id_ed25519 \
+    | ssh user@server 'cat > /tmp/backup-TS.tar'
+  ```
 
-Encrypts with an Age public key. Supports native Age keys and SSH keys (`ssh-ed25519`, `ssh-rsa`).
-
-**Best for**: Teams already using SSH keys. No GPG keyring management needed.
-
-**Setup with Age keys**:
-
-```bash
-# Generate an Age key pair
-age-keygen -o key.txt
-# Output: public key: age1...
-```
-
-Add the public key to your `.env`:
-
-```
-AGE_PUBLIC_KEYS=age1ql3z7hjy54pw3hyww5ayyfg7zqgvc7w3j2elw8zmrj2kg5sfn9aqmcac8p
-```
-
-**Setup with SSH keys**:
-
-```bash
-# Use an existing SSH public key
-cat ~/.ssh/id_ed25519.pub
-```
-
-Add the SSH public key to your `.env`:
-
-```
-AGE_PUBLIC_KEYS=ssh-ed25519 AAAA...
-```
-
-**Decrypt**:
-
-```bash
-# With Age identity file
-age --decrypt -i key.txt -o backup.tar.gz backup.tar.gz.age
-
-# With SSH private key
-age --decrypt -i ~/.ssh/id_ed25519 -o backup.tar.gz backup.tar.gz.age
-```
-
-## Choosing a method
-
-| | GPG symmetric | GPG asymmetric | Age symmetric | Age asymmetric |
-|---|---|---|---|---|
-| Env var | `GPG_PASSPHRASE` | `GPG_PUBLIC_KEY_RING_FILE` | `AGE_PASSPHRASE` | `AGE_PUBLIC_KEYS` |
-| Config via | `.env` | Key file + compose edit | `.env` | `.env` |
-| Algorithm | AES-256 | AES-256 | ChaCha20-Poly1305 | ChaCha20-Poly1305 |
-| Secret on server | Passphrase | Public key only | Passphrase | Public key only |
-| Hardware key support | No | YubiKey | No | SSH keys |
-| Setup complexity | Low | Medium | Low | Low |
-| Decrypt tooling | `gpg` | `gpg` | `age` | `age` |
-| Best for | Simple setups | Maximum security | Simple setups | SSH-based teams |
-
-**Recommendation**: Use **GPG asymmetric** if you want maximum security (private key never on server, YubiKey compatible). Use **Age asymmetric with SSH keys** if your team already has SSH keys and wants minimal setup.
-
-## YubiKey integration
-
-GPG asymmetric encryption works with YubiKey (or other OpenPGP smartcards). The private key lives on the YubiKey and never exists as a file — only the public key is needed on the server for encryption.
-
-### How it works
-
-- **Encryption** (automated daily backup): Uses only the public key file on the server. No YubiKey involved.
-- **Decryption** (manual disaster recovery): Requires the YubiKey. GPG talks to the smartcard to perform the decryption operation.
-
-### Setup
-
-Follow the [GPG asymmetric setup](#gpg-asymmetric-gpg_public_key_ring_file) above. If your key pair already lives on a YubiKey, just export the public key:
-
-```bash
-gpg --armor --export your-key-id > public_key.asc
-scp public_key.asc user@server:/opt/stacks/gpg-public-key.asc
-```
-
-### Decrypting with a YubiKey
-
-You have two options for decryption during a restore:
-
-**Option A: Decrypt on your laptop, transfer the tarball**
-
-Simplest approach. Download the encrypted backup to your laptop, decrypt locally (YubiKey plugged in), then upload the decrypted tarball to the server:
-
-```bash
-# On your laptop
-aws s3 cp s3://PROJECT-backup/vol/backup.tar.gz.gpg . --region REGION
-gpg --decrypt backup.tar.gz.gpg > backup.tar.gz   # YubiKey prompts for PIN
-scp backup.tar.gz user@server:/tmp/
-```
-
-Trade-off: the backup transits through your laptop. Impractical for very large backups.
-
-**Option B: GPG agent forwarding over SSH (recommended for large backups)**
-
-Forward your local `gpg-agent` socket to the server so `gpg --decrypt` on the server uses the YubiKey plugged into your laptop. The backup data stays on the server — only the crypto operations travel over SSH.
-
-1. **Import your public key on the server** (one-time setup, so GPG knows which smartcard to ask for):
-
-   ```bash
-   # On the server
-   gpg --import /opt/stacks/gpg-public-key.asc
-   ```
-
-2. **Enable agent forwarding in the server's sshd_config** (one-time setup):
-
-   ```
-   # /etc/ssh/sshd_config
-   StreamLocalBindUnlink yes
-   ```
-
-   Restart sshd: `sudo systemctl restart sshd`
-
-3. **SSH in with agent forwarding**:
-
-   ```bash
-   # Find your local agent socket
-   gpgconf --list-dir agent-extra-socket
-   # e.g. /Users/you/.gnupg/S.gpg-agent.extra
-
-   # Find the remote agent socket
-   ssh user@server gpgconf --list-dir agent-socket
-   # e.g. /run/user/1000/gnupg/S.gpg-agent
-
-   # Connect with forwarding
-   ssh -R /run/user/1000/gnupg/S.gpg-agent:/Users/you/.gnupg/S.gpg-agent.extra user@server
-   ```
-
-4. **Decrypt on the server** (YubiKey prompts for PIN on your laptop):
-
-   ```bash
-   gpg --decrypt backup.tar.gz.gpg > backup.tar.gz
-   ```
-
-**Tip**: Add the forwarding to your `~/.ssh/config` so you don't have to type the socket paths each time:
-
-```
-Host myserver
-    HostName 203.0.113.10
-    User admin
-    RemoteForward /run/user/1000/gnupg/S.gpg-agent /Users/you/.gnupg/S.gpg-agent.extra
-```
-
-### Notes
-
-- If your YubiKey has a touch policy for decryption, you'll need to touch the key when GPG prompts during `--decrypt`.
-- The YubiKey PIN stays on your laptop: `pinentry` prompts for it locally, passes it to `gpg-agent`, which sends it to the YubiKey over USB. Only the decryption request and result travel over the SSH tunnel — the PIN never crosses the network.
-- If you lose the YubiKey and have no backup of the private key, **encrypted backups are unrecoverable**. Keep a backup key in a secure offline location (e.g. a second YubiKey or a printed paperkey stored in a safe).
+  Only the (encrypted) object and the resulting plaintext cross the wire; the
+  private key stays on the laptop / YubiKey.
 
 ## Verifying encryption
 
-After setting an encryption variable, trigger a manual backup and confirm the output file has the expected extension:
+After setting the encryption variable and applying the role, trigger a run and
+confirm the uploaded object has the expected extension:
 
 ```bash
-# Trigger a manual backup
-docker exec backup backup
+# Trigger a backup run on the server (don't wait for the timer)
+systemctl start miuops-backup.service
+journalctl -u miuops-backup.service -f
 
-# Check S3 for the encrypted file
-aws s3 ls s3://PROJECT-backup/vol/
-# Should show: backup-YYYYMMDDTHHMMSS.tar.gz.gpg (or .age)
+# Check S3 for the encrypted object
+aws s3 ls s3://PROJECT-backup/vol/ --recursive --region REGION
+# Should show: vol/<volume>/backup-YYYYMMDDTHHMMSSZ.tar.age
 ```
 
 ## Restoring encrypted backups
 
-1. Download the backup from S3
-2. Decrypt (see the method-specific instructions above)
-3. Extract the tarball as usual
+1. Download the backup from S3.
+2. Decrypt it (see [Decrypt](#decrypt) above).
+3. Extract the tar (it is **not** gzip-compressed).
 
 ```bash
 # Download
-aws s3 cp s3://PROJECT-backup/vol/backup-YYYYMMDDTHHMMSS.tar.gz.gpg . --region REGION
+aws s3 cp s3://PROJECT-backup/vol/VOLUME/backup-YYYYMMDDTHHMMSSZ.tar.age . --region REGION
 
-# Decrypt (example: GPG symmetric)
-gpg --decrypt --batch --passphrase "your-passphrase" backup-YYYYMMDDTHHMMSS.tar.gz.gpg > backup-YYYYMMDDTHHMMSS.tar.gz
+# Decrypt (age — identity file, SSH private key, or YubiKey)
+age --decrypt -i key.txt -o backup-YYYYMMDDTHHMMSSZ.tar backup-YYYYMMDDTHHMMSSZ.tar.age
 
-# Extract
-tar xzf backup-YYYYMMDDTHHMMSS.tar.gz
+# Extract (the tar is rooted at the volume's contents; --numeric-owner keeps
+# ownership deterministic across hosts)
+tar --numeric-owner -xf backup-YYYYMMDDTHHMMSSZ.tar
 ```
 
-The `.env` file is in the tarball at `dotenv/.env`.
-
-For full restore procedures, see [Disaster Recovery](DISASTER_RECOVERY.md).
+For full restore procedures (extracting straight into a Docker volume), see [Disaster Recovery](DISASTER_RECOVERY.md).

--- a/docs/DAILY_OPS.md
+++ b/docs/DAILY_OPS.md
@@ -84,10 +84,15 @@ cd $STACK_DIR
 docker compose exec postgres walg-backup.sh
 ```
 
-### Volume backup (offen)
+### Volume backup (host-side `backup` role)
 
 ```bash
-docker exec backup backup
+# Trigger a run now (does not wait for the timer)
+systemctl start miuops-backup.service
+journalctl -u miuops-backup.service -f   # watch it
+
+# When does it next fire?
+systemctl list-timers miuops-backup.timer
 ```
 
 ### List existing backups
@@ -96,8 +101,8 @@ docker exec backup backup
 # PostgreSQL base backups
 docker compose exec postgres wal-g backup-list
 
-# Volume tarballs in S3 (run locally, not on server)
-aws s3 ls s3://PROJECT-backup/vol/ --region REGION
+# Volume tarballs in S3 (one prefix per volume)
+aws s3 ls s3://PROJECT-backup/vol/ --recursive --region REGION
 ```
 
 ## Deploying changes

--- a/docs/DISASTER_RECOVERY.md
+++ b/docs/DISASTER_RECOVERY.md
@@ -1,21 +1,27 @@
 # Disaster Recovery
 
-Procedures for restoring services after failures. The backup system uses WAL-G (PostgreSQL continuous archiving) and offen (Docker volume tarballs), both writing to a single S3 bucket with Object Lock protection.
+Procedures for restoring services after failures. The backup system uses WAL-G (PostgreSQL continuous archiving) and a host-side Docker-volume backup (volume tarballs), both writing to a single S3 bucket with Object Lock protection.
 
 ## Backup architecture
 
 ```
 S3 bucket: {project}-backup
-├── db/                    # WAL-G: base backups + WAL segments
+├── db/                          # WAL-G: base backups + WAL segments
 │   ├── basebackups_005/
 │   └── wal_005/
-└── vol/                   # offen: volume tarballs
-    └── backup-YYYYMMDDTHHMMSS.tar.gz
+└── vol/                         # host-side volume tarballs (backup role)
+    └── {volume}/                #   one prefix per Docker volume
+        └── backup-YYYYMMDDTHHMMSSZ.tar[.age]
 ```
 
+- **Volume tarballs** are produced by the Ansible `backup` role: a host `systemd`
+  timer stops each volume's writers, tars the volume, optionally encrypts it, and
+  streams it to S3. One object per volume per run, keyed by UTC timestamp.
+  See [roles/backup/README.md](../roles/backup/README.md).
 - **Object Lock** (Governance, 30 days) prevents deletion of any backup
 - **Lifecycle**: transition to Glacier at 30 days, expire at 90 days
-- **IAM policy**: PutObject + GetObject + ListBucket only (no DeleteObject)
+- **IAM policy**: PutObject + GetObject + ListBucket only (no DeleteObject); the
+  backup job never deletes — retention is enforced by S3 alone
 
 ## Scenario 1: Full server rebuild
 
@@ -75,7 +81,7 @@ git commit --allow-empty -m "Redeploy to new server" && git push
 
 See [Scenario 2](#scenario-2-postgresql-point-in-time-recovery) below.
 
-### 7. Restore volume data from offen
+### 7. Restore volume data
 
 See [Scenario 3](#scenario-3-volume-data-restore) below.
 
@@ -162,70 +168,93 @@ docker compose exec postgres psql -U postgres -c "SELECT pg_is_in_recovery();"
 
 ## Scenario 3: Volume data restore
 
-Restore Docker volume data from offen backup tarballs stored in S3. Run all commands **on the server** — download directly from S3 to avoid double-transferring large backups through your laptop.
+Restore Docker volume data from the host-side volume tarballs stored in S3. Run all commands **on the server** — download directly from S3 to avoid double-transferring large backups through your laptop.
 
-**1. List available backups:**
+Each Docker volume has its own prefix (`vol/{volume}/`), and each run uploads one
+tarball keyed by UTC timestamp. The tar is rooted at the volume's contents (it is
+created with `tar -C /var/lib/docker/volumes/<volume>/_data --numeric-owner -cf - .`),
+so it extracts directly into the target volume's root — there is no wrapper
+directory. The archive is **not gzip-compressed** (extract with `tar -xf`, not
+`-xzf`). Extract with `--numeric-owner` too (below) so UIDs/GIDs are restored as
+numbers — deterministic ownership even when the restore host has a different
+`/etc/passwd` than the source.
+
+**1. List backups for the volume:**
 
 ```bash
-aws s3 ls s3://PROJECT-backup/vol/ --region REGION
+aws s3 ls s3://PROJECT-backup/vol/VOLUME_NAME/ --region REGION
 ```
 
-If encrypted, files will have a `.gpg` or `.age` extension (e.g. `backup-YYYYMMDDTHHMMSS.tar.gz.gpg`).
+If encrypted, files have a `.age` extension (e.g. `backup-YYYYMMDDTHHMMSSZ.tar.age`).
 
 **2. Download the backup:**
 
 ```bash
 # Unencrypted
-aws s3 cp s3://PROJECT-backup/vol/backup-YYYYMMDDTHHMMSS.tar.gz . --region REGION
+aws s3 cp s3://PROJECT-backup/vol/VOLUME_NAME/backup-YYYYMMDDTHHMMSSZ.tar . --region REGION
 
-# Encrypted (include the .gpg or .age extension)
-aws s3 cp s3://PROJECT-backup/vol/backup-YYYYMMDDTHHMMSS.tar.gz.gpg . --region REGION
+# Encrypted (include the .age extension)
+aws s3 cp s3://PROJECT-backup/vol/VOLUME_NAME/backup-YYYYMMDDTHHMMSSZ.tar.age . --region REGION
 ```
 
 **3. Decrypt the backup (if encrypted):**
 
 ```bash
-# GPG (symmetric or asymmetric)
-gpg --decrypt backup-YYYYMMDDTHHMMSS.tar.gz.gpg > backup-YYYYMMDDTHHMMSS.tar.gz
-
-# Age (symmetric — passphrase)
-age --decrypt -o backup-YYYYMMDDTHHMMSS.tar.gz backup-YYYYMMDDTHHMMSS.tar.gz.age
-
-# Age (asymmetric — identity file)
-age --decrypt -i key.txt -o backup-YYYYMMDDTHHMMSS.tar.gz backup-YYYYMMDDTHHMMSS.tar.gz.age
+# age (asymmetric — identity file, SSH private key, or YubiKey-backed identity)
+age --decrypt -i key.txt -o backup-YYYYMMDDTHHMMSSZ.tar backup-YYYYMMDDTHHMMSSZ.tar.age
 ```
 
-If using Age: `apt install age` (Debian/Ubuntu) or download from [github.com/FiloSottile/age](https://github.com/FiloSottile/age). GPG is pre-installed on most systems. For asymmetric methods, you'll need the private key or identity file — transfer it to the server temporarily and remove it after decryption.
+Install age with `apt install age` (Debian/Ubuntu) or download it from
+[github.com/FiloSottile/age](https://github.com/FiloSottile/age). The role
+encrypts to a public key only, so decryption needs the matching private key or
+identity file — transfer it to the server temporarily and remove it afterward, or
+keep the key off the host and decrypt on your laptop while streaming the plaintext
+over SSH (see [Backup Encryption](BACKUP_ENCRYPTION.md)). For a YubiKey-backed
+recipient, decrypt where the key is plugged in, with `age-plugin-yubikey`
+installed.
 
-See [Backup Encryption](BACKUP_ENCRYPTION.md) for details on each method.
-
-**4. Stop the affected services:**
+**4. Stop the consumers of the volume:**
 
 ```bash
-cd /path/to/stack
-docker compose stop
+docker stop CONTAINER [CONTAINER...]
 ```
 
-**5. Extract to the target volume:**
+**5. Extract into the target volume:**
+
+`--numeric-owner` keeps the restored files' UIDs/GIDs as numbers, so ownership is
+correct even when this host's `/etc/passwd` differs from the source host's.
 
 ```bash
 docker run --rm \
-  -v STACK_volume_name:/restore \
-  -v $(pwd)/backup-YYYYMMDDTHHMMSS.tar.gz:/backup.tar.gz \
-  alpine sh -c "cd /restore && tar xzf /backup.tar.gz"
+  -v VOLUME_NAME:/restore \
+  -v "$(pwd)/backup-YYYYMMDDTHHMMSSZ.tar:/backup.tar:ro" \
+  alpine sh -c "cd /restore && tar --numeric-owner -xf /backup.tar"
 ```
 
-**6. Restart services:**
+To restore into a clean volume, clear it first (inside the same `alpine` shell:
+`rm -rf /restore/* /restore/..?* 2>/dev/null; tar --numeric-owner -xf /backup.tar`).
+
+**6. Restart the consumers:**
 
 ```bash
-docker compose up -d
+docker start CONTAINER [CONTAINER...]
 ```
 
-**Note:** The `.env` file (containing all secrets) is included in the backup tarball under `dotenv/.env`. If you need to recover it, extract it from the tarball:
+### Notes on the backup job (`stop` list, downtime, restart policy)
 
-```bash
-tar xzf backup-YYYYMMDDTHHMMSS.tar.gz dotenv/.env
-```
+- A container listed in a volume's `stop` is **down for that whole volume's**
+  stop + tar + encrypt + upload + restart — a window proportional to
+  **volume size ÷ upload bandwidth**, not seconds. Don't put a large,
+  customer-facing writer volume in `stop` expecting sub-minute downtime; use a
+  snapshot/replication approach for those instead.
+- Give every backed-up container `restart: unless-stopped`. The backup script's
+  trap restarts containers it stopped, but it **cannot** catch `SIGKILL` or a
+  host reboot mid-backup; with `restart: unless-stopped`, Docker brings the
+  container back on its own after such an event.
+- A failure on one volume no longer aborts the run: the job restarts that
+  volume's containers, logs the error, continues with the remaining volumes, and
+  exits non-zero at the end. Check `journalctl -u miuops-backup.service` for any
+  per-volume `ERROR` lines after a non-zero run.
 
 ## Scenario 4: Credential rotation
 
@@ -283,9 +312,15 @@ Backups that haven't been tested are not backups. Periodically verify:
 
 2. **WAL-G restore test** — Spin up a throwaway container from the latest backup and run a query against it.
 
-3. **offen backup list** — Confirm volume tarballs exist in S3:
+3. **Volume backup list** — Confirm recent volume tarballs exist in S3 (one
+   prefix per volume):
    ```bash
-   aws s3 ls s3://PROJECT-backup/vol/ --region REGION
+   aws s3 ls s3://PROJECT-backup/vol/ --recursive --region REGION
+   ```
+   You can also trigger a run on demand and watch it:
+   ```bash
+   systemctl start miuops-backup.service
+   journalctl -u miuops-backup.service -f
    ```
 
 4. **Object Lock verification** — Confirm backups cannot be deleted:

--- a/playbook.yml
+++ b/playbook.yml
@@ -45,3 +45,5 @@
       tags: ['cloudflared']
     - role: observability
       tags: ['observability']
+    - role: backup
+      tags: ['backup']

--- a/roles/backup/README.md
+++ b/roles/backup/README.md
@@ -1,0 +1,201 @@
+# roles/backup
+
+Host-side, **stop-consistent** Docker volume backup to S3. A host `systemd`
+timer runs a bash script that, for each configured volume:
+
+1. stops the volume's writing containers (so the on-disk data is at rest),
+2. streams a `tar` of the volume through optional client-side encryption
+   **straight to S3** (nothing staged on local disk),
+3. restarts the containers.
+
+There is no backup container and nothing mounts the Docker socket into a
+container. The job runs as a host process using the host's own `docker` CLI.
+
+Opt-in per host. The whole role is a no-op unless `backup_enabled: true`.
+
+## What it is (and isn't) for
+
+Use it for the **volumes around** your apps — uploads, content directories,
+config volumes, caches. For PostgreSQL, prefer a log-shipping tool such as
+WAL-G (continuous archiving) and leave its data volume out of this list; a
+stop-the-world tar of a live database volume is a crash-consistent snapshot at
+best. This job's strength is that it can take an at-rest snapshot by stopping
+the writer first.
+
+## Quick start
+
+1. Create the S3 bucket + IAM user (Object Lock + lifecycle):
+   `scripts/setup-s3-backup.sh` (one bucket is shared with WAL-G — see the repo
+   README).
+2. Export the AWS credentials in the shell you run miuOps from:
+
+   ```bash
+   export AWS_ACCESS_KEY_ID=AKIA...
+   export AWS_SECRET_ACCESS_KEY=...
+   export AWS_REGION=us-west-2
+   ```
+
+3. Configure the host in `host_vars/<host>.yml` (see schema below).
+4. Apply: `./miuops apply <host>` (or `ansible-playbook playbook.yml --tags backup --limit <host>`).
+
+## Configuration (host_vars schema)
+
+| Variable | Default | Description |
+|---|---|---|
+| `backup_enabled` | `false` | Master switch. Role is a no-op when false. |
+| `backup_volumes` | `[]` | List of `{ name, stop }` items (below). |
+| `backup_s3_bucket` | `""` | Destination bucket name (no `s3://`). Required. |
+| `backup_s3_prefix` | `"vol"` | Key prefix. Objects land under `<prefix>/<volume>/`. |
+| `backup_schedule` | `"*-*-* 02:00:00"` | systemd `OnCalendar` expression. |
+| `backup_randomized_delay_sec` | `"45m"` | `RandomizedDelaySec` to smear the start. |
+| `backup_encryption` | `"none"` | `none` \| `age`. |
+| `backup_age_recipients` | `[]` | age recipients (`age1...`, `ssh-ed25519`/`ssh-rsa`, or `age1yubikey1...`). |
+| `backup_aws_access_key_id` | env `AWS_ACCESS_KEY_ID` | AWS key. Keep env-only. |
+| `backup_aws_secret_access_key` | env `AWS_SECRET_ACCESS_KEY` | AWS secret. Keep env-only. |
+| `backup_aws_region` | env `AWS_REGION` or `us-west-2` | AWS region. |
+| `backup_s3_endpoint_url` | `""` | Optional S3-compatible endpoint override. |
+
+Each `backup_volumes` item:
+
+```yaml
+- name: <docker volume name as shown by `docker volume ls`>
+  stop: [<container names to stop before archiving, restart after>]   # empty/omit = hot copy
+```
+
+### Downtime and the `stop` list — read before listing a volume
+
+A container in a volume's `stop` list is **down for the entire backup of that
+volume**: stop + tar + encrypt + upload + restart. That window is proportional to
+**volume size ÷ upload bandwidth**, not seconds — a 50 GiB volume on a 100 Mbit/s
+uplink is offline for over an hour. Do **not** put a large, customer-facing writer
+volume in `stop` and expect sub-minute downtime. For those, prefer a tool that
+snapshots without stopping the writer (filesystem/LVM snapshot, or a
+log-shipping/replication tool for databases) and leave the volume out of this
+list, or accept a hot copy (empty `stop`) if its writer tolerates a fuzzy
+snapshot.
+
+**Set `restart: unless-stopped` on every backed-up container.** The script's trap
+restarts containers it stopped, but it **cannot** catch `SIGKILL` or a host
+reboot mid-backup. With `restart: unless-stopped`, Docker brings the container
+back on its own after such an event; without it, a container could be left down
+until the next manual intervention.
+
+### Example
+
+```yaml
+# host_vars/<host>.yml
+backup_enabled: true
+backup_s3_bucket: "myproject-backup"
+backup_s3_prefix: "vol"
+backup_schedule: "*-*-* 02:00:00"
+backup_encryption: "age"
+backup_age_recipients:
+  - "age1ql3z7hjy54pw3hyww5ayyfg7zqgvc7w3j2elw8zmrj2kg5sfn9aqmcac8p"
+  # or an SSH public key:
+  # - "ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAA..."
+backup_volumes:
+  - name: app_uploads        # stateful: stop the writer for an at-rest copy
+    stop: [app]
+  - name: caddy_data         # tolerant of a hot copy: no stop
+    stop: []
+```
+
+AWS credentials are **not** in host_vars — export them as environment variables
+(above) so they stay out of the repo. They are rendered on the host into
+`/etc/miuops-backup/backup.env` (mode `0600`, root) and sourced by the script,
+so they never appear in `ps` / the process table.
+
+## Files on the host
+
+| Path | Mode | Purpose |
+|---|---|---|
+| `/usr/local/bin/miuops-backup` | `0700` root | the backup script |
+| `/etc/miuops-backup/backup.env` | `0600` root | AWS credentials (sourced) |
+| `/etc/miuops-backup/volumes.json` | `0600` root | volume list |
+| `/etc/systemd/system/miuops-backup.service` | `0644` | oneshot unit |
+| `/etc/systemd/system/miuops-backup.timer` | `0644` | schedule |
+
+## Object naming
+
+```
+s3://<bucket>/<prefix>/<volume>/backup-<UTC ISO8601>.tar[.age]
+# e.g. s3://myproject-backup/vol/app_uploads/backup-20260624T020000Z.tar.age
+```
+
+## Retention
+
+The job **never deletes** anything. Retention is enforced entirely by S3:
+Object Lock (Governance, 30 days) blocks deletion and the bucket lifecycle
+transitions to Glacier at 30 days and expires at 90. This matches the WAL-G
+side and means a compromised host (or a bug here) cannot erase history.
+
+## Operations
+
+```bash
+# Trigger a backup now (does not wait for the timer)
+systemctl start miuops-backup.service
+
+# Watch it run
+journalctl -u miuops-backup.service -f
+
+# When does it next fire?
+systemctl list-timers miuops-backup.timer
+
+# What got uploaded?
+aws s3 ls s3://<bucket>/vol/ --recursive --region <region>
+```
+
+## Restore
+
+Run on the server so large backups download straight from S3 (no laptop
+round-trip).
+
+```bash
+# 1. Pick a backup
+aws s3 ls s3://<bucket>/vol/<volume>/ --region <region>
+
+# 2. Download it
+aws s3 cp s3://<bucket>/vol/<volume>/backup-<ts>.tar.age . --region <region>
+
+# 3. Decrypt (skip if unencrypted)
+#    age (identity file, SSH private key, or YubiKey-backed identity):
+age --decrypt -i key.txt -o backup-<ts>.tar backup-<ts>.tar.age
+
+# 4. Stop the consumers, extract into the target volume, restart.
+#    --numeric-owner preserves UIDs/GIDs as numbers, so ownership is
+#    deterministic even when restoring onto a host with different /etc/passwd.
+docker stop <containers>
+docker run --rm \
+  -v <volume>:/restore \
+  -v "$(pwd)/backup-<ts>.tar:/backup.tar:ro" \
+  alpine sh -c "cd /restore && tar --numeric-owner -xf /backup.tar"
+docker start <containers>
+```
+
+The tar is rooted at the volume's contents (created with
+`tar -C .../_data --numeric-owner -cf - .`), so it extracts directly into the
+target volume root.
+
+See [docs/BACKUP_ENCRYPTION.md](../../docs/BACKUP_ENCRYPTION.md) and
+[docs/DISASTER_RECOVERY.md](../../docs/DISASTER_RECOVERY.md) for the full
+procedures and encryption key handling (including SSH-key and YubiKey-backed age).
+
+## Why these choices
+
+- **No socket mount / no container.** Mounting `docker.sock` into a container
+  grants root-equivalent control of the host to that container. Running the job
+  as a host process with the host CLI avoids handing that surface to anything.
+- **awscli for upload.** A single small dependency that streams stdin to an
+  object (`aws s3 cp - s3://...`), and AWS credentials are already the
+  project's convention (shared with WAL-G). No extra config file format to
+  template. The Debian/Ubuntu `awscli` package is **v1**, which handles the
+  streamed `aws s3 cp - s3://...` upload fine. Note the ceiling: a single
+  streamed object is capped at S3's 10 000-part multipart limit, ~**78 GiB** per
+  object with the default chunk size. A volume that exceeds that fails **loud**
+  (the upload stage returns non-zero, caught by the PIPESTATUS check), it is not
+  silently truncated — but it means a very large volume needs a different
+  approach (raise the CLI's `multipart_chunksize`, or split/snapshot the volume).
+- **Asymmetric encryption only.** The private key never sits on the server, so
+  a host compromise yields the backups but not the ability to read them.
+- **Stream, never stage.** `tar | encrypt | upload` keeps no plaintext copy on
+  disk and needs no scratch space sized to the volume.

--- a/roles/backup/defaults/main.yml
+++ b/roles/backup/defaults/main.yml
@@ -1,0 +1,73 @@
+---
+# Host-side, stop-consistent Docker volume backup to S3. Opt-in per host:
+# set `backup_enabled: true` in that host's host_vars. The whole role is a
+# no-op otherwise.
+#
+# A host systemd timer runs a bash script that, for each volume in
+# `backup_volumes`, stops its containers (for a consistent on-disk snapshot),
+# streams a tar of the volume through optional encryption straight to S3, then
+# restarts the containers. No container, no docker.sock mount.
+backup_enabled: false
+
+# --- What to back up --------------------------------------------------------
+# A list of Docker volumes. Each item:
+#   name: <docker volume name as shown by `docker volume ls`>
+#   stop: [<container names/ids to stop before archiving, restart after>]
+# An empty (or omitted) `stop` list takes a HOT copy with the containers still
+# running -- only safe for volumes whose writers can tolerate a fuzzy snapshot
+# (append-only logs, idempotently-rebuilt caches). For anything stateful
+# (databases, queues) list the writing containers so the archive is taken at
+# rest. Databases are better served by their own log-shipping tool (e.g. WAL-G);
+# use this for the volumes around them.
+backup_volumes: []
+#   - name: app_uploads
+#     stop: [app]
+#   - name: caddy_data
+#     stop: []
+
+# --- Destination ------------------------------------------------------------
+# S3 bucket (name only, no s3:// prefix) and key prefix. Objects land at
+#   s3://<bucket>/<prefix>/<volume>/backup-<UTC ISO8601>.tar[.age]
+backup_s3_bucket: ""
+backup_s3_prefix: "vol"
+
+# --- Schedule ---------------------------------------------------------------
+# systemd OnCalendar expression for the timer. Default: daily at ~02:00 local.
+# A randomized delay (below) smears the actual start to avoid a thundering herd
+# across a fleet and to dodge round-the-hour S3 contention.
+backup_schedule: "*-*-* 02:00:00"
+backup_randomized_delay_sec: "45m"
+
+# --- Encryption (client-side, before upload) --------------------------------
+# One of: none | age. Encrypts the tar stream so a leaked S3 credential
+# (or a leaked object) cannot read backup contents.
+#   age  -> recipients in `backup_age_recipients` (native age1... keys and/or
+#           ssh-ed25519 / ssh-rsa public keys). Output extension: .tar.age
+#           age covers hardware/SSH workflows too: it accepts SSH public keys
+#           as recipients (restore with the matching SSH private key) and
+#           supports age-plugin-yubikey for hardware-backed keys -- see
+#           docs/BACKUP_ENCRYPTION.md.
+# Asymmetric only by design: the private key never lives on the server, so a
+# host compromise does not expose the means to decrypt the backups.
+backup_encryption: "none"
+backup_age_recipients: []
+
+# --- AWS credentials --------------------------------------------------------
+# Supplied via environment variables at apply time so secrets stay env-only and
+# never get written into the repo. Export before running, e.g.:
+#   export AWS_ACCESS_KEY_ID=...  AWS_SECRET_ACCESS_KEY=...
+#   ./miuops apply <host>
+# (The region is not secret; set backup_aws_region directly if you prefer.)
+# These render into /etc/miuops-backup/backup.env (0600, root) on the host; the
+# script sources that file, so credentials never appear in argv / `ps` output.
+backup_aws_access_key_id: "{{ lookup('env', 'AWS_ACCESS_KEY_ID') | default('', true) }}"
+backup_aws_secret_access_key: "{{ lookup('env', 'AWS_SECRET_ACCESS_KEY') | default('', true) }}"
+backup_aws_region: "{{ lookup('env', 'AWS_REGION') | default('us-west-2', true) }}"
+
+# Optional S3-compatible endpoint override (e.g. for non-AWS object stores).
+# Leave empty for AWS S3. When set, passed to the AWS CLI as --endpoint-url.
+backup_s3_endpoint_url: ""
+
+# --- Internal paths (override only if you must) -----------------------------
+backup_config_dir: "/etc/miuops-backup"
+backup_script_path: "/usr/local/bin/miuops-backup"

--- a/roles/backup/handlers/main.yml
+++ b/roles/backup/handlers/main.yml
@@ -1,0 +1,12 @@
+---
+- name: Reload systemd
+  ansible.builtin.systemd:
+    daemon_reload: true
+  when: backup_enabled | bool
+
+- name: Restart backup timer
+  ansible.builtin.systemd:
+    name: miuops-backup.timer
+    state: restarted
+    daemon_reload: true
+  when: backup_enabled | bool

--- a/roles/backup/tasks/main.yml
+++ b/roles/backup/tasks/main.yml
@@ -1,0 +1,143 @@
+---
+# Host-side, stop-consistent Docker volume backup to S3, driven by a systemd
+# timer. No-op unless `backup_enabled`. Self-contained: installs its own
+# dependencies so a `--tags backup` run works on its own (mirrors the
+# observability / cloudflared roles).
+
+# ---- Validate configuration up front -----------------------------------------
+- name: Ensure backup destination + credentials are configured
+  ansible.builtin.assert:
+    that:
+      - backup_s3_bucket | length > 0
+      - backup_aws_access_key_id | length > 0
+      - backup_aws_secret_access_key | length > 0
+      - backup_aws_region | length > 0
+    fail_msg: >-
+      backup_enabled is true but the destination/credentials are incomplete.
+      Set backup_s3_bucket in host_vars and export the AWS credentials before
+      running (see roles/backup/README.md):
+      AWS_ACCESS_KEY_ID, AWS_SECRET_ACCESS_KEY, AWS_REGION.
+    quiet: true
+  when: backup_enabled | bool
+  tags: ['backup']
+
+- name: Validate encryption mode
+  ansible.builtin.assert:
+    that:
+      - backup_encryption in ['none', 'age']
+      - not (backup_encryption == 'age' and (backup_age_recipients | length == 0))
+    fail_msg: >-
+      Invalid encryption config. backup_encryption must be one of none|age;
+      age requires backup_age_recipients.
+    quiet: true
+  when: backup_enabled | bool
+  tags: ['backup']
+
+# ---- Dependencies (self-contained) -------------------------------------------
+# awscli streams the upload (`aws s3 cp - s3://...`); jq parses the volume list;
+# tar is base. age is installed only when that encryption mode is used.
+- name: Install backup dependencies (awscli, jq, tar)
+  ansible.builtin.apt:
+    name:
+      - awscli
+      - jq
+      - tar
+    state: present
+    update_cache: true
+  when: backup_enabled | bool
+  tags: ['backup']
+
+- name: Install age (only when encryption=age)
+  ansible.builtin.apt:
+    name: age
+    state: present
+    update_cache: true
+  when:
+    - backup_enabled | bool
+    - backup_encryption == 'age'
+  tags: ['backup']
+
+# ---- Config + secrets --------------------------------------------------------
+- name: Create backup config directory
+  ansible.builtin.file:
+    path: "{{ backup_config_dir }}"
+    state: directory
+    owner: root
+    group: root
+    mode: '0700'
+  when: backup_enabled | bool
+  tags: ['backup']
+
+- name: Deploy AWS credentials env file (sourced by the script; root-only)
+  ansible.builtin.template:
+    src: backup.env.j2
+    dest: "{{ backup_config_dir }}/backup.env"
+    owner: root
+    group: root
+    mode: '0600'
+  no_log: true
+  when: backup_enabled | bool
+  notify: Restart backup timer
+  tags: ['backup']
+
+- name: Deploy volume list
+  ansible.builtin.template:
+    src: volumes.json.j2
+    dest: "{{ backup_config_dir }}/volumes.json"
+    owner: root
+    group: root
+    mode: '0600'
+  when: backup_enabled | bool
+  notify: Restart backup timer
+  tags: ['backup']
+
+# ---- Backup script -----------------------------------------------------------
+- name: Deploy backup script
+  ansible.builtin.template:
+    src: miuops-backup.sh.j2
+    dest: "{{ backup_script_path }}"
+    owner: root
+    group: root
+    mode: '0700'
+  when: backup_enabled | bool
+  notify: Restart backup timer
+  tags: ['backup']
+
+# ---- systemd service + timer -------------------------------------------------
+- name: Deploy backup systemd service
+  ansible.builtin.template:
+    src: miuops-backup.service.j2
+    dest: /etc/systemd/system/miuops-backup.service
+    owner: root
+    group: root
+    mode: '0644'
+  when: backup_enabled | bool
+  notify:
+    - Reload systemd
+    - Restart backup timer
+  tags: ['backup']
+
+- name: Deploy backup systemd timer
+  ansible.builtin.template:
+    src: miuops-backup.timer.j2
+    dest: /etc/systemd/system/miuops-backup.timer
+    owner: root
+    group: root
+    mode: '0644'
+  when: backup_enabled | bool
+  notify:
+    - Reload systemd
+    - Restart backup timer
+  tags: ['backup']
+
+- name: Enable + start the backup timer
+  ansible.builtin.systemd:
+    name: miuops-backup.timer
+    enabled: true
+    state: started
+    daemon_reload: true
+  when: backup_enabled | bool
+  tags: ['backup']
+
+- name: Flush handlers
+  ansible.builtin.meta: flush_handlers

--- a/roles/backup/templates/backup.env.j2
+++ b/roles/backup/templates/backup.env.j2
@@ -1,0 +1,6 @@
+# Managed by Ansible (roles/backup). Do not edit by hand.
+# AWS credentials for the backup job. mode 0600, owner root. The backup script
+# sources this file so credentials never appear in argv / `ps` output.
+AWS_ACCESS_KEY_ID={{ backup_aws_access_key_id }}
+AWS_SECRET_ACCESS_KEY={{ backup_aws_secret_access_key }}
+AWS_DEFAULT_REGION={{ backup_aws_region }}

--- a/roles/backup/templates/miuops-backup.service.j2
+++ b/roles/backup/templates/miuops-backup.service.j2
@@ -1,0 +1,37 @@
+{{ ansible_managed | comment }}
+[Unit]
+Description=miuOps host-side Docker volume backup to S3
+Documentation=https://github.com/tianshanghong/miuops
+# Only run once the container runtime and network are up.
+After=network-online.target docker.service
+Wants=network-online.target
+
+[Service]
+Type=oneshot
+ExecStart={{ backup_script_path }}
+
+# --- Sandbox -----------------------------------------------------------------
+# The job legitimately needs: root, the docker CLI (talks to the daemon socket),
+# outbound network (S3), and READ access to /var/lib/docker/volumes. The sandbox
+# blunts a compromised process without breaking any of that. Deliberately NOT
+# using ProtectSystem=strict (it would hide /var/lib/docker behind a read-only
+# overlay and require an explicit allow-list); the looser ProtectSystem=full
+# keeps /etc, /boot and /usr read-only while leaving /var writable for docker.
+NoNewPrivileges=true
+ProtectSystem=full
+ProtectHome=true
+PrivateTmp=true
+ProtectKernelTunables=true
+ProtectKernelModules=true
+ProtectKernelLogs=true
+ProtectControlGroups=true
+RestrictAddressFamilies=AF_INET AF_INET6 AF_UNIX
+RestrictRealtime=true
+RestrictSUIDSGID=true
+LockPersonality=true
+RestrictNamespaces=true
+SystemCallFilter=@system-service
+SystemCallErrorNumber=EPERM
+
+[Install]
+WantedBy=multi-user.target

--- a/roles/backup/templates/miuops-backup.sh.j2
+++ b/roles/backup/templates/miuops-backup.sh.j2
@@ -1,0 +1,270 @@
+#!/usr/bin/env bash
+#
+# Managed by Ansible (roles/backup). Do not edit by hand.
+#
+# Host-side, stop-consistent Docker volume backup to S3.
+#
+# For each volume in the config it: stops the listed containers (so the
+# on-disk data is at rest), streams a tar of the volume's _data directory
+# through optional client-side encryption straight to S3, then restarts the
+# containers. Nothing is staged on local disk and no plaintext copy is written
+# anywhere. Retention is enforced by S3 (Object Lock + lifecycle), so this job
+# never deletes anything.
+#
+# Safety model:
+#   * `set -euo pipefail` + an explicit pipe-status check, so a failure in any
+#     stage of `tar | encrypt | upload` fails the whole job (a naive pipeline
+#     would report only the last command's status and hide a tar/encrypt error).
+#   * A trap restarts every container this run stopped, even on error, signal,
+#     or early exit -- a backup must never leave a service down.
+#   * AWS credentials are sourced from a root-only env file, never passed on the
+#     command line, so they do not appear in `ps` / the process table.
+
+set -euo pipefail
+
+# ---------------------------------------------------------------------------
+# Configuration (rendered by Ansible)
+# ---------------------------------------------------------------------------
+CONFIG_DIR="{{ backup_config_dir }}"
+ENV_FILE="${CONFIG_DIR}/backup.env"
+VOLUMES_FILE="${CONFIG_DIR}/volumes.json"
+
+S3_BUCKET="{{ backup_s3_bucket }}"
+S3_PREFIX="{{ backup_s3_prefix }}"
+ENCRYPTION="{{ backup_encryption }}"
+ENDPOINT_URL="{{ backup_s3_endpoint_url }}"
+
+# age recipients (one -r flag per recipient).
+AGE_RECIPIENTS=(
+{% for r in backup_age_recipients %}
+  {{ r | quote }}
+{% endfor %}
+)
+
+# Docker's volume storage root. Each named volume lives at <root>/<name>/_data.
+DOCKER_VOLUME_ROOT="/var/lib/docker/volumes"
+
+log() { printf '%s %s\n' "$(date -u +%Y-%m-%dT%H:%M:%SZ)" "$*"; }
+die() { log "ERROR: $*"; exit 1; }
+
+# ---------------------------------------------------------------------------
+# Restart-on-exit safety net
+# ---------------------------------------------------------------------------
+# Every container we stop is appended here. The trap restarts them all on ANY
+# exit path. Idempotent: `docker start` on an already-running container is a
+# no-op, so a normal-path restart followed by the trap is harmless.
+STOPPED_CONTAINERS=()
+
+restart_stopped() {
+  # Preserve the real exit code; this trap must not mask it.
+  local rc=$?
+  # Snapshot the list through a `set -u`-safe guard (an unguarded expansion of a
+  # possibly-empty array is an unbound-variable error on some bash builds).
+  local -a pending=(${STOPPED_CONTAINERS[@]+"${STOPPED_CONTAINERS[@]}"})
+  if [ -n "${pending[*]:-}" ]; then
+    log "Restarting containers stopped during this run: ${pending[*]}"
+    local c
+    for c in "${pending[@]}"; do
+      # Best-effort: never let a failed restart hide the original error, but do
+      # surface it so a stuck container is visible in the journal.
+      if ! docker start "$c" >/dev/null 2>&1; then
+        log "WARNING: failed to restart container '$c' -- check it manually"
+      fi
+    done
+  fi
+  exit "$rc"
+}
+trap restart_stopped EXIT INT TERM
+
+# ---------------------------------------------------------------------------
+# Preconditions
+# ---------------------------------------------------------------------------
+[ -n "$S3_BUCKET" ] || die "S3 bucket is not configured"
+[ -r "$ENV_FILE" ]  || die "credentials file not readable: $ENV_FILE"
+[ -r "$VOLUMES_FILE" ] || die "volume list not readable: $VOLUMES_FILE"
+
+command -v docker >/dev/null 2>&1 || die "docker CLI not found"
+command -v aws    >/dev/null 2>&1 || die "aws CLI not found"
+command -v jq     >/dev/null 2>&1 || die "jq not found"
+command -v tar    >/dev/null 2>&1 || die "tar not found"
+
+case "$ENCRYPTION" in
+  none) ;;
+  age)
+    command -v age >/dev/null 2>&1 || die "encryption=age but 'age' not found"
+    [ -n "${AGE_RECIPIENTS[*]}" ] || die "encryption=age but no recipients configured"
+    ;;
+  *) die "unknown encryption mode: $ENCRYPTION (expected none|age)" ;;
+esac
+
+# Load AWS credentials into the environment (file is 0600 root). Sourcing keeps
+# them out of argv (the file path, not the secrets, is all that is ever passed).
+set -a
+# shellcheck source=/dev/null  # runtime-only path; nothing to follow at lint time
+. "$ENV_FILE"
+set +a
+
+# Endpoint override only when configured (empty arg would break the CLI).
+AWS_ENDPOINT_ARGS=()
+[ -n "$ENDPOINT_URL" ] && AWS_ENDPOINT_ARGS=(--endpoint-url "$ENDPOINT_URL")
+
+# ---------------------------------------------------------------------------
+# Per-volume backup
+# ---------------------------------------------------------------------------
+# Run the tar|encrypt|upload pipeline and fail if ANY stage failed. We capture
+# every stage's status via PIPESTATUS rather than trusting the pipeline's final
+# exit code (which would only reflect the upload).
+#
+# Returns 0 on success and non-zero on a real failure (it does NOT call `die`),
+# so the caller can isolate a single volume's failure without aborting the run.
+#
+# tar exit-code handling: stage 0 is GNU tar. tar exits 1 for "some files differ"
+# / "file changed as we read it" -- benign here (a writer touched a file mid-read;
+# the archive is still valid and complete), so we LOG A WARNING and proceed. Only
+# tar exit >=2 (a real, fatal archiver error) fails the volume. Every other stage
+# (age, aws) is fatal on ANY non-zero status.
+#
+# Empty arrays (AWS_ENDPOINT_ARGS, AGE_ARGS) are expanded with the
+# `${arr[@]+"${arr[@]}"}` guard so they vanish cleanly instead of tripping
+# `set -u` -- an unguarded `"${empty[@]}"` is an unbound-variable error on some
+# bash builds.
+run_pipeline() {
+  local data_dir="$1" key="$2"
+  local -a statuses
+
+  case "$ENCRYPTION" in
+    none)
+      tar -C "$data_dir" --numeric-owner -cf - . \
+        | aws ${AWS_ENDPOINT_ARGS[@]+"${AWS_ENDPOINT_ARGS[@]}"} s3 cp - "s3://${S3_BUCKET}/${key}"
+      statuses=("${PIPESTATUS[@]}")
+      ;;
+    age)
+      tar -C "$data_dir" --numeric-owner -cf - . \
+        | age ${AGE_ARGS[@]+"${AGE_ARGS[@]}"} \
+        | aws ${AWS_ENDPOINT_ARGS[@]+"${AWS_ENDPOINT_ARGS[@]}"} s3 cp - "s3://${S3_BUCKET}/${key}"
+      statuses=("${PIPESTATUS[@]}")
+      ;;
+  esac
+
+  local idx st
+  for idx in "${!statuses[@]}"; do
+    st="${statuses[$idx]}"
+    [ "$st" -eq 0 ] && continue
+    if [ "$idx" -eq 0 ] && [ "$st" -eq 1 ]; then
+      # tar stage, exit 1: "file changed as we read it" -- archive still valid.
+      log "WARNING: tar reported a benign change-during-read (exit 1) for ${key}; archive is intact, continuing"
+      continue
+    fi
+    log "ERROR: backup pipeline stage $idx exited ${st} for ${key}"
+    return 1
+  done
+  return 0
+}
+
+# Pre-build the age recipient flags (-r <recipient> per recipient).
+AGE_ARGS=()
+if [ "$ENCRYPTION" = "age" ]; then
+  for r in "${AGE_RECIPIENTS[@]}"; do
+    AGE_ARGS+=(-r "$r")
+  done
+fi
+
+ext=".tar"
+[ "$ENCRYPTION" = "age" ] && ext=".tar.age"
+
+# Restart the containers this volume stopped and clear the global stop list, so
+# the run can continue to the next volume without leaving this one's services
+# down (and without the EXIT trap redundantly restarting them). Used by BOTH the
+# success path and the per-volume failure path -- the global trap is only the
+# catastrophic backstop, not the normal restart mechanism.
+restart_volume_containers() {
+  local c
+  for c in "$@"; do
+    log "Restarting container '$c'"
+    docker start "$c" >/dev/null || log "WARNING: failed to restart '$c'"
+  done
+  STOPPED_CONTAINERS=()
+}
+
+# Back up a single volume. Returns non-zero on any failure (it does NOT call
+# `die`) so the main loop can isolate one volume's failure and still process the
+# rest. On every return path this volume's stopped containers are restarted here
+# -- we do not rely on the global EXIT trap, because the run continues.
+backup_volume() {
+  local name="$1"
+  shift
+  local stop_list=("$@")
+  local data_dir="${DOCKER_VOLUME_ROOT}/${name}/_data"
+
+  if [ ! -d "$data_dir" ]; then
+    # Nothing stopped yet, so nothing to restart.
+    log "ERROR: volume data dir not found: $data_dir (is '$name' a real docker volume?)"
+    return 1
+  fi
+
+  # Stop writers for a consistent on-disk snapshot. Record each BEFORE issuing
+  # the stop so the trap restarts it even if `docker stop` itself is interrupted.
+  # `stop_list` is empty for a hot-copy volume; the guard keeps `set -u` happy.
+  local c
+  for c in ${stop_list[@]+"${stop_list[@]}"}; do
+    log "Stopping container '$c' for volume '$name'"
+    STOPPED_CONTAINERS+=("$c")
+    if ! docker stop "$c" >/dev/null; then
+      log "ERROR: failed to stop container '$c' for volume '$name'"
+      restart_volume_containers ${stop_list[@]+"${stop_list[@]}"}
+      return 1
+    fi
+  done
+
+  local ts key
+  ts="$(date -u +%Y%m%dT%H%M%SZ)"
+  key="${S3_PREFIX}/${name}/backup-${ts}${ext}"
+
+  log "Archiving volume '$name' -> s3://${S3_BUCKET}/${key}"
+  if ! run_pipeline "$data_dir" "$key"; then
+    log "ERROR: backup failed for volume '$name'"
+    restart_volume_containers ${stop_list[@]+"${stop_list[@]}"}
+    return 1
+  fi
+  log "Uploaded s3://${S3_BUCKET}/${key}"
+
+  # Success: restart this volume's containers now (don't keep services down
+  # across the whole run) and clear the global stop list.
+  restart_volume_containers ${stop_list[@]+"${stop_list[@]}"}
+  return 0
+}
+
+# ---------------------------------------------------------------------------
+# Main
+# ---------------------------------------------------------------------------
+volume_count="$(jq 'length' "$VOLUMES_FILE")"
+[ "$volume_count" -gt 0 ] || { log "No volumes configured; nothing to do."; exit 0; }
+
+log "Starting backup of ${volume_count} volume(s) to s3://${S3_BUCKET}/${S3_PREFIX}/ (encryption=${ENCRYPTION})"
+
+# Per-volume failure isolation: a failure backing up ONE volume must not skip the
+# others. `backup_volume` returns non-zero (instead of `die`-ing) and restarts
+# its own containers on the failure path; here we count the failure and move on.
+# `if ! ...` keeps the non-zero return from aborting the script under
+# `set -e`. After the loop we exit non-zero iff any volume failed. The global
+# `trap restart_stopped EXIT INT TERM` remains the catastrophic backstop.
+failures=0
+
+# Read each volume as a TSV row: <name>\t<space-joined stop list>. A missing or
+# empty `stop` defaults to [] (jq's `// []`), yielding an empty field -> hot copy.
+# The guarded expansion of `stop_arr` keeps `set -u` happy when that field is
+# empty. Container names cannot contain whitespace, so a space split is safe.
+while IFS=$'\t' read -r vol_name stop_joined; do
+  stop_arr=()
+  [ -n "$stop_joined" ] && read -r -a stop_arr <<< "$stop_joined"
+  if ! backup_volume "$vol_name" ${stop_arr[@]+"${stop_arr[@]}"}; then
+    failures=$((failures + 1))
+    log "Continuing to next volume after failure on '$vol_name'."
+  fi
+done < <(jq -r '.[] | [.name, ((.stop // []) | join(" "))] | @tsv' "$VOLUMES_FILE")
+
+if [ "$failures" -gt 0 ]; then
+  die "Backup run finished with ${failures} failed volume(s)."
+fi
+
+log "Backup run complete."

--- a/roles/backup/templates/miuops-backup.timer.j2
+++ b/roles/backup/templates/miuops-backup.timer.j2
@@ -1,0 +1,14 @@
+{{ ansible_managed | comment }}
+[Unit]
+Description=Schedule for miuOps host-side Docker volume backup
+
+[Timer]
+OnCalendar={{ backup_schedule }}
+# Smear the start across a window so a fleet does not all hit S3 at once and to
+# avoid exactly-on-the-hour contention.
+RandomizedDelaySec={{ backup_randomized_delay_sec }}
+# If the machine was off at the scheduled time, run as soon as it is back up.
+Persistent=true
+
+[Install]
+WantedBy=timers.target

--- a/roles/backup/templates/volumes.json.j2
+++ b/roles/backup/templates/volumes.json.j2
@@ -1,0 +1,9 @@
+{#
+  Managed by Ansible (roles/backup). Do not edit by hand.
+  The backup job reads this with jq. Each item:
+    { "name": "<docker volume>", "stop": ["<container>", ...] }
+  `stop` may be absent or empty -> hot copy (the script defaults it to []).
+  Rendered via to_nice_json so it is always valid JSON regardless of how the
+  volume / container names are written in host_vars.
+#}
+{{ backup_volumes | to_nice_json }}

--- a/scripts/setup-s3-backup.sh
+++ b/scripts/setup-s3-backup.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 
 # Setup S3 backup bucket with Object Lock, lifecycle rules, and IAM user
-# Creates a single bucket for both WAL-G database and offen volume backups
+# Creates a single bucket for both WAL-G database and host-side volume backups
 # Idempotent — safe to re-run if a previous run failed partway through
 
 set -e
@@ -170,6 +170,14 @@ aws s3api put-bucket-lifecycle-configuration \
                 "NoncurrentVersionExpiration": {
                     "NoncurrentDays": 90
                 }
+            },
+            {
+                "ID": "abort-incomplete-multipart-uploads",
+                "Status": "Enabled",
+                "Filter": {},
+                "AbortIncompleteMultipartUpload": {
+                    "DaysAfterInitiation": 7
+                }
             }
         ]
     }'
@@ -254,29 +262,39 @@ echo "Secret Key:      $SECRET_ACCESS_KEY"
 echo ""
 echo "Save these credentials now — the secret key cannot be retrieved again."
 echo ""
-echo "--- .env configuration ---"
+echo "--- AWS credentials ---"
 echo ""
-echo "# AWS credentials (shared by offen + WAL-G)"
-echo "AWS_ACCESS_KEY_ID=$ACCESS_KEY_ID"
-echo "AWS_SECRET_ACCESS_KEY=$SECRET_ACCESS_KEY"
-echo "AWS_REGION=$AWS_REGION"
+echo "# Host-side volume backup (Ansible 'backup' role): export these in the"
+echo "# shell you run miuOps from -- they stay env-only and are never committed."
+echo "export AWS_ACCESS_KEY_ID=$ACCESS_KEY_ID"
+echo "export AWS_SECRET_ACCESS_KEY=$SECRET_ACCESS_KEY"
+echo "export AWS_REGION=$AWS_REGION"
 echo ""
-echo "# Offen volume backup (stacks/backup)"
-echo "BACKUP_S3_BUCKET=$BUCKET_NAME"
-echo "BACKUP_S3_PATH=vol"
+echo "# Then in host_vars/<host>.yml:"
+echo "#   backup_enabled: true"
+echo "#   backup_s3_bucket: \"$BUCKET_NAME\""
+echo "#   backup_s3_prefix: \"vol\""
+echo "#   backup_volumes: [ { name: <volume>, stop: [<container>] }, ... ]"
 echo ""
-echo "# WAL-G database backup (set per stack, replace <app-name>)"
-echo "# WALG_S3_PREFIX=s3://${BUCKET_NAME}/db/<app-name>"
+echo "# WAL-G database backup still reads these from the server's .env"
+echo "# (/opt/stacks/.env), per stack:"
+echo "#   AWS_ACCESS_KEY_ID=$ACCESS_KEY_ID"
+echo "#   AWS_SECRET_ACCESS_KEY=$SECRET_ACCESS_KEY"
+echo "#   AWS_REGION=$AWS_REGION"
+echo "#   WALG_S3_PREFIX=s3://${BUCKET_NAME}/db/<app-name>"
 echo ""
 echo "=============================================="
 echo "        Next Steps                            "
 echo "=============================================="
 echo ""
-echo "1. SSH into the server and add the .env values above to /opt/stacks/.env"
-echo "2. Use the pre-built postgres-walg image in your compose file:"
+echo "1. Configure + apply the volume backup role (see roles/backup/README.md):"
+echo "   set backup_* in host_vars/<host>.yml, export the AWS creds above, then"
+echo "   ./miuops apply <host>"
+echo "2. For PostgreSQL, add the .env values above to /opt/stacks/.env and use"
+echo "   the pre-built postgres-walg image in your compose file:"
 echo "   image: ghcr.io/tianshanghong/postgres-walg:17"
 echo "3. Add a host cron job for daily base backups:"
 echo "   0 3 * * * cd /opt/stacks/<app-name> && docker compose exec -T -u postgres db walg-backup.sh"
-echo "4. Set up backup encryption — see docs/BACKUP_ENCRYPTION.md"
-echo "   Strongly recommended: backups include .env (secrets)"
+echo "4. Set up volume backup encryption -- see docs/BACKUP_ENCRYPTION.md"
+echo "   Strongly recommended: volumes may contain secrets/personal data"
 echo "=============================================="


### PR DESCRIPTION
Add `roles/backup`: a host systemd timer that backs up Docker volumes **without a docker.sock-mounting container**. Replaces the old volume-backup container's escape surface with a host process in the host trust domain.

## What it does
For each configured volume: `docker stop` the listed containers (at-rest consistency) → stream `tar | age | aws s3 cp -` (nothing staged on disk) → `docker start`. Opt-in via `backup_enabled`; generic + parameterized via host_vars (which volumes, which containers to stop, S3 bucket/prefix, schedule, age recipients).

## Robustness
- A trap restarts every container it stopped on any exit (EXIT/INT/TERM).
- The pipeline checks **every** stage (PIPESTATUS), tolerating only GNU tar's benign exit-1.
- **Per-volume failure isolation**: one volume's failure never skips the others — each failed volume's containers are still restarted and the run exits non-zero.
- AWS creds in a root-only `0600` env file **sourced** by the script (never in argv). systemd sandbox on the oneshot service.

## Security
- No docker.sock, no container — net reduction vs the old socket-mounting backup container.
- Asymmetric client-side encryption (age; supports `ssh-ed25519`/`ssh-rsa` recipients + `age-plugin-yubikey`). A host compromise yields ciphertext, not decryption capability.
- Retention is S3 Object Lock + lifecycle; the role never deletes (a compromised host can't erase history). Adds an `AbortIncompleteMultipartUpload` lifecycle rule so a failed large upload can't orphan billable parts.

## Validation
On-host: happy path + restore (exact data, incl. nested dirs) + failure-trap (upload fails → container still restarted + non-zero exit) + per-volume isolation (3 volumes, middle fails → other two succeed, all restarted, exit 1) + age round-trip — all pass. shellcheck + ansible syntax clean.
