### PR TITLE
feat(policy-check): forbid the shared default bridge (docker0) + document app-level auth

### DIFF
--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -152,6 +152,18 @@ Lateral movement blocked:
 - iptables DOCKER-USER chain: blocks all direct container access from outside
 - iptables: only loopback traffic allowed to reach Docker bridges (cloudflared → Traefik)
 
+### App-level authentication
+
+Per-stack networks isolate stacks **from each other**, but containers **within** a stack's
+network can reach each other freely (Docker's `icc: false` only governs the default bridge, not
+user-defined networks). "Same network" is therefore **not** a trust boundary.
+
+So **authenticate at the application layer**, not by network position: each service that exposes
+anything to a sibling container must verify the caller itself — a token, password, or mTLS —
+exactly as it would on the public internet. miuops hardens the host and the network edges
+(Cloudflare tunnel, loopback-only publish, per-stack isolation, the publish-time policy-check),
+but intra-stack lateral movement is the application developer's responsibility.
+
 ## Backup Design
 
 Single S3 bucket, single IAM user. Prefixes separate data by type.

--- a/tests/fixtures/stack_policy/bad-external-bridge-legacy.yml
+++ b/tests/fixtures/stack_policy/bad-external-bridge-legacy.yml
@@ -1,0 +1,9 @@
+services:
+  app:
+    image: example/app:1.0
+    cap_drop: [ALL]
+    networks: [shared]
+networks:
+  shared:
+    external:
+      name: bridge

--- a/tests/fixtures/stack_policy/bad-external-bridge.yml
+++ b/tests/fixtures/stack_policy/bad-external-bridge.yml
@@ -1,0 +1,9 @@
+services:
+  app:
+    image: example/app:1.0
+    cap_drop: [ALL]
+    networks: [shared]
+networks:
+  shared:
+    external: true
+    name: bridge

--- a/tests/fixtures/stack_policy/bad-external-default-bridge.yml
+++ b/tests/fixtures/stack_policy/bad-external-default-bridge.yml
@@ -1,0 +1,11 @@
+# The most dangerous variant: the implicit project `default` network — which every service
+# with no explicit `networks:` joins — is redefined as the external docker0 bridge, silently
+# putting the whole stack on the shared bridge.
+services:
+  app:
+    image: example/app:1.0
+    cap_drop: [ALL]
+networks:
+  default:
+    external: true
+    name: bridge

--- a/tests/fixtures/stack_policy/bad-netmode-bridge.yml
+++ b/tests/fixtures/stack_policy/bad-netmode-bridge.yml
@@ -1,0 +1,5 @@
+services:
+  app:
+    image: example/app:1.0
+    cap_drop: [ALL]
+    network_mode: bridge

--- a/tests/stack_policy_check.py
+++ b/tests/stack_policy_check.py
@@ -11,6 +11,8 @@ privilege at *publish time* (this gate), not with a runtime firewall. A compose 
   - shares a host namespace — `network_mode`/`pid`/`ipc`/`uts`/`cgroup: host`,
     `cgroupns: host`, `userns_mode: host`, or `network_mode/pid/ipc: "container:..."`
     (host networking can be opted in per service with `x-miuops-allow-host-net: true`),
+  - uses the shared default bridge (docker0) instead of a per-stack user-defined network —
+    via `network_mode: bridge` or an external network resolving to `bridge`/`docker0`,
   - is missing `cap_drop: [ALL]`, or re-adds a dangerous capability via `cap_add`
     (with or without the `CAP_` prefix),
   - weakens the sandbox via `security_opt` (unconfined / label:disable / no-new-privileges:false),
@@ -148,6 +150,9 @@ def check_file(path):
                               "(add `x-miuops-allow-host-net: true` to opt in if intentional)")
         elif network_mode.startswith("container:"):
             violations.append(f"{prefix} uses network_mode: container (joins another container's net ns)")
