### PR TITLE
feat(metadata-block): block containers from the cloud metadata endpoint

### DIFF
--- a/playbook.yml
+++ b/playbook.yml
@@ -41,6 +41,8 @@
       tags: ['ssh']
     - role: docker
       tags: ['docker']
+    - role: metadata-block
+      tags: ['metadata-block']
     - role: traefik
       tags: ['traefik']
     - role: cloudflared

--- a/roles/metadata-block/README.md
+++ b/roles/metadata-block/README.md
@@ -1,0 +1,43 @@
+# Metadata-Block Role
+
+Blocks **containers** from reaching the cloud metadata endpoint (`169.254.169.254`).
+
+A compromised container that can reach the metadata service can read cloud instance metadata —
+often including **credentials** (IAM role keys, API tokens). A request-forgery (SSRF) bug in
+any web app then becomes cloud-account compromise. Blocking the endpoint at the container
+boundary removes that path regardless of the app.
+
+Some clouds (and link-local routing) already make metadata unreachable from a container, but
+that is incidental and not portable — this role makes the block **explicit and host-agnostic**.
+
+## What it does
+
+- Installs `/usr/local/sbin/miuops-metadata-block.sh`, which inserts a DROP at the top of the
+  `DOCKER-USER` chain for the link-local range `169.254.0.0/16` (which hosts every cloud
+  metadata endpoint — `169.254.169.254` IMDS, the AWS ECS task-role endpoint `169.254.170.2`,
+  …) and the AWS IPv6 endpoint `fd00:ec2::254` (best-effort). `DOCKER-USER` is the chain Docker
+  traverses **first** in `FORWARD`, so the DROP beats Docker's own ACCEPT rules. The script is
+  idempotent (`-C` before `-I`). The whole `/16` is blocked because bridge containers get
+  RFC1918 addresses and have no legitimate use for link-local.
+- Installs a oneshot systemd unit (`After=docker.service`, `PartOf=docker.service`) that runs
+  the script on boot and re-applies it if Docker restarts. The converge also asserts the rule
+  is present, so a silent failure surfaces loudly.
+
+The **host's** own access to metadata is unaffected — the rule only filters Docker `FORWARD`
+(container) traffic, not the host's `OUTPUT`.
+
+## Scope
+
+- **Host-network containers** (`network_mode: host`) are **not** covered — they share the host
+  network namespace, so their traffic never enters `FORWARD`/`DOCKER-USER`. Such containers are
+  root-equivalent anyway and are governed separately by the publish-time policy-check (which
+  forbids host networking unless a service explicitly opts in).
+- **IPv6:** the v6 block is best-effort and applies only when Docker IPv6 is enabled. Enabling
+  Docker IPv6 later means revisiting `metadata_block_ipv6`.
+- Clouds whose metadata endpoint is outside `169.254.0.0/16` (e.g. Alibaba `100.100.100.200`)
+  are not covered by default; add them to `metadata_block_ipv4` if relevant.
+
+## Requirements
+
+- Docker (the `DOCKER-USER` chain is created by the Docker daemon). The role runs after the
+  `docker` role.

--- a/roles/metadata-block/defaults/main.yml
+++ b/roles/metadata-block/defaults/main.yml
@@ -1,0 +1,10 @@
+---
+# Block containers from the link-local range that hosts every cloud metadata endpoint. A
+# compromised container could otherwise SSRF the metadata service to steal cloud credentials
+# (IAM role keys, API tokens). We block the whole 169.254.0.0/16 rather than just the well-known
+# 169.254.169.254: bridge containers get RFC1918 addresses + a default route and have NO
+# legitimate use for link-local, so this is zero-cost and also closes the AWS ECS task-role
+# credential endpoint (169.254.170.2) and any other provider service in that range.
+metadata_block_ipv4: "169.254.0.0/16"
+# AWS IPv6 metadata endpoint; blocked best-effort (skipped if IPv6 is disabled in Docker).
+metadata_block_ipv6: "fd00:ec2::254"

--- a/roles/metadata-block/handlers/main.yml
+++ b/roles/metadata-block/handlers/main.yml
@@ -1,0 +1,7 @@
+---
+- name: Reapply metadata block
+  ansible.builtin.systemd:
+    name: miuops-metadata-block.service
+    state: restarted
+    daemon_reload: true
+  become: true

