### PR TITLE
feat(policy-check): allow a read-only docker-socket-proxy to bind docker.sock

### DIFF
--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -9,7 +9,7 @@ Design rationale and internal architecture of miuOps.
 | Ansible | Keep for day-0 bootstrap + infra upgrades | Firewall, Docker, cloudflared, and Traefik upgrades are infrastructure — not appropriate for GitOps. |
 | GitHub Actions | GitOps for service deployment | Sync compose files via SSH + rsync, `docker compose up -d`. Server never pulls from git. |
 | Cloudflare Tunnel | Zero exposed ports | All ingress flows through Cloudflare. No public-facing ports on the server. |
-| Traefik | Stateless reverse proxy | Label-based service discovery, no config files to manage per-service. |
+| Traefik | Stateless reverse proxy | Label-based service discovery via a read-only docker-socket-proxy (never the raw socket — see [DOCKER_SOCKET_PROXY.md](DOCKER_SOCKET_PROXY.md)), no config files to manage per-service. |
 | WAL-G | PostgreSQL backup | Physical backup + continuous WAL archiving to S3, baked into a custom PG image. |
 | Single S3 bucket | Backup storage | One bucket, one IAM user, prefixes separate data types. Simplifies lifecycle and Object Lock config. |
 | Two repos | Public tool + private config | miuOps is open-source; user infrastructure is private. Different lifecycles, different audiences. |

--- a/docs/DOCKER_SOCKET_PROXY.md
+++ b/docs/DOCKER_SOCKET_PROXY.md
@@ -1,0 +1,75 @@
+# Traefik → read-only docker-socket-proxy
+
+Traefik discovers services from container labels, which needs the Docker API. The raw
+`/var/run/docker.sock` is **root-equivalent**: anything that can talk to it can start a
+privileged container and own the host. So Traefik must **not** mount the raw socket.
+Instead, a small **read-only proxy** mounts the socket and exposes only the read-only API
+Traefik needs; Traefik talks to the proxy over TCP on an internal network.
+
+A compromised Traefik then reaches only `GET`/`HEAD` on a few endpoints — it cannot
+start/exec/modify containers or read swarm secrets.
+
+## What the stack must look like
+
+The proxy and Traefik live in the **stack repo** (the GitOps-deployed compose), not in
+miuops. Configure them like this:
+
+```yaml
+services:
+  docker-socket-proxy:
+    # Pin a digest (see hub.docker.com/r/tecnativa/docker-socket-proxy/tags).
+    image: tecnativa/docker-socket-proxy:latest
+    x-miuops-docker-socket-proxy: true     # opt in to the policy-check exception
+    cap_drop: [ALL]
+    read_only: true
+    restart: unless-stopped
+    environment:
+      CONTAINERS: 1     # Traefik lists/inspects containers
+      EVENTS: 1         # Traefik watches for changes
+      PING: 1           # health
+      POST: 0           # read-only: only GET/HEAD reach the daemon
+      # everything else (SECRETS, CONFIGS, AUTH, EXEC, IMAGES, NETWORKS, …) stays off (0)
+    volumes:
+      - /var/run/docker.sock:/var/run/docker.sock:ro
+    networks: [socket_proxy]
+
+  traefik:
+    image: traefik:v3   # pin a digest
+    # NO docker.sock mount here.
+    command:
+      - --providers.docker.endpoint=tcp://docker-socket-proxy:2375
+      - --providers.docker.exposedByDefault=false
+    networks: [socket_proxy, traefik_default]
+    # ports / labels / ingress networks as before
+    depends_on: [docker-socket-proxy]
+
+networks:
+  socket_proxy:
+    internal: true     # proxy↔traefik only; no egress, no app stacks
+  traefik_default: {}
+```
+
+## Why those exact settings (policy-check enforced)
+
+The stack policy-check (`tests/stack_policy_check.py`) forbids any `docker.sock` mount
+**except** a service that proves it is a read-only proxy. A compose file is rejected unless
+the only `docker.sock`-mounting service:
+
+- carries `x-miuops-docker-socket-proxy: true` (explicit opt-in),
+- mounts the socket `:ro`,
+- publishes no host port (it is reached only over the internal network, never re-exposed),
+- sets `POST: 0` (no write methods reach the daemon), and
+- enables none of `SECRETS` / `CONFIGS` / `AUTH` / `EXEC` (no secret read / no exec).
+
+`POST: 0` blocks every write/exec verb — create/start/stop/exec are all `POST`, so they are
+refused even if those sections are enabled. It does **not** block `GET` reads of `/secrets`,
+`/configs`, `/auth`, so the policy-check requires those sections off *independently* of
+`POST`. Verified on a host: with `POST=0` and those sections off, the proxy answers
+`GET /containers/json` and `/_ping` (200) but returns `403` on `POST /containers/create`
+and `GET /secrets`.
+
+## Network isolation
+
+Put the proxy on an `internal: true` network shared only with Traefik. The proxy needs no
+outbound network of its own, and no application stack should be able to reach it — only
+Traefik. Keep Traefik on that internal network **plus** its normal ingress networks.

