### PR TITLE
feat(policy-check): warn on un-pinned (non-digest) stack images

### DIFF
--- a/tests/fixtures/stack_policy/good-pinned-image.yml
+++ b/tests/fixtures/stack_policy/good-pinned-image.yml
@@ -1,0 +1,7 @@
+# Digest-pinned image → clean AND no advisory warning.
+services:
+  web:
+    image: nginx@sha256:1234567890abcdef1234567890abcdef1234567890abcdef1234567890abcdef
+    cap_drop: [ALL]
+    ports:
+      - "127.0.0.1:8080:80"

--- a/tests/fixtures/stack_policy/warn-unpinned-image.yml
+++ b/tests/fixtures/stack_policy/warn-unpinned-image.yml
@@ -1,0 +1,7 @@
+# Clean (no violations) but the image is not digest-pinned → advisory warning, still exit 0.
+services:
+  web:
+    image: nginx:latest
+    cap_drop: [ALL]
+    ports:
+      - "127.0.0.1:8080:80"

--- a/tests/stack_policy_check.py
+++ b/tests/stack_policy_check.py
@@ -20,6 +20,10 @@ privilege at *publish time* (this gate), not with a runtime firewall. A compose 
     sensitive host path (/proc, /sys, /dev, /var/run, ...),
   - passes through host `devices:`.
 