--- a/roles/metadata-block/tasks/main.yml
+++ b/roles/metadata-block/tasks/main.yml
@@ -1,0 +1,40 @@
+---
+# Block containers from the cloud metadata endpoint (SSRF -> credential theft). A focused
+# DOCKER-USER DROP rule — Docker traverses DOCKER-USER first in FORWARD, so it beats Docker's
+# own ACCEPTs — applied by a oneshot unit on boot and re-applied if Docker restarts. The host
+# itself still reaches metadata (this only filters container forwarding).
+
+- name: Install the metadata-block script
+  ansible.builtin.template:
+    src: miuops-metadata-block.sh.j2
+    dest: /usr/local/sbin/miuops-metadata-block.sh
+    owner: root
+    group: root
+    mode: '0755'
+  become: true
+  notify: Reapply metadata block
+
+- name: Install the metadata-block systemd unit
+  ansible.builtin.template:
+    src: miuops-metadata-block.service.j2
+    dest: /etc/systemd/system/miuops-metadata-block.service
+    owner: root
+    group: root
+    mode: '0644'
+  become: true
+  notify: Reapply metadata block
+
+- name: Enable + start the metadata-block unit
+  ansible.builtin.systemd:
+    name: miuops-metadata-block.service
+    enabled: true
+    state: started
+    daemon_reload: true
+  become: true
+
+- name: Verify the metadata block rule is actually applied (fail loud, not silent)
+  # The unit is a oneshot; if it failed (e.g. DOCKER-USER absent), the host would silently lack
+  # the block. Assert the rule is present so a failure surfaces at converge time.
+  ansible.builtin.command: "iptables -C DOCKER-USER -d {{ metadata_block_ipv4 }} -j DROP"
+  changed_when: false
+  become: true

--- a/roles/metadata-block/templates/miuops-metadata-block.service.j2
+++ b/roles/metadata-block/templates/miuops-metadata-block.service.j2
@@ -1,0 +1,16 @@
+{{ ansible_managed | comment }}
+[Unit]
+Description=Block containers from the cloud metadata endpoint (miuops)
+# Docker creates the DOCKER-USER chain, so it must exist before the rule is inserted. PartOf so
+# the rule is re-applied if Docker is restarted (it normally survives, but this is fail-safe).
+After=docker.service
+Requires=docker.service
+PartOf=docker.service
+
+[Service]
+Type=oneshot
+RemainAfterExit=yes
+ExecStart=/usr/local/sbin/miuops-metadata-block.sh
+
+[Install]
+WantedBy=multi-user.target

--- a/roles/metadata-block/templates/miuops-metadata-block.sh.j2
+++ b/roles/metadata-block/templates/miuops-metadata-block.sh.j2
@@ -1,0 +1,19 @@
+#!/bin/sh
+{{ ansible_managed | comment }}
+# Block containers from reaching the cloud metadata endpoint (SSRF -> credential theft).
+# DOCKER-USER is the chain Docker traverses FIRST in FORWARD, so a DROP here beats Docker's own
+# ACCEPT rules. The rule is idempotent (-C before -I) and inserted at the top of DOCKER-USER.
+# This only filters Docker FORWARD traffic — the host's own access to metadata is unaffected.
+set -eu
+
+# Insert a DROP at the top of DOCKER-USER if it is not already present.
+ensure() {  # $1 = iptables binary, $2 = destination
+  "$1" -C DOCKER-USER -d "$2" -j DROP 2>/dev/null || "$1" -I DOCKER-USER 1 -d "$2" -j DROP
+}
+
+ensure iptables {{ metadata_block_ipv4 }}
+
+# IPv6 metadata: best-effort. Skip if ip6tables or its DOCKER-USER chain is absent (IPv6 off).
+if ip6tables -L DOCKER-USER -n >/dev/null 2>&1; then
+  ensure ip6tables {{ metadata_block_ipv6 }}
+fi


### PR DESCRIPTION
Block containers from reaching the cloud metadata endpoint, so a container SSRF/RCE can't steal cloud credentials.

## Why
A compromised container that reaches the metadata service (`169.254.169.254`) can read instance credentials (IAM role keys, API tokens) — any app SSRF bug then becomes cloud-account compromise. Some clouds make metadata unreachable from a container via link-local routing, but that is incidental and not portable; this makes the block explicit and host-agnostic.

## What
`roles/metadata-block`: a DROP at the top of the `DOCKER-USER` chain for the link-local range `169.254.0.0/16` (and the AWS IPv6 endpoint `fd00:ec2::254`, best-effort), applied by a oneshot systemd unit on boot and re-applied if Docker restarts. `DOCKER-USER` is the chain Docker traverses **first** in `FORWARD`, so the DROP beats Docker's own ACCEPTs.

- The whole `/16` is blocked because bridge containers have no legitimate link-local use — this also covers the AWS ECS task-role credential endpoint (`169.254.170.2`).
- The converge asserts the rule is present, so a silent failure surfaces loudly.
- The host's own access to metadata is unaffected (the rule only filters container `FORWARD`, not the host's `OUTPUT`).

Host-network containers are out of scope (they bypass `FORWARD`; governed by the publish-time policy-check).

## Validation
On-host: the rule drops a container reaching both `169.254.169.254` (IMDS) and `169.254.170.2` (ECS) — packet counters confirm; the host still reaches metadata (200); the rule survives a Docker restart; idempotent re-runs; the converge-time assertion passes.