--- a/tests/fixtures/stack_policy/bad-socket-proxy-annotation-string.yml
+++ b/tests/fixtures/stack_policy/bad-socket-proxy-annotation-string.yml
@@ -1,0 +1,10 @@
+# Annotation must be a real YAML boolean true, not the string "true".
+services:
+  docker-socket-proxy:
+    image: tecnativa/docker-socket-proxy:0.4.2
+    x-miuops-docker-socket-proxy: "true"
+    cap_drop: [ALL]
+    environment:
+      POST: 0
+    volumes:
+      - /var/run/docker.sock:/var/run/docker.sock:ro

--- a/tests/fixtures/stack_policy/bad-socket-proxy-ports.yml
+++ b/tests/fixtures/stack_policy/bad-socket-proxy-ports.yml
@@ -1,0 +1,12 @@
+# A read-only proxy must not publish a host port (it is reached over the internal network).
+services:
+  docker-socket-proxy:
+    image: tecnativa/docker-socket-proxy:0.4.2
+    x-miuops-docker-socket-proxy: true
+    cap_drop: [ALL]
+    environment:
+      POST: 0
+    ports:
+      - "127.0.0.1:2375:2375"
+    volumes:
+      - /var/run/docker.sock:/var/run/docker.sock:ro

--- a/tests/fixtures/stack_policy/bad-socket-proxy-post-float.yml
+++ b/tests/fixtures/stack_policy/bad-socket-proxy-post-float.yml
@@ -1,0 +1,10 @@
+# POST: 1.0 (YAML float) is writable; the proxy reads "1.0" as on, so the linter must too.
+services:
+  docker-socket-proxy:
+    image: tecnativa/docker-socket-proxy:0.4.2
+    x-miuops-docker-socket-proxy: true
+    cap_drop: [ALL]
+    environment:
+      POST: 1.0
+    volumes:
+      - /var/run/docker.sock:/var/run/docker.sock:ro

--- a/tests/fixtures/stack_policy/bad-socket-proxy-post-strnum.yml
+++ b/tests/fixtures/stack_policy/bad-socket-proxy-post-strnum.yml
@@ -1,0 +1,11 @@
+# Quoted numeric-leading string: the proxy's read_int64 parses "2.9" -> 2 -> writable,
+# so the linter must treat it as writable too (mirror, not the fixed word-set).
+services:
+  docker-socket-proxy:
+    image: tecnativa/docker-socket-proxy:0.4.2
+    x-miuops-docker-socket-proxy: true
+    cap_drop: [ALL]
+    environment:
+      POST: "2.9"
+    volumes:
+      - /var/run/docker.sock:/var/run/docker.sock:ro

--- a/tests/fixtures/stack_policy/bad-socket-proxy-rw.yml
+++ b/tests/fixtures/stack_policy/bad-socket-proxy-rw.yml
@@ -1,0 +1,9 @@
+services:
+  docker-socket-proxy:
+    image: tecnativa/docker-socket-proxy:0.4.2
+    x-miuops-docker-socket-proxy: true
+    cap_drop: [ALL]
+    environment:
+      POST: 0
+    volumes:
+      - /var/run/docker.sock:/var/run/docker.sock

--- a/tests/fixtures/stack_policy/bad-socket-proxy-secrets.yml
+++ b/tests/fixtures/stack_policy/bad-socket-proxy-secrets.yml
@@ -1,0 +1,10 @@
+services:
+  docker-socket-proxy:
+    image: tecnativa/docker-socket-proxy:0.4.2
+    x-miuops-docker-socket-proxy: true
+    cap_drop: [ALL]
+    environment:
+      POST: 0
+      SECRETS: 1
+    volumes:
+      - /var/run/docker.sock:/var/run/docker.sock:ro

--- a/tests/fixtures/stack_policy/bad-socket-proxy-writable.yml
+++ b/tests/fixtures/stack_policy/bad-socket-proxy-writable.yml
@@ -1,0 +1,10 @@
+services:
+  docker-socket-proxy:
+    image: tecnativa/docker-socket-proxy:0.4.2
+    x-miuops-docker-socket-proxy: true
+    cap_drop: [ALL]
+    environment:
+      CONTAINERS: 1
+      POST: 1
+    volumes:
+      - /var/run/docker.sock:/var/run/docker.sock:ro

