### PR TITLE
feat(ssh): key-only SSH (PasswordAuthentication no)

### DIFF
--- a/playbook.yml
+++ b/playbook.yml
@@ -37,6 +37,8 @@
   roles:
     - role: firewall
       tags: ['firewall']
+    - role: ssh
+      tags: ['ssh']
     - role: docker
       tags: ['docker']
     - role: traefik

--- a/roles/ssh/README.md
+++ b/roles/ssh/README.md
@@ -1,0 +1,41 @@
+# SSH Role
+
+Host SSH hardening: **key-only authentication**.
+
+The public SSH port (22) is the one service a tunnel-only host still exposes, and it is under
+constant internet-wide password brute-force. This role disables password authentication so
+that brute-force is pointless — only key holders can log in.
+
+## What it does
+
+Deploys `/etc/ssh/sshd_config.d/10-miuops-ssh.conf` (a drop-in, leaving the distro's base
+`sshd_config` untouched) and reloads sshd:
+
+```
+PasswordAuthentication no
+KbdInteractiveAuthentication no
+PermitRootLogin prohibit-password
+PubkeyAuthentication yes
+AuthenticationMethods publickey
+```
+
+The `10-` prefix matters: sshd uses the **first** value it sees for each keyword and reads
+`sshd_config.d/*.conf` in lexical order, so this must sort **before** a cloud image's
+`50-cloud-init.conf` (which may set `PasswordAuthentication yes`) — otherwise the cloud-init
+value silently wins and the host stays password-open. `PermitRootLogin prohibit-password`
+keeps root reachable by key (the deploy connects as root) while refusing root password
+logins. `AuthenticationMethods publickey` makes "publickey and nothing else" explicit. The
+drop-in is validated with `sshd -t` before the reload, so a syntax error can never lock you
+out.
+
+SSH connection **rate-limiting** (`ufw limit`, ~6 conns/30s) is handled by `roles/firewall`,
+which runs just before this role. fail2ban and a tight `MaxAuthTries` are intentionally
+omitted — key-only already makes password brute-force pointless, and a low `MaxAuthTries`
+breaks legitimate multi-key SSH agents.
+
+## Requirements
+
+- A working SSH **key** in the deploy user's `authorized_keys` BEFORE this runs — once
+  password auth is off, only keys work. The role **asserts** this and fails fast (no lockout)
+  if none is present. (Fresh hosts are provisioned with the operator's key.)
+- Debian/Ubuntu with the `sshd_config.d/` drop-in directory (default on current releases).

--- a/roles/ssh/handlers/main.yml
+++ b/roles/ssh/handlers/main.yml
@@ -1,0 +1,6 @@
+---
+- name: Reload sshd
+  ansible.builtin.systemd:
+    name: ssh
+    state: reloaded
+  become: true

--- a/roles/ssh/tasks/main.yml
+++ b/roles/ssh/tasks/main.yml
@@ -1,0 +1,40 @@
+---
+# Host SSH hardening: key-only authentication. A fresh host refuses password logins out of
+# the box, so the constant internet-wide SSH password brute-force against the public port is
+# pointless (keys only). Deployed as a drop-in so the distro's base sshd_config is untouched.
+# SSH rate-limiting (ufw limit) lives in roles/firewall, which runs just before this.
+
+- name: Check the deploy user has an authorized key (lockout guard)
+  ansible.builtin.stat:
+    path: "{{ ansible_env.HOME }}/.ssh/authorized_keys"
+  register: ssh_authorized_keys
+
+- name: Refuse to enforce key-only SSH without a key present
+  ansible.builtin.assert:
+    that:
+      - ssh_authorized_keys.stat.exists
+      - (ssh_authorized_keys.stat.size | default(0)) > 0
+    fail_msg: >-
+      The deploy user has no ~/.ssh/authorized_keys on the host — enforcing key-only would
+      lock you out. Add your public key to the host first.
+    quiet: true
+
+- name: Deploy SSH key-only drop-in
+  # 10- so it sorts BEFORE a cloud image's 50-cloud-init.conf: sshd uses the FIRST value it
+  # sees for each keyword and reads sshd_config.d/*.conf in lexical order, so a cloud-init
+  # drop-in setting `PasswordAuthentication yes` would otherwise silently win.
+  ansible.builtin.copy:
+    dest: /etc/ssh/sshd_config.d/10-miuops-ssh.conf
+    content: |
+      # Managed by Ansible (roles/ssh). Key-only SSH.
+      PasswordAuthentication no
+      KbdInteractiveAuthentication no
+      PermitRootLogin prohibit-password
+      PubkeyAuthentication yes
+      AuthenticationMethods publickey
+    owner: root
+    group: root
+    mode: '0644'
+    validate: /usr/sbin/sshd -t -f %s
+  notify: Reload sshd
+  become: true


### PR DESCRIPTION
Make host SSH key-only. The public SSH port (22) is the one service a tunnel-only host still exposes and it is under constant internet-wide password brute-force; disabling password auth makes that pointless.

## What
A new `roles/ssh` deploys `/etc/ssh/sshd_config.d/10-miuops-ssh.conf`:
- `PasswordAuthentication no`, `KbdInteractiveAuthentication no`
- `PermitRootLogin prohibit-password` (root by key only — the deploy connects as root)
- `AuthenticationMethods publickey`

The `10-` prefix sorts the drop-in **before** a cloud image's `50-cloud-init.conf`: sshd uses the first value per keyword, so a later cloud-init `PasswordAuthentication yes` would otherwise silently win (the host would stay password-open). A pre-flight assertion refuses to enforce key-only if the deploy user has no `authorized_keys` (lockout guard); the drop-in is validated with `sshd -t` before the reload. SSH rate-limiting (`ufw limit`) lives in `roles/firewall`, which runs just before this.

## Validation
On-host: with `10-` the effective `passwordauthentication no` wins over a `50-cloud-init.conf` set to `yes`; with the original `99-` it lost (proving the prefix matters). The drop-in passes `sshd -t`. Two independent review rounds (code + security): ship it.