### PR TITLE
feat(traefik): run Traefik as a non-root host binary via a read-only docker-socket-proxy

### DIFF
--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -103,11 +103,11 @@ All compose stacks follow a three-tier network model with per-stack ingress isol
 
 | Network | Type | Scope | Purpose |
 |---|---|---|---|
-| `ingress` | normal bridge | Per-stack (e.g. `app1_ingress`) | HTTP ingress. Traefik connects via deploy workflow. Isolates stacks from each other. |
+| `ingress` | normal bridge | Per-stack (e.g. `app1_ingress`) | HTTP ingress. The host Traefik reaches it over the bridge. Isolates stacks from each other. |
 | `internal` | `internal: true` | Per-stack (e.g. `app1_internal`) | Backend isolation. DB, cache, queues. No internet, no cross-stack. |
 | `egress` | normal bridge | Per-stack (e.g. `app1_egress`) | Outbound internet. Only for containers that must call external APIs. |
 
-Traefik uses its compose-managed default network (`traefik_default`). No external network is required — cloudflared reaches Traefik via host port binding (`ports: 80:80, 443:443`) and the iptables loopback-to-bridge rule (`-i lo -o br+`), which matches any bridge interface.
+Traefik runs as a **host binary**, not on any Docker network. cloudflared reaches it on loopback (`https://127.0.0.1:8443`), and it routes to each stack's containers by their per-stack bridge IP — the host is the gateway for every bridge, so no `docker network connect` is needed.
 
 Docker Compose scopes non-external networks by project name, so each stack's `ingress`, `internal`, and `egress` are automatically isolated from other stacks.
 
@@ -115,42 +115,42 @@ Docker Compose scopes non-external networks by project name, so each stack's `in
 
 A shared ingress network allows any container on the network to reach any other container — on any port. Docker's `icc: false` setting only applies to the default bridge (`docker0`), not user-defined networks. If one service is compromised, the attacker can pivot laterally to all other services on the same network.
 
-Per-stack ingress networks eliminate this risk. Each stack gets its own bridge network. Traefik joins each via `docker network connect` (handled automatically by the deploy workflow). A compromised container can only see Traefik on its own isolated network — not other stacks.
+Per-stack ingress networks eliminate this risk. Each stack gets its own bridge network, and the host Traefik reaches each stack's containers over that bridge directly (the host is the bridge gateway, so no `docker network connect` is needed). A compromised container is confined to its own per-stack networks — it cannot pivot laterally to other stacks.
 
 ### Rules
 
-1. **Web-facing services join a per-stack `ingress` network** — the deploy workflow connects Traefik to each stack's ingress network via `docker network connect`.
+1. **Web-facing services join a per-stack `ingress` network** — the host Traefik reaches them over that bridge directly (no `docker network connect`).
 2. **Backend services (DB, cache) go on `internal` only** — `internal: true` blocks outbound internet and isolates from other stacks.
 3. **Containers needing outbound internet join `egress`** — a normal bridge with NAT. Most services don't need this.
 4. **Dual-network for mixed needs** — a container needing both DB access and outbound internet joins both `internal` and `egress`.