--- a/tests/fixtures/stack_policy/good-socket-proxy.yml
+++ b/tests/fixtures/stack_policy/good-socket-proxy.yml
@@ -1,0 +1,13 @@
+# A read-only docker-socket-proxy: the one service permitted to bind docker.sock.
+services:
+  docker-socket-proxy:
+    image: tecnativa/docker-socket-proxy:0.4.2
+    x-miuops-docker-socket-proxy: true
+    cap_drop: [ALL]
+    environment:
+      CONTAINERS: 1
+      EVENTS: 1
+      PING: 1
+      POST: 0
+    volumes:
+      - /var/run/docker.sock:/var/run/docker.sock:ro

--- a/tests/stack_policy_check.py
+++ b/tests/stack_policy_check.py
@@ -14,14 +14,16 @@ privilege at *publish time* (this gate), not with a runtime firewall. A compose 
   - is missing `cap_drop: [ALL]`, or re-adds a dangerous capability via `cap_add`
     (with or without the `CAP_` prefix),
   - weakens the sandbox via `security_opt` (unconfined / label:disable / no-new-privileges:false),
-  - bind-mounts the docker socket, a whole system directory (/, /etc, /usr, ...), or a
-    sensitive host path (/proc, /sys, /dev, /var/run, ...),
+  - bind-mounts the docker socket (allowed ONLY for a read-only docker-socket-proxy that
+    opts in with `x-miuops-docker-socket-proxy: true`, `POST=0`, and a `:ro` mount), a
+    whole system directory (/, /etc, /usr, ...), or a sensitive host path (/proc, /sys, ...),
   - passes through host `devices:`.
 
 Usage: stack_policy_check.py <compose.yml> [more.yml ...]
 Requires PyYAML (`pip install pyyaml`).
 """
 import posixpath
+import re
 import sys
 
 try:
@@ -57,7 +59,16 @@ SENSITIVE_MOUNT_FILES = frozenset({"/etc/shadow", "/etc/gshadow", "/etc/passwd",
 def _is_truthy(value):
     if isinstance(value, bool):
         return value
-    return str(value).strip().lower() in {"true", "yes", "on", "1"}
+    if isinstance(value, (int, float)):
+        return value != 0  # POST: 1.0 / 2 are truthy; the proxy reads them as "on"
+    text = str(value).strip().lower()
+    if text in {"true", "yes", "on"}:
+        return True
+    # Mirror the proxy's HAProxy `-m bool` parse (read_int64): an optional sign + leading
+    # decimal digits, nonzero => enabled. So "1", "01", "2.9", "-1", "1abc" are all truthy,
+    # matching the running proxy — a writable value can't read as "read-only" here.
+    leading_int = re.match(r"[+-]?\d+", text)
+    return bool(leading_int) and int(leading_int.group()) != 0
 
 
 def _norm_cap(cap):
@@ -116,6 +127,51 @@ def _published_host_ip(port):
     return None  # "host:container" or "container" — no explicit host IP
 
 
+def _env_map(environment):
+    """compose `environment` as a dict; accepts a mapping or a ['KEY=value', ...] list.
+
+    A bare `KEY` (host-env pass-through) maps to "" — its real value is unknown here, so
+    the read-only checks treat it as not-enabled. This is a publish-time guardrail, not a
+    defence against a deliberately obfuscated compose.
+    """
+    if isinstance(environment, dict):
+        return {str(k): ("" if v is None else v) for k, v in environment.items()}
+    result = {}
+    for item in _as_list(environment):
+        key, sep, value = str(item).partition("=")
+        result[key.strip()] = value.strip() if sep else ""
+    return result
+
+
+def _mount_is_read_only(vol):
+    """True if a compose volume mount is read-only (`:ro` short syntax / `read_only: true`)."""
+    if isinstance(vol, dict):
+        return bool(vol.get("read_only"))
+    parts = str(vol).split(":")
+    return len(parts) >= 3 and "ro" in parts[2].split(",")
+
+
+def _is_approved_socket_proxy(svc):
+    """True iff this service is an explicitly-opted-in, read-only docker-socket-proxy.
+
+    The docker socket is root-equivalent, so it is the one host path a service may bind —
+    and only when (a) the service is marked `x-miuops-docker-socket-proxy: true`, (b) it
+    publishes no host port (it is reached only over the internal Docker network, never
+    re-exposed), and (c) it is configured read-only: `POST` is off (GET/HEAD only) and no
+    secret- or exec-exposing section (SECRETS / CONFIGS / AUTH / EXEC) is enabled. Combined
+    with the read-only mount flag checked at the call site, a compromised proxy can only
+    LIST/READ the Docker API — never start/exec/modify or read swarm secrets.
+    """
+    if svc.get("x-miuops-docker-socket-proxy") is not True:
+        return False
+    if _as_list(svc.get("ports")):
+        return False  # reached over the internal network only — it must never publish a port
+    env = _env_map(svc.get("environment"))
+    if _is_truthy(env.get("POST")):
+        return False
+    return not any(_is_truthy(env.get(section)) for section in ("SECRETS", "CONFIGS", "AUTH", "EXEC"))
+
+
 def check_file(path):
     """Return a list of policy-violation strings for one compose file (empty = clean)."""
     try:
@@ -169,10 +225,16 @@ def check_file(path):
             if "unconfined" in normalised or normalised in {"label:disable", "no-new-privileges:false"}:
                 violations.append(f"{prefix} weakens the sandbox via security_opt: {opt!r}")
 
+        proxy_ok = _is_approved_socket_proxy(svc)
         for vol in _as_list(svc.get("volumes")):
             source = vol.get("source") if isinstance(vol, dict) else str(vol).split(":", 1)[0]
-            if source and _is_sensitive_mount(source):
-                violations.append(f"{prefix} bind-mounts a sensitive host path: {source!r}")
+            if not source or not _is_sensitive_mount(source):
+                continue
+            # The docker socket on an approved, read-only docker-socket-proxy is the one
+            # permitted sensitive mount — Traefik et al. reach Docker through it, not raw.
+            if "docker.sock" in str(source) and proxy_ok and _mount_is_read_only(vol):
+                continue
+            violations.append(f"{prefix} bind-mounts a sensitive host path: {source!r}")
 
         if _as_list(svc.get("devices")):
             violations.append(f"{prefix} passes through host devices (raw device access)")

--- a/tests/stack_policy_check_test.sh
+++ b/tests/stack_policy_check_test.sh
@@ -54,6 +54,17 @@ expect_pass good-localtime.yml
 expect_fail bad-mount-dotdot.yml
 expect_fail bad-mount-dotslash.yml
 
+# docker-socket-proxy exception: a read-only, opted-in proxy may bind docker.sock; anything
+# short of fully read-only (POST=1, a :rw mount, or a secret-exposing section) is rejected.
+expect_pass good-socket-proxy.yml
+expect_fail bad-socket-proxy-writable.yml
+expect_fail bad-socket-proxy-rw.yml
+expect_fail bad-socket-proxy-secrets.yml
+expect_fail bad-socket-proxy-post-float.yml
+expect_fail bad-socket-proxy-post-strnum.yml
+expect_fail bad-socket-proxy-ports.yml
+expect_fail bad-socket-proxy-annotation-string.yml
+
 # A batch containing any violating file must fail as a whole.
 if "$PY" "$CHECK" "$FIX/good.yml" "$FIX/bad-privileged.yml" >/dev/null 2>&1; then
   echo "FAIL (reject): a batch containing a bad file should be rejected"; fail=1


### PR DESCRIPTION
Add a narrow exception to the stack policy-check so Traefik can reach the Docker API through a **read-only docker-socket-proxy** instead of mounting the raw, root-equivalent socket.

## The exception
A compose service may bind-mount `docker.sock` ONLY when it:
- opts in with `x-miuops-docker-socket-proxy: true` (a real YAML boolean),
- mounts the socket `:ro`,
- publishes no host port (reached only over the internal Docker network),
- sets `POST: 0` (GET/HEAD-only), and
- enables none of `SECRETS` / `CONFIGS` / `AUTH` / `EXEC`.

Any other `docker.sock` mount — and any proxy that is not fully read-only — is still rejected. The truthiness check mirrors the proxy's own HAProxy `-m bool` parse, so a writable value (e.g. `POST: "2.9"`) can't read as "read-only" here.

## Why
The raw `docker.sock` is root-equivalent. Behind a `POST=0` proxy a compromised Traefik can only LIST/READ the Docker API — never start/exec/modify containers or read swarm secrets.

## Scope
The proxy + Traefik compose live in the stack repo (where Traefik already lives); this PR is the miuops-side enabler (the policy-check exception) plus the pattern doc (`docs/DOCKER_SOCKET_PROXY.md`).

## Validation
Self-test (the read-only proxy passes; `POST=1`/`1.0`/`"2.9"`, a `:rw` mount, a published port, `SECRETS=1`, and a non-annotated `docker.sock` are all rejected) + on-host (a real proxy with `POST=0` answers `GET /containers` + `/_ping` with 200 but 403 on `POST /containers/create` and `GET /secrets`). Two independent review rounds; truthiness verified against the upstream HAProxy semantics.