### PR TITLE
docs: sync user docs to the ufw + host-side architecture

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 Ansible-based bootstrap for secure Docker infrastructure on bare metal servers.
 
-miuOps provisions a server with Docker, Traefik, Cloudflare Tunnel, and an iptables firewall — then gets out of the way. Day-to-day service deployment is handled by your own private GitOps stack repo via GitHub Actions.
+miuOps provisions a server with Docker, Traefik, Cloudflare Tunnel, and a ufw firewall — then gets out of the way. Day-to-day service deployment is handled by your own private GitOps stack repo via GitHub Actions.
 
 ## Architecture Overview
 
@@ -20,10 +20,10 @@ miuOps provisions a server with Docker, Traefik, Cloudflare Tunnel, and an iptab
                       |
                   cloudflared
                       |
-                   Traefik
+              Traefik (host binary)
                       |
    +-------------------------------------+
-   |  DOCKER-USER iptables chain         |
+   |  Per-stack bridge networks          |
    +-------------------------------------+
                       |
                 Docker Services
@@ -32,7 +32,7 @@ miuOps provisions a server with Docker, Traefik, Cloudflare Tunnel, and an iptab
 - Traffic flows through Cloudflare's network for DDoS protection and WAF
 - No ports are exposed to the internet (all ingress via Cloudflare Tunnel)
 - Traefik reverse proxy handles TLS termination and service routing
-- System and Docker networking are secured with iptables rules
+- The host firewall (ufw) denies all inbound except rate-limited SSH; containers run on isolated per-stack networks
 
 ## Quick Start
 
@@ -101,14 +101,19 @@ management-CIDR SSH allowlist).
 
 | Component | Role | Purpose |
 |---|---|---|
-| iptables firewall | `firewall` | INPUT + DOCKER-USER chains, rate-limited SSH, zero public container exposure |
-| Docker engine | `docker` | Docker CE + Compose plugin, hardened daemon config |
-| Traefik | `traefik` | Reverse proxy directories + Docker network (compose deployed via stack repo) |
-| Cloudflare Tunnel | `cloudflared` | Secure ingress, wildcard DNS records, systemd service |
+| ufw firewall | `firewall` | Default-deny inbound; only rate-limited SSH is open. No public container exposure. |
+| Docker engine | `docker` | Docker CE + Compose plugin; hardened daemon (loopback-published ports, `userns-remap`, ICC off, API never on TCP). |
+| Traefik | `traefik` | Non-root host binary; discovers services through a read-only docker-socket-proxy and routes to per-stack networks. |
+| Cloudflare Tunnel | `cloudflared` | Zero exposed ports; wildcard + root DNS records; systemd service. |
+| SSH hardening | `ssh` | Key-only login (`PasswordAuthentication no`). |
+| Metadata block | `metadata-block` | Blocks containers from reaching the cloud metadata endpoint (`169.254.0.0/16`). |
+| Observability | `observability` | Grafana Alloy host binary shipping metrics + logs to Grafana Cloud (opt-in, off by default). |
+| Volume backup | `backup` | Host `systemd` timer that tars Docker volumes to S3 — no container, no `docker.sock`. |
+| Security upgrades | `unattended-upgrades` | Automatic unattended security patches, no auto-reboot. |
 
 ## Deploy Services
 