+        elif network_mode == "bridge":
+            violations.append(f"{prefix} uses network_mode: bridge (the shared default bridge / docker0); "
+                              "put the service on a per-stack user-defined network instead")
         for field in ("pid", "ipc", "uts", "cgroup"):
             value = str(svc.get(field, ""))
             if value == "host" or value.startswith("container:"):
@@ -184,6 +189,25 @@ def check_file(path):
                                   "(use `127.0.0.1:<host>:<container>`)")
             elif host_ip not in LOOPBACK_HOST_IPS:
                 violations.append(f"{prefix} publishes {port!r} to {host_ip} (must bind 127.0.0.1)")
+
+    # File-level: reject attaching to the shared default bridge (docker0) through an external
+    # network — the back door that evades the per-service `network_mode: bridge` check above.
+    networks = doc.get("networks")
+    if isinstance(networks, dict):
+        for net_name, net in networks.items():
+            if not isinstance(net, dict):
+                continue
+            ext = net.get("external")
+            # `external: true` (current) or `external: {name: ...}` (legacy) both mark it external.
+            # NB: a dict is NOT _is_truthy (that is a str/bool coercion), so check isinstance too.
+            if not (_is_truthy(ext) or isinstance(ext, dict)):
+                continue
+            backing = net.get("name")
+            if backing is None and isinstance(ext, dict):
+                backing = ext.get("name")  # legacy `external: {name: ...}` form
+            if str(backing if backing is not None else net_name).lower() in ("bridge", "docker0"):
+                violations.append(f"{path}: network '{net_name}' attaches to the shared default "
+                                  "bridge (docker0); use a per-stack network")
 
     return violations
 

--- a/tests/stack_policy_check_test.sh
+++ b/tests/stack_policy_check_test.sh
@@ -47,6 +47,10 @@ expect_fail bad-devices.yml
 expect_fail bad-cap-prefix.yml
 expect_fail bad-cgroup-host.yml
 expect_fail bad-netmode-container.yml
+expect_fail bad-netmode-bridge.yml
+expect_fail bad-external-bridge.yml
+expect_fail bad-external-bridge-legacy.yml
+expect_fail bad-external-default-bridge.yml
 expect_fail bad-mount-etc.yml
 expect_fail bad-security-opt-equals.yml
 expect_pass good-localtime.yml


### PR DESCRIPTION
Forbid attaching a service to the shared default bridge (docker0) at publish time, and document that app-level authentication — not network position — is the trust boundary.

## Why
Per-stack user-defined networks isolate stacks from each other. The one way a compose stack can escape that and land on the shared default bridge (docker0) — where it sits alongside every other docker0 container — is by explicitly asking for it. This closes that door at publish time. And because containers **within** a stack's network can always reach each other (Docker's `icc: false` only governs the default bridge, not user-defined networks), the docs now make explicit that "same network" is not a trust boundary.

## What
- The publish-time policy-check (`tests/stack_policy_check.py`) now rejects a service that attaches to docker0:
  - `network_mode: bridge`, and
  - an external network resolving to `bridge`/`docker0` — current (`external: true` + `name: bridge`), legacy (`external: {name: bridge}`), the bare-key form, and the implicit `default` network redefined as external bridge.
  - Compose's per-project default network (`<project>_default`) is already isolated, so a stack that simply omits `networks:` is fine — only an explicit docker0 attachment is rejected. Legitimate external user-defined (non-bridge) networks still pass.
  - Adds fixtures covering each docker0 path.
- `docs/ARCHITECTURE.md` gains an "App-level authentication" section: per-stack networks isolate stacks from each other but not containers within a stack, so apps must authenticate at the application layer (token/password/mTLS), exactly as on the public internet.

## Validation
The self-test (`tests/stack_policy_check_test.sh`) rejects every docker0 attachment path while a legitimate external non-bridge network and Compose's per-project default both still pass (no false positive).