-5. **Every application service MUST have explicit `networks:`** — no implicit defaults. Traefik is the exception — it uses compose default (`traefik_default`) since its network connections are managed by the deploy workflow.
-6. **No `ports:` except Traefik** — all other ingress goes through Traefik labels.
+5. **Every application service MUST have explicit `networks:`** — no implicit defaults. (Traefik is not a stack service; it is a host binary managed by Ansible.)
+6. **No `ports:`** — ingress goes through Traefik labels; Traefik is a host process binding loopback, not a published container port.
 7. **Some images default to binding on `localhost`** — if a container is unreachable from Traefik, set `HOST=0.0.0.0` in its environment. This is safe within a per-stack ingress network because only Traefik can reach the container.
 
 ### Topology
 
 ```
-cloudflared (host) → 127.0.0.1:443
-    ↓ (host port binding, iptables: -i lo -o br+ -j RETURN)
-Traefik (traefik_default, ports 80/443)
-    ├── docker network connect app_ingress
-    ├── docker network connect crawler_ingress
+cloudflared (host) → https://127.0.0.1:8443 (noTLSVerify)
+    ↓
+Traefik (host binary, non-root, systemd-sandboxed)
+    ├── discovers labels via the read-only docker-socket-proxy (127.0.0.1:2375, POST=0)
+    └── routes to each container's per-stack bridge IP (the host is the bridge gateway)
     ↓
 app (app_ingress + app_internal)         crawler (crawler_ingress + crawler_internal + crawler_egress)
     ↓                                        ↓                  ↓
 db (app_internal only)                   db (crawler_internal)  internet (crawler_egress)
 
 Lateral movement blocked:
-  app ✕──► crawler  (different ingress networks)
-  crawler ✕──► app  (different ingress networks)
+  app ✕──► crawler  (separate per-stack bridges; only the host reaches them all)
+  crawler ✕──► app  (separate per-stack bridges)
 ```
 
 ### Defense in depth (Ansible-managed)
 
 - Per-stack ingress networks: lateral movement between stacks blocked at Docker network level
 - Docker daemon: `icc: false`, `userland-proxy: false`
-- iptables DOCKER-USER chain: blocks all direct container access from outside
-- iptables: only loopback traffic allowed to reach Docker bridges (cloudflared → Traefik)
+- ufw default-deny inbound: the only open port is SSH (rate-limited); no container port is ever publicly reachable
+- Traefik is a non-root host binary and reaches Docker only via a read-only docker-socket-proxy (POST=0, loopback) — it never holds the raw docker.sock
 
 ## Backup Design
 

--- a/roles/cloudflared/templates/config.yml.j2
+++ b/roles/cloudflared/templates/config.yml.j2
@@ -6,11 +6,11 @@ credentials-file: {{ credentials_file }}
 ingress:
 {% for domain in domains %}
   - hostname: "{{ domain }}"
-    service: https://127.0.0.1:443
+    service: https://127.0.0.1:8443
     originRequest:
       noTLSVerify: true
   - hostname: "*.{{ domain }}"
-    service: https://127.0.0.1:443
+    service: https://127.0.0.1:8443
     originRequest:
       noTLSVerify: true
 {% endfor %}

--- a/roles/docker/tasks/main.yml
+++ b/roles/docker/tasks/main.yml
@@ -108,8 +108,8 @@
 - name: Assert the Docker API is not exposed over TCP (unix socket only)
   # The Docker API over TCP = unauthenticated root on the host. Check every path it can be
   # enabled on, not just daemon.json: the systemd unit/socket (-H/--host tcp, or a TCP
-  # ListenStream incl. a bare port = all interfaces) and any real listener on the API ports
-  # (2375/2376). Fails loud if `ss` is unavailable rather than silently passing. miuops only
+  # ListenStream incl. a bare port = all interfaces) and any non-loopback listener on the API
+  # ports (2375/2376). Fails loud if `ss` is unavailable rather than silently passing. miuops only
   # ever uses the unix socket. (Runs as root — the play sets become.)
   shell: |
     set -e
@@ -121,8 +121,13 @@
       echo "FAIL: docker systemd unit/socket exposes the API over TCP"; exit 1
     fi
     listeners=$(ss -H -tln 2>/dev/null) || { echo "FAIL: ss unavailable; cannot verify the Docker API is not on TCP"; exit 1; }