-After bootstrap, create your private stack repo from the **[miuops-stack-template](https://github.com/tianshanghong/miuops-stack-template)** — it includes Traefik, S3 backups, and a GitHub Actions pipeline that deploys on push to `main`.
+After bootstrap, create your private stack repo from the **[miuops-stack-template](https://github.com/tianshanghong/miuops-stack-template)** — it includes example stacks and a GitHub Actions pipeline that deploys your services on push to `main`.
 
 ## Infrastructure Upgrades
 
@@ -149,9 +154,11 @@ The setup script creates a single `{project}-backup` bucket used by both the hos
 ## Security
 
 - Zero exposed ports — all traffic flows through Cloudflare Tunnel
-- iptables firewall with default-DROP on INPUT and DOCKER-USER chains
-- Rate-limited SSH by default (6 attempts / 60s, configurable); optional management-CIDR allowlist
-- Docker daemon hardened (ICC disabled, userland proxy disabled)
+- ufw firewall: default-deny inbound, only rate-limited SSH open (`ufw limit`); optional management-CIDR allowlist
+- **SSH is key-only** (`PasswordAuthentication no`) — make sure your public key is in the server's `~/.ssh/authorized_keys` before converging, or you will be locked out
+- Docker daemon hardened — ports publish to loopback by default, the API is never exposed over TCP, ICC and the userland proxy are disabled, and `userns-remap` maps container root to an unprivileged host UID
+- Containers are blocked from the cloud metadata endpoint (`169.254.0.0/16`)
+- Automatic unattended security upgrades (no auto-reboot)
 - Sensitive files excluded from version control (`.gitignore`)
 
 ## Documentation

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -32,11 +32,15 @@ The tool. Users clone this to bootstrap their server.
 miuOps/
 ├── miuops                    # CLI entrypoint (./miuops up)
 ├── roles/                    # Ansible roles for bootstrap + upgrades
-│   ├── docker/               #   Docker engine
-│   ├── firewall/             #   iptables (IPv4 + IPv6)
+│   ├── docker/               #   Docker engine + hardened daemon
+│   ├── firewall/             #   ufw host firewall (IPv4 + IPv6)
+│   ├── ssh/                  #   Key-only SSH
 │   ├── cloudflared/          #   Cloudflare Tunnel + systemd + DNS
-│   ├── traefik/              #   Bootstrap (dirs, network) + upgrades
-│   └── backup/               #   Host-side Docker volume backup (systemd timer)
+│   ├── traefik/              #   Non-root host binary + read-only socket-proxy
+│   ├── metadata-block/       #   Block container → cloud metadata endpoint
+│   ├── observability/        #   Grafana Alloy host binary (opt-in)
+│   ├── backup/               #   Host-side Docker volume backup (systemd timer)
+│   └── unattended-upgrades/  #   Automatic security upgrades
 ├── playbook.yml
 ├── scripts/
 │   └── setup-s3-backup.sh
@@ -77,14 +81,14 @@ my-infra/
 │  GITHUB            │  │  SERVER (runtime)                  │
 │                    │  │                                    │
 │  miuOps (public)   │  │  [infra — Ansible-owned]           │
-│  - Ansible roles   │  │  ├─ iptables firewall              │
+│  - Ansible roles   │  │  ├─ ufw firewall                   │
 │  - scripts         │  │  ├─ Docker engine                  │
 │                    │  │  ├─ cloudflared (systemd)          │
-│                    │  │  ├─ /opt/traefik (dirs, acme.json) │
-│  my-infra (private)│  │                                    │
+│                    │  │  ├─ Traefik (host binary)          │
+│  my-infra (private)│  │  └─ docker-socket-proxy (RO)       │
 │  - compose files   │  │  [apps — GitOps-owned]             │
-│  - GH Actions  ───────▶  ├─ Traefik (compose)              │
-│  - .env (secrets)  │SSH│  ├─ App containers                 │
+│  - GH Actions  ───────▶  ├─ App containers                 │
+│  - .env (secrets)  │SSH│  │   (per-stack networks)         │
 │                    │  │  ├─ PG + WAL-G ──────┐              │
 │                    │  │  ├─ volume backup ───┤  (systemd    │
 │                    │  │  │                   │   timer,     │

--- a/docs/DAILY_OPS.md
+++ b/docs/DAILY_OPS.md
@@ -39,8 +39,8 @@ docker compose logs -f SERVICE_NAME
 # cloudflared tunnel
 sudo journalctl -u cloudflared -f
 
-# Firewall (iptables)
-sudo journalctl -k | grep iptables
+# Firewall (ufw)
+sudo ufw status verbose
 ```
 
 ## Checking status

--- a/docs/INSTALLATION.md
+++ b/docs/INSTALLATION.md
@@ -68,10 +68,13 @@ The CLI handles everything:
 7. Runs the playbook
 
 The playbook provisions the server with:
-- **iptables firewall** — default-DROP on INPUT and DOCKER-USER chains, rate-limited SSH
-- **Docker CE + Compose** — hardened daemon (ICC disabled, userland proxy disabled)
-- **Traefik directories + Docker network** — ready for compose deployment
+- **ufw firewall** — default-deny inbound, only rate-limited SSH open
+- **Docker CE + Compose** — hardened daemon (loopback-published ports, `userns-remap`, ICC off, API never on TCP)
+- **Traefik** — non-root host binary reading Docker via a read-only socket-proxy
 - **cloudflared** — systemd service with tunnel config for all domains
+- **SSH hardening** — key-only login (`PasswordAuthentication no`)
+- **Metadata block** — containers blocked from the cloud metadata endpoint
+- **Unattended security upgrades** — automatic, no auto-reboot
 
 ### Dry run
 

--- a/docs/SCALING.md
+++ b/docs/SCALING.md
@@ -22,7 +22,7 @@ each server's `files/<tunnel_id>.json`, then retire the old clones.
 ## Per-server firewall posture
 
 Each server's exposure is data in its `host_vars`. Defaults are generic-safe (SSH
-rate-limited, 10 attempts / 60s). To harden a specific server:
+rate-limited via `ufw limit`). To harden a specific server:
 
 ```yaml
 # host_vars/prod-a.yml

--- a/docs/STRUCTURE.md
+++ b/docs/STRUCTURE.md
@@ -9,10 +9,15 @@
 ├── host_vars/
 │   └── server1.yml.example    # Per-server config example (domains + tunnel_id)
 ├── roles/
-│   ├── firewall/              # iptables firewall (INPUT + DOCKER-USER)
-│   ├── docker/                # Docker engine installation
-│   ├── traefik/               # Traefik reverse proxy setup
-│   └── cloudflared/           # Cloudflare Tunnel + DNS records
+│   ├── firewall/              # ufw host firewall (default-deny inbound)
+│   ├── docker/                # Docker engine + hardened daemon
+│   ├── ssh/                   # Key-only SSH
+│   ├── traefik/               # Non-root host binary + read-only socket-proxy
+│   ├── cloudflared/           # Cloudflare Tunnel + DNS records
+│   ├── metadata-block/        # Block containers from the cloud metadata endpoint
+│   ├── observability/         # Grafana Alloy host binary (opt-in)
+│   ├── backup/                # Host-side Docker volume backup (systemd timer)
+│   └── unattended-upgrades/   # Automatic security upgrades
 ├── files/                     # Tunnel credentials (gitignored)
 ├── images/
 │   └── postgres-walg/         # PostgreSQL 17 + WAL-G Docker image
@@ -24,11 +29,15 @@
 
 ## Roles
 
-- **firewall** — Configures iptables with nft backend. INPUT chain (rate-limited SSH, management networks, whitelisted ports) and DOCKER-USER chain (blocks all direct container access, allows only loopback for cloudflared).
-- **docker** — Installs Docker CE + Compose plugin via signed apt repo. Hardens daemon (ICC disabled, userland proxy disabled).
-- **traefik** — Bootstraps Traefik directories and Docker network. Pulls latest image when stack is deployed.
+- **firewall** — Configures ufw as the host inbound firewall: default-deny incoming, allow outgoing, only rate-limited SSH (`ufw limit`) open. Optional management-network CIDRs and whitelisted ports. IPv4 + IPv6.
+- **docker** — Installs Docker CE + Compose plugin via signed apt repo. Hardens the daemon: ports publish to loopback, the API is never on TCP, ICC and the userland proxy are disabled, and `userns-remap` maps container root to an unprivileged host UID.
+- **ssh** — Enforces key-only login (`PasswordAuthentication no`, `PermitRootLogin prohibit-password`), with a guard that refuses to converge if no authorized key is present (avoids lockout).
+- **traefik** — Installs Traefik as a non-root host binary (systemd). It reads Docker only through a read-only docker-socket-proxy on loopback and routes to each stack's bridge network; cloudflared connects to it on loopback.
 - **cloudflared** — Installs cloudflared via apt repo, deploys tunnel credentials and config, creates wildcard + root CNAME DNS records, runs as systemd service.
+- **metadata-block** — Blocks containers from reaching the cloud metadata endpoint (`169.254.0.0/16`) via a `DOCKER-USER` egress rule, re-applied on Docker restart.
 - **observability** *(opt-in, off by default)* — Runs Grafana Alloy as a host systemd service that ships host + container + cloudflared metrics and Docker container logs to Grafana Cloud. Enabled per host via `observability_enabled`; egress-only (no inbound port). See [OBSERVABILITY.md](OBSERVABILITY.md).
+- **backup** — A host `systemd` timer that stops a volume's writers, tars the volume, optionally encrypts, and streams it to S3 — no container, no `docker.sock`. See [DISASTER_RECOVERY.md](DISASTER_RECOVERY.md).
+- **unattended-upgrades** — Installs and enables automatic unattended security upgrades with no automatic reboot.
 
 ## Images
 


### PR DESCRIPTION
Reconcile the user-facing docs with the shipped architecture: the host firewall is **ufw** (default-deny inbound), not iptables/DOCKER-USER; Traefik is a non-root host binary; and the playbook deploys several roles the docs never mentioned.

## Changes
- **README / STRUCTURE / INSTALLATION / ARCHITECTURE / DAILY_OPS** — the firewall is ufw (default-deny inbound, SSH rate-limited via `ufw limit`), not iptables/DOCKER-USER. Fixes a self-contradiction inside ARCHITECTURE.md.
- **"What Gets Deployed" + the roles list now cover all nine roles**: firewall, docker, ssh, traefik, cloudflared, metadata-block, observability, backup, unattended-upgrades.
- **SSH key-only** is now documented prominently, with a lockout warning (ensure your public key is in `~/.ssh/authorized_keys` before converging).
- Docker daemon hardening (loopback-published ports, `userns-remap`, API never on TCP), the cloud-metadata block, and unattended security upgrades are now described.
- **ARCHITECTURE.md system diagram** — Traefik is drawn in the infra section as a host binary (plus the read-only docker-socket-proxy); it is not a compose app.
- Drop a stale SSH rate-limit figure in SCALING.md.

The one remaining `DOCKER-USER` mention is the metadata-block egress rule, which legitimately uses that chain.

Docs-only; no behavior change.