### PR TITLE
feat(unattended-upgrades): unattended security upgrades, no auto-reboot

### DIFF
--- a/playbook.yml
+++ b/playbook.yml
@@ -47,3 +47,5 @@
       tags: ['observability']
     - role: backup
       tags: ['backup']
+    - role: unattended-upgrades
+      tags: ['unattended-upgrades']

--- a/roles/unattended-upgrades/README.md
+++ b/roles/unattended-upgrades/README.md
@@ -26,8 +26,9 @@ relies on the default rather than rewriting it — and the default already exclu
 
 Because the host never reboots itself, a security upgrade that needs a reboot (kernel, glibc)
 or a service restart leaves it patched-on-disk but still running the old code until the
-operator acts. `unattended-upgrades` writes `/var/run/reboot-required` when a reboot is owed —
-check it (or alert on it via the observability role) and reboot in a maintenance window.
+operator acts. Such an upgrade leaves `/var/run/reboot-required` behind (the package postinst
+writes it; `unattended-upgrades` only reads it to decide whether to reboot) — check that file,
+or alert on it via the observability role, and reboot in a maintenance window.
 
 ## Requirements
 

--- a/roles/unattended-upgrades/README.md
+++ b/roles/unattended-upgrades/README.md
@@ -1,0 +1,35 @@
+# Unattended-Upgrades Role
+
+Applies **unattended security upgrades with NO automatic reboot**.
+
+A tunnel-only host should patch its own security holes without an operator babysitting it —
+but it must never reboot itself unattended: a surprise reboot drops the Cloudflare tunnel and
+every running stack until someone notices.
+
+## What it does
+
+- Installs `unattended-upgrades`.
+- Deploys `/etc/apt/apt.conf.d/52-miuops-unattended.conf`:
+  - `APT::Periodic::Update-Package-Lists "1";` + `APT::Periodic::Unattended-Upgrade "1";` —
+    refresh + apply on the `apt-daily` timer.
+  - `Unattended-Upgrade::Automatic-Reboot "false";` — **never reboot unattended**.
+- Enables `apt-daily-upgrade.timer`.
+
+**Origins:** left at the distro default — the `-security` pocket plus the base release pocket,
+and **not** `-updates` / `-proposed` / backports. The `-security` pocket carries the security
+fixes; the base release pocket changes only at point releases (which fold in stable-updates),
+so in normal operation the only automatic upgrades are security ones. (apt.conf list semantics
+let a drop-in only *append* to `Allowed-Origins`, never remove the default entries, so the role
+relies on the default rather than rewriting it — and the default already excludes `-updates`.)
+
+## Maintenance
+
+Because the host never reboots itself, a security upgrade that needs a reboot (kernel, glibc)
+or a service restart leaves it patched-on-disk but still running the old code until the
+operator acts. `unattended-upgrades` writes `/var/run/reboot-required` when a reboot is owed —
+check it (or alert on it via the observability role) and reboot in a maintenance window.
+
+## Requirements
+
+- Debian/Ubuntu with the `unattended-upgrades` package available + the `apt-daily` systemd
+  timers (default on current releases).

--- a/roles/unattended-upgrades/tasks/main.yml
+++ b/roles/unattended-upgrades/tasks/main.yml
@@ -1,0 +1,36 @@
+---
+# Unattended SECURITY upgrades, with NO automatic reboot. A fresh host patches itself from
+# the security pocket on the apt-daily timer; it never reboots unattended — the operator
+# reboots on their own schedule (a surprise reboot would drop the tunnel + every stack).
+
+- name: Install unattended-upgrades
+  ansible.builtin.apt:
+    name: unattended-upgrades
+    state: present
+    update_cache: true
+  become: true
+
+- name: Configure unattended security upgrades (security only, no auto-reboot)
+  ansible.builtin.copy:
+    dest: /etc/apt/apt.conf.d/52-miuops-unattended.conf
+    content: |
+      // Managed by Ansible (roles/unattended-upgrades). Unattended security upgrades, no reboot.
+      // Allowed-Origins is left at the distro default: the -security pocket plus the base release
+      // pocket, and NOT -updates. -security carries the security fixes; the base pocket changes
+      // only at point releases, so in normal operation only security upgrades are applied. (apt.conf
+      // list semantics let a drop-in only append origins, never remove them, so we rely on the
+      // default rather than rewriting it.)
+      APT::Periodic::Update-Package-Lists "1";
+      APT::Periodic::Unattended-Upgrade "1";
+      Unattended-Upgrade::Automatic-Reboot "false";
+    owner: root
+    group: root
+    mode: '0644'
+  become: true
+
+- name: Enable the apt-daily-upgrade timer (drives unattended-upgrades)
+  ansible.builtin.systemd:
+    name: apt-daily-upgrade.timer
+    enabled: true
+    state: started
+  become: true


### PR DESCRIPTION
Apply unattended SECURITY upgrades with NO automatic reboot.

## What
A new `roles/unattended-upgrades`: installs `unattended-upgrades`, deploys
`/etc/apt/apt.conf.d/52-miuops-unattended.conf` (periodic update/upgrade on,
`Unattended-Upgrade::Automatic-Reboot "false"`), and enables `apt-daily-upgrade.timer`. A
tunnel-only host patches its own security holes unattended but never reboots itself — a
surprise reboot would drop the Cloudflare tunnel and every running stack.

Allowed-Origins is left at the distro default (the `-security` pocket plus the base release
pocket, not `-updates`), which is security-only in normal operation; apt.conf list semantics
let a drop-in only append origins, never remove them, so the role relies on the default
rather than rewriting it. The README documents tracking `/var/run/reboot-required` to close
the no-auto-reboot tradeoff.

## Validation
On-host (Ubuntu): `Automatic-Reboot` resolves to `false`, `APT::Periodic::Unattended-Upgrade
"1"`, `unattended-upgrade --dry-run` exits 0. Independent review rounds (code + security +
sensitive-info): ship it.