-    if printf '%s\n' "$listeners" | grep -Eq -- ':(2375|2376)([[:space:]]|$)'; then
-      echo "FAIL: a process is listening on the Docker API TCP port"; exit 1
+    # Only a non-loopback bind on 2375/2376 is the API-over-TCP risk. A loopback-only
+    # read-only docker-socket-proxy (127.0.0.1:2375, used by the traefik role) is allowed: the
+    # daemon.json/unit checks above already prove the daemon itself is not on TCP, and no
+    # container or off-host packet can reach the host loopback.
+    exposed=$(printf '%s\n' "$listeners" | grep -E -- ':(2375|2376)([[:space:]]|$)' | grep -vE -- '(^|[[:space:]])(127\.[0-9.]+|\[::1\]):(2375|2376)([[:space:]]|$)') || true
+    if [ -n "$exposed" ]; then
+      echo "FAIL: a process exposes a Docker API TCP port on a non-loopback address: $exposed"; exit 1
     fi
   changed_when: false
   tags: ['docker']

--- a/roles/traefik/defaults/main.yml
+++ b/roles/traefik/defaults/main.yml
@@ -1,1 +1,31 @@
 ---
+# Traefik as a non-root host binary (systemd), not a container. Cloudflared connects to it on
+# loopback; it discovers stacks through a read-only docker-socket-proxy and routes to their
+# container IPs directly (the host is the gateway for every per-stack bridge).
+
+traefik_version: "3.7.5"
+# Arch derived from the host so the role is portable across amd64 + arm64 VPS/bare-metal.
+traefik_arch_map:
+  x86_64: amd64
+  aarch64: arm64
+traefik_arch: "{{ traefik_arch_map[ansible_architecture] | default('amd64') }}"
+# SHA-256 per arch (from the release's *_checksums.txt) — the binary is verified on download
+# (supply-chain). Update both when bumping traefik_version.
+traefik_sha256:
+  amd64: "9da81a928fde965c2c4678698bbc28bc3f600223b14c32b35bd480bf5ec863dc"
+  arm64: "9892c0974a3958d95f049d5dad3d751ba3597bdc33e96255d2369aad3d2bfeca"
+
+traefik_user: "traefik"
+traefik_group: "traefik"
+traefik_bin: "/usr/local/bin/traefik"
+traefik_config_dir: "/etc/traefik"
+traefik_data_dir: "/var/lib/traefik"
+
+# Loopback entrypoint cloudflared targets. A high (non-privileged) port so traefik needs no
+# CAP_NET_BIND_SERVICE and runs fully unprivileged.
+traefik_bind_address: "127.0.0.1:8443"
+
+# Read-only docker-socket-proxy: the single docker.sock holder, gives the non-root traefik
+# read-only Docker discovery. Pinned by digest so the image is immutable.
+traefik_proxy_image: "tecnativa/docker-socket-proxy@sha256:9e4b9e7517a6b660f2cc903a19b257b1852d5b3344794e3ea334ff00ae677ac2"
+traefik_proxy_bind: "127.0.0.1:2375"

--- a/roles/traefik/handlers/main.yml
+++ b/roles/traefik/handlers/main.yml
@@ -1,0 +1,14 @@
+---
+- name: Restart docker-socket-proxy
+  ansible.builtin.systemd:
+    name: docker-socket-proxy.service
+    state: restarted
+    daemon_reload: true
+  become: true
+
+- name: Restart traefik
+  ansible.builtin.systemd:
+    name: traefik.service
+    state: restarted
+    daemon_reload: true
+  become: true

--- a/roles/traefik/tasks/main.yml
+++ b/roles/traefik/tasks/main.yml
@@ -1,45 +1,122 @@
 ---
-# Traefik role: bootstrap server directories and upgrade Traefik image
-# Compose deployment is handled by the user's GitOps stack repo
+# Traefik as a non-root host binary + a read-only docker-socket-proxy. Replaces the old
+# container-in-the-stack-repo model — nothing about Traefik lives in /opt/stacks anymore, and
+# the host process reaches each stack's containers directly over the per-stack bridges (no
+# `docker network connect` dance).
 
-# ========== Bootstrap tasks (run on first setup) =============================
+- name: Assert the host architecture is supported
+  ansible.builtin.assert:
+    that: ansible_architecture in traefik_arch_map
+    fail_msg: >-
+      Unsupported architecture '{{ ansible_architecture }}'. Add it to traefik_arch_map and pin
+      its checksum in traefik_sha256 before deploying Traefik on this host.
+    quiet: true
 