+It also prints a non-fatal WARNING (still exit 0) for any service whose `image:` is not
+digest-pinned — `:latest`, no tag, or a tag without an `@sha256:` digest. Pin a digest for
+reproducible, immutable deploys.
+
 Usage: stack_policy_check.py <compose.yml> [more.yml ...]
 Requires PyYAML (`pip install pyyaml`).
 """
@@ -118,28 +122,56 @@ def _published_host_ip(port):
     return None  # "host:container" or "container" — no explicit host IP
 
 
+def _image_pin_warning(image):
+    """Return an advisory string if an image reference is not digest-pinned, else None.
+
+    A digest-pinned image (`name@sha256:...`) is immutable and reproducible. A bare
+    `:latest`, no tag, or a mutable version tag can change between deploys.
+    """
+    ref = str(image).strip()
+    if "@sha256:" in ref:
+        return None  # digest-pinned — immutable
+    _repo, sep, tag = ref.rpartition(":")
+    has_tag = bool(sep) and "/" not in tag  # a trailing `:port/path` is a registry port, not a tag
+    if not has_tag:
+        return f"image '{ref}' is untagged — pin a digest (image@sha256:...) for an immutable deploy"
+    if tag == "latest":
+        return f"image '{ref}' uses the mutable ':latest' tag — pin a digest (image@sha256:...)"
+    return f"image '{ref}' is not digest-pinned — consider a digest (image@sha256:...) for immutability"
+
+
 def check_file(path):
-    """Return a list of policy-violation strings for one compose file (empty = clean)."""
+    """Return (violations, warnings) for one compose file — both lists of strings.
+
+    Violations cause a non-zero exit; warnings are advisory (e.g. an un-pinned image).
+    """
     try:
         with open(path) as handle:
             doc = yaml.safe_load(handle)
     except (OSError, yaml.YAMLError) as exc:
-        return [f"{path}: cannot read/parse compose file: {exc}"]
+        return [f"{path}: cannot read/parse compose file: {exc}"], []
     if not isinstance(doc, dict):
-        return [f"{path}: not a valid compose mapping"]
+        return [f"{path}: not a valid compose mapping"], []
 
     services = doc.get("services")
     if services is None:
-        return []  # no services → nothing to publish or privilege
+        return [], []  # no services → nothing to publish or privilege
     if not isinstance(services, dict):
-        return [f"{path}: `services` is not a mapping"]
+        return [f"{path}: `services` is not a mapping"], []
 
     violations = []
+    warnings = []
     for name, svc in services.items():
         prefix = f"{path}: service '{name}'"
         if not isinstance(svc, dict):
             violations.append(f"{prefix} is not a mapping")
             continue
+
+        image = svc.get("image")
+        if image is not None:
+            warn = _image_pin_warning(image)
+            if warn:
+                warnings.append(f"{prefix} {warn}")
 
         if _is_truthy(svc.get("privileged")):
             violations.append(f"{prefix} sets privileged")
@@ -209,7 +241,7 @@ def check_file(path):
                 violations.append(f"{path}: network '{net_name}' attaches to the shared default "
                                   "bridge (docker0); use a per-stack network")
 
-    return violations
+    return violations, warnings
 
 
 def main(argv):
@@ -217,8 +249,15 @@ def main(argv):
         sys.stderr.write(__doc__)
         return 2
     all_violations = []
+    all_warnings = []
     for path in argv:
-        all_violations.extend(check_file(path))
+        violations, warnings = check_file(path)
+        all_violations.extend(violations)
+        all_warnings.extend(warnings)
+    if all_warnings:
+        sys.stderr.write("Stack policy-check warnings (advisory, non-blocking):\n")
+        for item in all_warnings:
+            sys.stderr.write(f"  ! {item}\n")
     if all_violations:
         sys.stderr.write("Stack policy-check FAILED:\n")
         for item in all_violations:

--- a/tests/stack_policy_check_test.sh
+++ b/tests/stack_policy_check_test.sh
@@ -27,6 +27,24 @@ expect_fail() {
     echo "ok   (reject): $1"
   fi
 }
+# Passes (exit 0) AND prints an advisory warning whose text matches $2.
+expect_warn() {
+  out="$("$PY" "$CHECK" "$FIX/$1" 2>&1)"; rc=$?
+  if [ "$rc" -eq 0 ] && printf '%s' "$out" | grep -q "$2"; then
+    echo "ok   (warn):   $1"
+  else
+    echo "FAIL (warn):   expected $1 to pass(0) with warning matching '$2' (rc=$rc)"; fail=1
+  fi
+}
+# Passes (exit 0) AND prints NO image warning.
+expect_nowarn() {
+  out="$("$PY" "$CHECK" "$FIX/$1" 2>&1)"; rc=$?
+  if [ "$rc" -eq 0 ] && ! printf '%s' "$out" | grep -qiE "digest|:latest|untagged"; then
+    echo "ok   (nowarn): $1"
+  else
+    echo "FAIL (nowarn): expected $1 to pass(0) with no image warning (rc=$rc)"; fail=1
+  fi
+}
 
 expect_pass good.yml
 expect_pass good-loopback-longform.yml
@@ -58,6 +76,10 @@ expect_pass good-localtime.yml
 
 expect_fail bad-mount-dotdot.yml
 expect_fail bad-mount-dotslash.yml
+
+# Image pin: an un-pinned image warns (but still passes); a digest-pinned image is silent.
+expect_warn warn-unpinned-image.yml "digest"
+expect_nowarn good-pinned-image.yml
 
 # A batch containing any violating file must fail as a whole.
 if "$PY" "$CHECK" "$FIX/good.yml" "$FIX/bad-privileged.yml" >/dev/null 2>&1; then


### PR DESCRIPTION
The stack policy-check now emits a **non-fatal warning** for any service whose `image:` is not digest-pinned — it uses `:latest`, no tag, or a tag without an `@sha256:` digest. Digest-pinning keeps deploys immutable and reproducible.

## Behavior
- **Advisory only** — an un-pinned image prints a warning but does NOT fail the check (exit stays 0). Only real security violations fail (exit 1). The two coexist: a file with both an un-pinned image and a violation still fails.
- `nginx@sha256:...` → silent; `nginx:latest` / `nginx:1.27` / `nginx` (untagged) → warning.
- Registry ports are handled correctly (`localhost:5000/app` is untagged, not tag `5000/app`).

## Tests
- New `expect_warn` / `expect_nowarn` helpers + fixtures (`warn-unpinned-image.yml`, `good-pinned-image.yml`).
- Full self-test passes; `shellcheck -S error` clean; `py_compile` OK.