+- name: Create traefik group
+  ansible.builtin.group:
+    name: "{{ traefik_group }}"
+    system: true
+  become: true
+
+- name: Create traefik system user
+  ansible.builtin.user:
+    name: "{{ traefik_user }}"
+    group: "{{ traefik_group }}"
+    system: true
+    shell: /usr/sbin/nologin
+    create_home: false
+  become: true
+
+- name: Create traefik config + data directories
+  ansible.builtin.file:
+    path: "{{ item.path }}"
+    state: directory
+    owner: "{{ item.owner }}"
+    group: "{{ traefik_group }}"
+    mode: "{{ item.mode }}"
+  loop:
+    - { path: "{{ traefik_config_dir }}", owner: root, mode: '0755' }
+    - { path: "{{ traefik_data_dir }}", owner: "{{ traefik_user }}", mode: '0750' }
+  become: true
+
+- name: Download Traefik binary archive (checksum-verified)
+  ansible.builtin.get_url:
+    url: "https://github.com/traefik/traefik/releases/download/v{{ traefik_version }}/traefik_v{{ traefik_version }}_linux_{{ traefik_arch }}.tar.gz"
+    dest: "/tmp/traefik_v{{ traefik_version }}_linux_{{ traefik_arch }}.tar.gz"
+    checksum: "sha256:{{ traefik_sha256[traefik_arch] }}"
+    mode: '0644'
+  become: true
+
+- name: Install Traefik binary
+  ansible.builtin.unarchive:
+    src: "/tmp/traefik_v{{ traefik_version }}_linux_{{ traefik_arch }}.tar.gz"
+    dest: /usr/local/bin
+    include: [traefik]
+    remote_src: true
+    owner: root
+    group: root
+    mode: '0755'
+  become: true
+  notify: Restart traefik
+
+- name: Deploy Traefik static config
+  ansible.builtin.template:
+    src: traefik.yml.j2
+    dest: "{{ traefik_config_dir }}/traefik.yml"
+    owner: root
+    group: "{{ traefik_group }}"
+    mode: '0640'
+  become: true
+  notify: Restart traefik
+
+- name: Deploy docker-socket-proxy systemd unit
+  ansible.builtin.template:
+    src: docker-socket-proxy.service.j2
+    dest: /etc/systemd/system/docker-socket-proxy.service
+    owner: root
+    group: root
+    mode: '0644'
+  become: true
+  notify: Restart docker-socket-proxy
+
+- name: Deploy Traefik systemd unit
+  ansible.builtin.template:
+    src: traefik.service.j2
+    dest: /etc/systemd/system/traefik.service
+    owner: root
+    group: root
+    mode: '0644'
+  become: true
+  notify: Restart traefik
+
+- name: Enable + start docker-socket-proxy
+  ansible.builtin.systemd:
+    name: docker-socket-proxy.service
+    enabled: true
+    state: started
+    daemon_reload: true
+  become: true
+
+- name: Enable + start Traefik
+  ansible.builtin.systemd:
+    name: traefik.service
+    enabled: true
+    state: started
+    daemon_reload: true
+  become: true
+
+# User-stack scaffolding (unchanged): the GitOps repo deploys app stacks under /opt/stacks.
 - name: Create stacks directory
-  file:
+  ansible.builtin.file:
     path: /opt/stacks
     state: directory
     mode: '0755'
-  tags: ['traefik']
+  become: true
 
 - name: Create stacks .env file
-  copy:
+  ansible.builtin.copy:
     content: ""
     dest: /opt/stacks/.env
     mode: '0600'
-    force: no
-  tags: ['traefik']
-
-# ========== Upgrade tasks (idempotent — skipped if stack not yet deployed) ====
-
-- name: Check if Traefik stack is deployed
-  ansible.builtin.stat:
-    path: /opt/stacks/traefik/docker-compose.yml
-  register: traefik_stack_compose
-  tags: ['traefik']
-
-- name: Pull latest Traefik image and recreate container
-  shell: >
-    docker compose -f /opt/stacks/traefik/docker-compose.yml pull &&
-    docker compose -f /opt/stacks/traefik/docker-compose.yml up -d
-  when: traefik_stack_compose.stat.exists
-  tags: ['traefik']
-
-- name: Reconnect Traefik to per-stack ingress networks
-  shell: |
-    for stack in /opt/stacks/*/; do
-      stack="$(basename "$stack")"
-      [ "$stack" = "traefik" ] && continue
-      docker network connect "${stack}_ingress" traefik 2>/dev/null || true
-    done
-  when: traefik_stack_compose.stat.exists
-  tags: ['traefik']
+    force: false
+  become: true

--- a/roles/traefik/templates/docker-socket-proxy.service.j2
+++ b/roles/traefik/templates/docker-socket-proxy.service.j2
@@ -1,0 +1,24 @@
+{{ ansible_managed | comment }}
+[Unit]
+Description=Read-only docker-socket-proxy (miuops, for Traefik discovery)
+After=docker.service
+Requires=docker.service
+
+[Service]
+# The single docker.sock holder. POST=0 makes the proxy refuse every write/mutation; only the
+# read endpoints Traefik needs (containers, networks, plus the default version/events/ping) are
+# enabled. Bound to loopback so only host processes (Traefik) can reach it. Run as a managed
+# container so the docker.sock access is isolated from the internet-facing Traefik process.
+ExecStartPre=-/usr/bin/docker rm -f docker-socket-proxy
+ExecStart=/usr/bin/docker run --rm --name docker-socket-proxy \
+  -v /var/run/docker.sock:/var/run/docker.sock:ro \
+  -p {{ traefik_proxy_bind }}:2375 \
+  -e POST=0 -e CONTAINERS=1 -e NETWORKS=1 \
+  --security-opt no-new-privileges \
+  {{ traefik_proxy_image }}
+ExecStop=/usr/bin/docker stop docker-socket-proxy
+Restart=on-failure
+RestartSec=5
+
+[Install]
+WantedBy=multi-user.target

--- a/roles/traefik/templates/traefik.service.j2
+++ b/roles/traefik/templates/traefik.service.j2
@@ -1,0 +1,44 @@
+{{ ansible_managed | comment }}
+[Unit]
+Description=Traefik reverse proxy (miuops host binary)
+After=network-online.target docker-socket-proxy.service
+Wants=network-online.target
+# Traefik discovers stacks through the proxy; without it there is nothing to route.
+Requires=docker-socket-proxy.service
+
+[Service]
+Type=simple
+User={{ traefik_user }}
+Group={{ traefik_group }}
+ExecStart={{ traefik_bin }} --configfile={{ traefik_config_dir }}/traefik.yml
+Restart=on-failure
+RestartSec=5
+
+# Sandbox. Traefik is the most internet-exposed component (it parses internet HTTP arriving
+# via cloudflared), so it runs as a dedicated NON-root user with NO capabilities — the
+# loopback entrypoint is a high port, so CAP_NET_BIND_SERVICE is not needed.
+NoNewPrivileges=true
+CapabilityBoundingSet=
+ProtectSystem=strict
+ReadWritePaths={{ traefik_data_dir }}
+ProtectHome=true
+PrivateTmp=true
+PrivateDevices=true
+ProtectKernelTunables=true
+ProtectKernelModules=true
+ProtectControlGroups=true
+ProtectProc=invisible
+ProcSubset=pid
+RestrictAddressFamilies=AF_INET AF_INET6 AF_UNIX
+RestrictRealtime=true
+RestrictSUIDSGID=true
+RestrictNamespaces=true
+LockPersonality=true
+MemoryDenyWriteExecute=true
+SystemCallFilter=@system-service
+SystemCallArchitectures=native
+SystemCallErrorNumber=EPERM
+UMask=0077
+
+[Install]
+WantedBy=multi-user.target

--- a/roles/traefik/templates/traefik.yml.j2
+++ b/roles/traefik/templates/traefik.yml.j2
@@ -1,0 +1,35 @@
+{{ ansible_managed | comment }}
+# Static configuration — mirrors the previous stack-repo Traefik command flags, adapted for the
+# host binary + read-only proxy. Per-app routers, services and middlewares still come from each
+# stack's container labels (the Docker provider).
+
+entryPoints:
+  # cloudflared reaches this on loopback (https, noTLSVerify). A high non-privileged port so
+  # Traefik needs no CAP_NET_BIND_SERVICE. TLS is on at the entrypoint, so app routers need no
+  # per-router tls (matches the previous `--entrypoints.websecure.http.tls=true`).
+  websecure:
+    address: "{{ traefik_bind_address }}"
+    http:
+      tls: true
+
+providers:
+  docker:
+    # The read-only docker-socket-proxy — Traefik never touches the raw docker.sock.
+    endpoint: "tcp://{{ traefik_proxy_bind }}"
+    exposedByDefault: false
+
+# No ACME: public TLS terminates at Cloudflare, and cloudflared connects to the entrypoint with
+# noTLSVerify, so Traefik's built-in default self-signed cert is sufficient (the previous config
+# also had no certresolver). The previous `web` (:80) -> https redirect is dropped: the host is
+# tunnel-only and Cloudflare already does public HTTP->HTTPS at the edge.
+
+api:
+  dashboard: false
+
+# Access logs for 4xx/5xx only (matches the previous `--accesslog.filters.statusCodes=400-599`).
+accessLog:
+  filters:
+    statusCodes: "400-599"
+
+log:
+  level: INFO


### PR DESCRIPTION
Rework Traefik from a container in the user's stack repo to a non-root host binary (systemd, sandboxed) plus a miuops-managed read-only docker-socket-proxy.

## Why
Traefik is the most internet-exposed component (it parses internet HTTP arriving via cloudflared). As a host binary it runs as a dedicated unprivileged user with zero capabilities — its loopback entrypoint is a high port, so no `CAP_NET_BIND_SERVICE` — and it never touches the raw docker.sock: discovery goes through the read-only proxy (`POST=0`, loopback-only). A compromise yields only an unprivileged user with read-only Docker, not host root.

## What
- `roles/traefik`: the pinned Traefik binary (checksum-verified per arch), a non-root `traefik` user, a sandboxed systemd unit (`ProtectSystem=strict`, `MemoryDenyWriteExecute`, `SystemCallFilter=@system-service`, empty `CapabilityBoundingSet`, …), and a systemd-managed read-only docker-socket-proxy (image pinned by digest).
- The host process reaches each stack's containers over the per-stack bridges directly (the host is the gateway for every bridge), so the old `docker network connect` to every ingress network is gone.
- Static config mirrors the previous deployment: `websecure` entrypoint with TLS, no ACME (Cloudflare terminates public TLS), 4xx/5xx access logs.
- cloudflared targets the loopback entrypoint (`127.0.0.1:8443`).
- The docker role's API-not-on-TCP assertion is scoped to non-loopback binds, so it still rejects an exposed daemon API but tolerates the loopback-only proxy on 2375.
- ARCHITECTURE.md's network model is synced to the host-binary design.

Nothing about Traefik lives in `/opt/stacks` anymore — the stack repo holds only user workloads.

## Validation
On-host (native arm64): Traefik runs as the non-root user with 0 restarts under the full sandbox; real TLS routing returns 200 (the app needs no per-router tls — the entrypoint provides it); the proxy refuses POST; and the relaxed docker assertion allows loopback 2375 while rejecting exposed binds (validated across address forms). The internet-facing component goes from a container holding a writable docker.sock to an unprivileged host process with read-only Docker — a strictly smaller blast radius.