### PR TITLE
feat(ci): reusable deploy workflow for per-server fleet stacks

### DIFF
--- a/.github/scripts/deploy-server.sh
+++ b/.github/scripts/deploy-server.sh
@@ -1,0 +1,158 @@
+#!/usr/bin/env bash
+# Deploy ONE fleet server's stacks over SSH. Invoked by the reusable deploy
+# workflow's matrix job, which binds `environment: <server>` so the SSH secrets
+# below belong to exactly this one server (no other server's key is in scope).
+#
+# Inputs (environment):
+#   SERVER             server name = the fleet/stacks/<server> directory name.
+#   SSH_HOST           target host (required).
+#   SSH_USER           SSH user (required).
+#   SSH_PRIVATE_KEY    deploy private key, PEM (required).
+#   SSH_PORT           SSH port (default 22).
+#   SSH_KNOWN_HOSTS    pinned known_hosts (optional; when set, host-key checking
+#                      is strict — no MITM window. When absent: accept-new TOFU).
+#   STACKS_DIR         repo path prefix for stacks (default fleet/stacks).
+#   REMOTE_STACKS_DIR  destination on the server (default /opt/stacks).
+#
+# By design the rsync excludes .env and any *.env: every *.env is treated as a
+# host-provisioned secret (the shared app env is decrypted + placed at setup,
+# never shipped by deploy), so a repo-managed *.env is never transferred and an
+# on-host *.env is never deleted by --delete.
+#
+# Security: SERVER comes from an operator-controlled directory name, so it is
+# re-validated here (second gate after discover) and only ever used as a path
+# segment / argument, never concatenated into a shell command. The private key
+# is written to a private temp dir and removed on exit. Secrets are read from
+# the environment, never interpolated into a logged command; no ssh/rsync
+# verbosity, no `set -x`.
+
+export LC_ALL=C
+set -euo pipefail
+
+err()  { printf '::error::%s\n' "$*" >&2; exit 1; }
+note() { printf '::notice::%s\n'  "$*"; }
+
+NAME_RE='^[A-Za-z0-9][A-Za-z0-9._-]*$'
+SERVER="${SERVER:?SERVER is required}"
+[[ "$SERVER" =~ $NAME_RE ]] || err "Refusing to deploy: invalid server name '${SERVER}'"
+
+# Fail fast on missing secrets BEFORE any network action, naming the server. A
+# typo'd Environment resolves to empty secrets (no cross-server fallback exists),
+# so this fails CLOSED — it can never reuse another server's key.
+[ -n "${SSH_HOST:-}" ]        || err "No SSH_HOST for environment '${SERVER}'. Set it in that GitHub Environment and use 'secrets: inherit' in the caller."
+[ -n "${SSH_USER:-}" ]        || err "No SSH_USER for environment '${SERVER}'."
+[ -n "${SSH_PRIVATE_KEY:-}" ] || err "No SSH_PRIVATE_KEY for environment '${SERVER}'."
+SSH_PORT="${SSH_PORT:-22}"
+[[ "$SSH_PORT" =~ ^[0-9]+$ ]] || err "Invalid SSH_PORT '${SSH_PORT}' for '${SERVER}' (must be numeric)."
+STACKS_DIR="${STACKS_DIR:-fleet/stacks}"; STACKS_DIR="${STACKS_DIR%/}"
+REMOTE_STACKS_DIR="${REMOTE_STACKS_DIR:-/opt/stacks}"; REMOTE_STACKS_DIR="${REMOTE_STACKS_DIR%/}"
+
+src="${GITHUB_WORKSPACE:-.}/${STACKS_DIR}/${SERVER}"
+# A server with no stack directory (e.g. just removed from the fleet) is a clean
+# skip, never a blind rsync of a nonexistent source.
+[ -d "$src" ] || { note "No stacks for '${SERVER}' (${STACKS_DIR}/${SERVER} absent) — nothing to deploy."; exit 0; }
+
+# Per-run private key + known_hosts in a 0700 temp dir; gone on exit.
+sshdir="$(mktemp -d)"; chmod 700 "$sshdir"
+trap 'rm -rf "$sshdir"' EXIT
+key="${sshdir}/id"; printf '%s\n' "$SSH_PRIVATE_KEY" > "$key"; chmod 600 "$key"
+kh="${sshdir}/known_hosts"
+
+# Host-key policy: pin when SSH_KNOWN_HOSTS is provided (no MITM window), else
+# accept-new -- trusts the key seen on the first connect of THIS run and rejects
+# a key that changes mid-run, but does NOT protect a first-ever connect against a
+# MITM. Set the per-server SSH_KNOWN_HOSTS Environment secret to pin (recommended
+# for production). Never =no.
+ssh_opts=(-i "$key" -p "$SSH_PORT" -o IdentitiesOnly=yes -o BatchMode=yes -o UserKnownHostsFile="$kh")
+if [ -n "${SSH_KNOWN_HOSTS:-}" ]; then
+  printf '%s\n' "$SSH_KNOWN_HOSTS" > "$kh"
+  ssh_opts+=(-o StrictHostKeyChecking=yes)
+else
+  : > "$kh"
+  ssh_opts+=(-o StrictHostKeyChecking=accept-new)
+fi
+
+dest="${SSH_USER}@${SSH_HOST}"
+note "Deploying '${SERVER}' -> ${dest}:${REMOTE_STACKS_DIR}"
+
+# Sync this server's stacks to /opt/stacks. --delete prunes removed stacks; the
+# shared, host-provisioned app env (.env or any *.env) is excluded so it is
+# neither shipped from the repo nor deleted on the host (the exclude is
+# unanchored, so it protects matching files at every depth).
+rsync -rlptz --delete --exclude='.env' --exclude='*.env' \
+  -e "ssh ${ssh_opts[*]}" \
+  "${src}/" "${dest}:${REMOTE_STACKS_DIR}/"
+
+# Bring up each stack on the host using the shared host-provisioned .env, then
+# tear down stacks whose directory was removed. REMOTE_STACKS_DIR is an
+# operator-trusted input; it is passed as a positional arg to the remote shell.
+ssh "${ssh_opts[@]}" "$dest" bash -s -- "$REMOTE_STACKS_DIR" <<'REMOTE'
+set -euo pipefail
+REMOTE_DIR="${1:?remote stacks dir}"
+cd "$REMOTE_DIR"
+
+# --env-file only if a shared .env exists (provisioned at setup, not by deploy).
+# Absolute path: the up-loop runs from inside each stack dir, so a relative
+# ".env" would resolve to the wrong place.
+compose_env=()
+[ -f .env ] && compose_env=(--env-file "$REMOTE_DIR/.env")
+
+# Optional registry auth: auto-discover DOCKER_REGISTRY_<NAME>_{URL,USER,PASSWORD}
+# from the shared .env and log in before pulling private images.
+if [ -f .env ]; then
+  get_env() { sed -n "s/^${1}=//p" .env; }
+  while IFS= read -r name; do
+    [ -n "$name" ] || continue
+    url="$(get_env "DOCKER_REGISTRY_${name}_URL")"
+    pass="$(get_env "DOCKER_REGISTRY_${name}_PASSWORD")"
+    if [ -n "$url" ] && [ -n "$pass" ]; then
+      echo "==> docker login ${url}"
+      printf '%s' "$pass" | docker login "$url" -u "$(get_env "DOCKER_REGISTRY_${name}_USER")" --password-stdin
+    fi
+  done < <(grep '^DOCKER_REGISTRY_.*_PASSWORD=' .env 2>/dev/null | sed 's/^DOCKER_REGISTRY_//; s/_PASSWORD=.*//')
+fi
+
+# Deploy each stack directory that is a valid compose project. Running from
+# inside the dir lets Compose auto-discover any canonical filename
+# (compose.yaml / compose.yml / docker-compose.yaml / docker-compose.yml), and
+# the project name defaults to the (normalized) directory basename -- the same
+# name the teardown below compares against.
+for stack in */; do
+  stack="${stack%/}"
+  ( cd "$stack" && docker compose "${compose_env[@]}" config -q ) 2>/dev/null || continue
+  echo "==> up ${stack}"
+  ( cd "$stack" && docker compose "${compose_env[@]}" up -d --pull always --remove-orphans )
+done
+
+# Tear down stacks whose directory was removed: compare running compose projects
+# (rooted under this dir) against the present directories, normalizing each dir
+# name the way Compose derives a project name (lowercase; drop chars outside
+# [a-z0-9_-]; trim leading separators) so a still-present stack is never flagged.
+# Enumeration is best-effort: a missing python3 (or any error) skips pruning --
+# the deploy already applied -- rather than failing it.
+teardown_rc=0
+if removed="$(docker compose ls --format json 2>/dev/null | python3 -c '
+import json, os, re, sys
+root = os.getcwd()
+def norm(n):
+    n = n.lower()
+    n = re.sub(r"[^a-z0-9_-]", "", n)
+    return re.sub(r"^[_-]+", "", n)
+present = {norm(d) for d in os.listdir(root) if os.path.isdir(os.path.join(root, d))}
+for p in json.load(sys.stdin):
+    cfg = p.get("ConfigFiles", "") or ""
+    if cfg.startswith(root + "/") and p["Name"] not in present:
+        print(p["Name"])
+' 2>/dev/null)"; then
+  while IFS= read -r name; do
+    [ -n "$name" ] || continue
+    echo "==> down (removed) ${name}"
+    docker compose -p "$name" down --remove-orphans || { echo "::warning::failed to tear down ${name}"; teardown_rc=1; }
+  done <<EOF
+$removed
+EOF
+else
+  echo "::warning::Skipped teardown of removed stacks (could not enumerate running projects; is python3 present?)"
+fi
+[ "$teardown_rc" -eq 0 ] || { echo "::error::one or more removed stacks failed to tear down"; exit 1; }
+REMOTE

--- a/.github/scripts/discover-changed-servers.sh
+++ b/.github/scripts/discover-changed-servers.sh
@@ -1,0 +1,138 @@
+#!/usr/bin/env bash
+# Determine which fleet servers changed in a push and emit them as a compact
+# JSON array on stdout (for a GitHub Actions dynamic matrix). Outputs "[]" when
+# nothing under a server stack directory changed.
+#
+# Two independent layers, both unit-testable offline:
+#   1. Git range resolution: turn (BEFORE, AFTER) into a list of changed paths,
+#      handling first push, unknown/rewritten base, and unrelated history safely.
+#   2. Path -> server-name mapping: keep only paths under STACKS_DIR/<server>/...,
+#      take <server>, validate it against a strict allowlist, dedupe, sort.
+#
+# Inputs (environment):
+#   BEFORE      git SHA before the push (github.event.before); may be the
+#               all-zero SHA on a first push / new branch, or a SHA that no
+#               longer exists after a force-push.
+#   AFTER       git SHA after the push (github.sha). Required.
+#   STACKS_DIR  path prefix that holds per-server stacks. Default: fleet/stacks
+#
+# Testability: when MIUOPS_CHANGED_PATHS_FILE is set, the changed-path list is
+# read from that file (one path per line) instead of being computed from git.
+# This lets the path -> server mapping be exercised with fixtures and no git.
+#
+# Security: a server name comes from an operator-controlled directory name and
+# later flows into ssh/rsync arguments and a remote path, so it is validated
+# against a strict allowlist here (first gate) and re-validated in the deploy
+# job (second gate). The JSON array is built with jq so a crafted name can only
+# ever be an inert, escaped JSON string -- never a shell token.
+
+# LC_ALL=C makes the validation globs/regex byte-wise. Under a UTF-8 locale a
+# range like [A-Za-z] is collation-ordered and can admit unexpected characters,
+# which would weaken the allowlist; force C so the allowlist means exactly what
+# it says.
+export LC_ALL=C
+set -euo pipefail
+
+STACKS_DIR="${STACKS_DIR:-fleet/stacks}"
+# Normalize to exactly one trailing slash so prefix matching is unambiguous.
+STACKS_DIR="${STACKS_DIR%/}/"
+
+ZERO_SHA="0000000000000000000000000000000000000000"
+
+# A server directory name must start with an alphanumeric and otherwise contain
+# only [A-Za-z0-9._-]. Starting with an alphanumeric blocks a leading-dash name
+# (which could be read as an ssh/rsync option) and a dotfile/"." / ".." name
+# (path traversal). This mirrors the CLI's valid_host_alias allowlist.
+NAME_RE='^[A-Za-z0-9][A-Za-z0-9._-]*$'
+
+# --- Layer 1: resolve the list of changed paths for this push --------------
+changed_paths() {
+  if [ -n "${MIUOPS_CHANGED_PATHS_FILE:-}" ]; then
+    # Fixtures are newline-delimited; emit NUL-delimited to match the consumer.
+    tr '\n' '\0' < "$MIUOPS_CHANGED_PATHS_FILE"
+    return
+  fi
+
+  local before="${BEFORE:-}"
+  local after="${AFTER:?AFTER (github.sha) is required}"
+
+  # First push / new branch (zero SHA), or a base that is not in the object
+  # store (force-push, rebase, shallow clone, garbage value): we cannot trust a
+  # range, so treat the whole tree as changed -> deploy all present stacks.
+  # This fails safe toward "deploy everything", never silently "deploy nothing".
+  if [ -z "$before" ] || [ "$before" = "$ZERO_SHA" ] \
+     || ! git rev-parse -q --verify "${before}^{commit}" >/dev/null 2>&1; then
+    git ls-tree -r -z --name-only "$after"
+    return
+  fi
+
+  # Base exists but is not an ancestor of AFTER (history was rewritten): diff
+  # against the merge-base if one exists; otherwise (unrelated/orphan history)
+  # fall back to the whole tree.
+  if ! git merge-base --is-ancestor "$before" "$after" >/dev/null 2>&1; then
+    local mb
+    if mb="$(git merge-base "$before" "$after" 2>/dev/null)" && [ -n "$mb" ]; then
+      git diff -z --name-only "$mb" "$after"
+    else
+      git ls-tree -r -z --name-only "$after"
+    fi
+    return
+  fi
+
+  # Normal fast-forward push.
+  git diff -z --name-only "$before" "$after"
+}
+
+# --- Layer 2: map changed paths to validated, unique server names ----------
+# Read NUL-delimited paths so a path containing spaces or newlines cannot split
+# a record. Accumulate unique names without bash-4 associative arrays so the
+# script also runs on the macOS system bash (3.2).
+servers=""
+contains() {
+  # contains <needle> -- true if "$needle" is already in the newline list $servers
+  case "
+${servers}
+" in
+    *"
+$1
+"*) return 0 ;;
+    *) return 1 ;;
+  esac
+}
+
+while IFS= read -r -d '' path; do
+  [ -n "$path" ] || continue
+  case "$path" in
+    "$STACKS_DIR"*) : ;;          # under the stacks prefix
+    *) continue ;;
+  esac
+  rest="${path#"$STACKS_DIR"}"    # e.g. "alpha/docker-compose.yml"
+  seg="${rest%%/*}"               # first segment -> candidate server name
+  # Require something beneath the server directory: a bare "fleet/stacks/alpha"
+  # (no file under it) or the prefix itself yields no server.
+  [ "$seg" != "$rest" ] || continue
+  [ -n "$seg" ] || continue
+  case "$seg" in
+    .|..) continue ;;             # explicit traversal guard
+  esac
+  [[ "$seg" =~ $NAME_RE ]] || continue
+  contains "$seg" && continue
+  servers="${servers:+$servers
+}$seg"
+done < <(changed_paths)
+
+if [ -z "$servers" ]; then
+  printf '[]\n'
+  exit 0
+fi
+
+# Sort for stable, deduplicated output, then emit as a JSON array. jq --args
+# turns each name into an escaped JSON string, so a name with shell
+# metacharacters is inert in the output. A portable read loop (not mapfile,
+# which needs bash 4) builds the argument list so this also runs on bash 3.2.
+sorted=()
+while IFS= read -r s; do
+  [ -n "$s" ] || continue
+  sorted+=("$s")
+done < <(printf '%s\n' "$servers" | LC_ALL=C sort -u)
+jq -cn '$ARGS.positional' --args "${sorted[@]}"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -23,8 +23,11 @@ jobs:
       - name: Lint + CLI unit tests
         run: |
           command -v shellcheck >/dev/null 2>&1 || { sudo apt-get update -qq && sudo apt-get install -y shellcheck >/dev/null; }
-          shellcheck -S error miuops tests/stack_policy_check_test.sh
+          shellcheck -S error miuops tests/stack_policy_check_test.sh \
+            .github/scripts/discover-changed-servers.sh .github/scripts/deploy-server.sh
           bash tests/cli_test.sh
+          bash tests/discover_changed_servers_test.sh
+          bash tests/deploy_workflow_lint_test.sh
 
       - name: Install Ansible
         run: pip install ansible

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -1,0 +1,118 @@
+name: Deploy fleet stacks
+
+# Reusable workflow that lives in miuops. The operator's private fleet repo adds
+# a tiny caller that runs on push to its main branch:
+#
+#   # .github/workflows/deploy.yml in the FLEET repo
+#   name: Deploy fleet
+#   on:
+#     push:
+#       branches: [main]
+#   jobs:
+#     deploy:
+#       # Pin to an immutable ref. This workflow handles per-server SSH keys, so a
+#       # mutable ref (a branch) would be a server-takeover supply-chain risk.
+#       # A release TAG is the minimum; a full commit SHA is strongest.
+#       uses: tianshanghong/miuops/.github/workflows/deploy.yml@v1
+#       secrets: inherit
+#
+# Per-server secret isolation: each changed server gets its own matrix job with a
+# job-level `environment: <server>`, so it loads ONLY that server's Environment
+# secrets (SSH_HOST/SSH_USER/SSH_PORT/SSH_PRIVATE_KEY/SSH_KNOWN_HOSTS). A matrix
+# job for one server cannot reference another's secrets — that is the isolation.
+# `on.workflow_call` cannot declare an environment, so the binding is at job level
+# (where the matrix context is available). `secrets: inherit` lets this workflow
+# reference secrets at all; the `environment:` binding (not inherit) is what
+# isolates one server from another. The age/SOPS key + Cloudflare token are never
+# GitHub secrets, so inherit cannot leak them.
+
+on:
+  workflow_call:
+    inputs:
+      stacks_dir:
+        description: Path prefix in the fleet repo that holds per-server stacks.
+        type: string
+        required: false
+        default: fleet/stacks
+      remote_stacks_dir:
+        description: Destination prefix on each server.
+        type: string
+        required: false
+        default: /opt/stacks
+
+# Least privilege: read the fleet repo and SSH out. Never write back to the repo.
+permissions:
+  contents: read
+
+# Serialize deploys of the same fleet ref. Do not cancel in progress: a
+# half-finished rsync is worse than a short queue.
+concurrency:
+  group: fleet-deploy-${{ github.repository }}-${{ github.ref }}
+  cancel-in-progress: false
+
+jobs:
+  # Determine which servers changed in this push -> a JSON array for the matrix.
+  # Reads no secrets, so a crafted server name has zero secret-exposure surface.
+  discover:
+    runs-on: ubuntu-latest
+    outputs:
+      servers: ${{ steps.scan.outputs.servers }}
+    steps:
+      # fetch-depth: 0 -> full history so a before..after diff is correct for any
+      # pushed range (the default depth-1 checkout lacks the base commit).
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+        with:
+          fetch-depth: 0
+
+      - name: Scan changed servers
+        id: scan
+        env:
+          # github context reflects the caller's push event. before is the
+          # all-zero SHA on a first push / new branch; the script handles that
+          # and any unknown/rewritten base by deploying all present stacks.
+          BEFORE: ${{ github.event.before }}
+          AFTER: ${{ github.sha }}
+          STACKS_DIR: ${{ inputs.stacks_dir }}
+        run: |
+          set -euo pipefail
+          servers="$(bash "${GITHUB_WORKSPACE}/.github/scripts/discover-changed-servers.sh")"
+          printf 'servers=%s\n' "$servers" >> "$GITHUB_OUTPUT"
+          printf 'Changed servers: %s\n' "$servers"
+
+  # One isolated runner per changed server.
+  deploy:
+    needs: discover
+    # An empty fromJSON matrix errors. Skip cleanly (green, zero jobs) when no
+    # server changed (e.g. a push that only touched inventory/host_vars).
+    if: needs.discover.outputs.servers != '[]'
+    runs-on: ubuntu-latest
+    environment: ${{ matrix.server }}
+    concurrency:
+      # Never two concurrent deploys to the SAME server; different servers still
+      # run in parallel. Do not cancel: let an in-flight deploy finish.
+      group: fleet-deploy-${{ github.repository }}-${{ github.ref }}-${{ matrix.server }}
+      cancel-in-progress: false
+    strategy:
+      # One server's failure must not cancel the others.
+      fail-fast: false
+      # Bound concurrent SSH fan-out across the fleet.
+      max-parallel: 4
+      matrix:
+        server: ${{ fromJSON(needs.discover.outputs.servers) }}
+    steps:
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+
+      - name: Deploy ${{ matrix.server }}
+        env:
+          # Resolve from environment: ${{ matrix.server }} -- this one server only.
+          SSH_HOST: ${{ secrets.SSH_HOST }}
+          SSH_USER: ${{ secrets.SSH_USER }}
+          SSH_PORT: ${{ secrets.SSH_PORT }}
+          SSH_PRIVATE_KEY: ${{ secrets.SSH_PRIVATE_KEY }}
+          SSH_KNOWN_HOSTS: ${{ secrets.SSH_KNOWN_HOSTS }}
+          # Untrusted directory name: only ever passed as an env var / argument,
+          # never concatenated into a command. Re-validated inside the script.
+          SERVER: ${{ matrix.server }}
+          STACKS_DIR: ${{ inputs.stacks_dir }}
+          REMOTE_STACKS_DIR: ${{ inputs.remote_stacks_dir }}
+        run: bash "${GITHUB_WORKSPACE}/.github/scripts/deploy-server.sh"

--- a/tests/deploy_workflow_lint_test.sh
+++ b/tests/deploy_workflow_lint_test.sh
@@ -1,0 +1,44 @@
+#!/usr/bin/env bash
+# Lint the reusable deploy workflow's security-critical properties so a future
+# edit that weakens per-server isolation, supply-chain pinning, or secret
+# hygiene fails CI. Pure structural assertions over the text (no runner needed).
+set -euo pipefail
+ROOT="$(cd "$(dirname "$0")/.." && pwd)"
+Y="$ROOT/.github/workflows/deploy.yml"
+S="$ROOT/.github/scripts/deploy-server.sh"
+fail() { echo "FAIL: $1"; exit 1; }
+
+# Trigger + permissions: reusable only, never fork-exposed, least privilege.
+grep -qF 'workflow_call:' "$Y"                              || fail "trigger must be workflow_call"
+! grep -q 'pull_request_target' "$Y"                        || fail "must NOT use pull_request_target (fork secret exposure)"
+grep -qE '^[[:space:]]*contents: read[[:space:]]*$' "$Y"    || fail "permissions must be contents: read"
+! grep -qE '(write-all|contents: write|packages: write|id-token: write)' "$Y" || fail "must not grant any write scope"
+
+# Per-server isolation: the deploy job binds the Environment to the matrix value.
+grep -qF 'environment: ${{ matrix.server }}' "$Y"           || fail "deploy job must bind environment to matrix.server (per-server isolation)"
+grep -qF 'fromJSON(needs.discover.outputs.servers)' "$Y"    || fail "matrix must come from the discover output"
+grep -qF "servers != '[]'" "$Y"                             || fail "deploy must guard against an empty matrix"
+grep -qF 'fail-fast: false' "$Y"                            || fail "matrix must set fail-fast: false (one server's failure must not cancel others)"
+
+# Supply chain: every real action use pinned to a 40-hex commit SHA, no tags.
+uses_count=$(grep -cE 'uses:[[:space:]]+[A-Za-z0-9_.-]+/[A-Za-z0-9_.-]+@[0-9a-f]{40}' "$Y" || true)
+[ "${uses_count:-0}" -ge 2 ]                                || fail "real action uses must be SHA-pinned (found ${uses_count})"
+! grep -qE 'uses:[[:space:]]+[A-Za-z0-9_.-]+/[A-Za-z0-9_.-]+@v[0-9]' "$Y" || fail "an action use is pinned to a mutable tag, not a SHA"
+
+# Secret hygiene: secrets only via env:, never interpolated into a run: string;
+# no shell tracing / ssh|rsync verbosity in the deploy script (ignore comments).
+! grep -qE 'run:.*\$\{\{[[:space:]]*secrets\.' "$Y"         || fail "a secret is interpolated into a run: string"
+code_only="$(grep -vE '^[[:space:]]*#' "$S")"
+! printf '%s\n' "$code_only" | grep -qE '(\bset -x\b|ssh[[:space:]]+-v|rsync[[:space:]]+-v)' \
+    || fail "deploy-server.sh has tracing/verbosity that could surface a secret"
+
+# Regression guards for confirmed review findings: the deploy must detect ANY
+# canonical compose filename (not hard-code docker-compose.yml), normalize the
+# project name in teardown so a still-present stack is never flapped, validate
+# SSH_PORT numeric, and treat teardown enumeration as best-effort (non-fatal).
+grep -qF 'config -q' "$S"               || fail "up-loop must detect any compose filename via 'compose config -q', not a hard-coded name"
+grep -qF 'def norm' "$S"                || fail "teardown must normalize dir names to compose project names before comparing"
+grep -qE 'SSH_PORT.*=~.*0-9' "$S"       || fail "SSH_PORT must be validated numeric"
+grep -qF 'Skipped teardown' "$S"        || fail "teardown enumeration must be best-effort (non-fatal on missing python3)"
+
+echo "ALL DEPLOY WORKFLOW LINT CHECKS PASSED"

--- a/tests/discover_changed_servers_test.sh
+++ b/tests/discover_changed_servers_test.sh
@@ -1,0 +1,79 @@
+#!/usr/bin/env bash
+# Unit tests for .github/scripts/discover-changed-servers.sh — the deploy
+# workflow's "which servers changed" matrix builder. Two layers:
+#   (A) path -> server mapping, via MIUOPS_CHANGED_PATHS_FILE fixtures (no git);
+#   (B) git range resolution (first push / normal / inventory-only / unknown
+#       base / force-push), via throwaway real git repos.
+# Every assertion is paired with the bad input it must reject, so it can FAIL.
+set -euo pipefail
+ROOT="$(cd "$(dirname "$0")/.." && pwd)"
+SCRIPT="$ROOT/.github/scripts/discover-changed-servers.sh"
+TMP="$(mktemp -d)"; trap 'rm -rf "$TMP"' EXIT
+fail() { echo "FAIL: $1"; exit 1; }
+
+# --- Layer A: path -> server mapping (offline fixtures) --------------------
+# expect_map <label> <expected-json> <path...>
+expect_map() {
+  local label="$1" expected="$2"; shift 2
+  local f="$TMP/paths"; printf '%s\n' "$@" > "$f"
+  local got; got="$(MIUOPS_CHANGED_PATHS_FILE="$f" bash "$SCRIPT")"
+  [ "$got" = "$expected" ] || fail "$label: expected $expected, got $got"
+}
+
+expect_map "normal sorted+deduped"          '["api","web"]' \
+  'fleet/stacks/web/docker-compose.yml' 'fleet/stacks/api/compose.yml'
+expect_map "non-stack paths ignored"        '[]' \
+  'fleet/inventory.ini' 'fleet/host_vars/web.yml' 'README.md'
+expect_map "prefix itself -> none"          '[]' 'fleet/stacks/'
+expect_map "server dir, no file beneath"    '[]' 'fleet/stacks/lonely'
+expect_map "substring traps rejected"       '[]' 'fleet/stacksXYZ/web/x' 'notfleet/stacks/web/x'
+expect_map "path traversal rejected"        '[]' 'fleet/stacks/../../etc/passwd' 'fleet/stacks/..'
+expect_map "injection names rejected"       '[]' 'fleet/stacks/a;rm -rf ~/x' 'fleet/stacks/$(id)/x'
+expect_map "leading-dash + dotfile rejected" '[]' 'fleet/stacks/-evil/x' 'fleet/stacks/.hidden/x'
+expect_map "valid dot/underscore/digit/upper" '["Web","db.1_node"]' \
+  'fleet/stacks/db.1_node/x' 'fleet/stacks/Web/x'
+expect_map "deep files + dups -> one"       '["api"]' \
+  'fleet/stacks/api/conf/nginx/site.conf' 'fleet/stacks/api/compose.yml' 'fleet/stacks/api/compose.yml'
+expect_map "deleted path still counts"      '["web"]' 'fleet/stacks/web/removed.yml'
+
+# empty input -> [] and exit 0 (must not trip set -u)
+: > "$TMP/empty"
+got="$(MIUOPS_CHANGED_PATHS_FILE="$TMP/empty" bash "$SCRIPT")"
+[ "$got" = '[]' ] || fail "empty input: expected [], got $got"
+
+# --- Layer B: git range resolution (real repos) ---------------------------
+GR="$TMP/repo"; mkdir -p "$GR"
+( cd "$GR" && git init -q && git config user.email t@example.com && git config user.name t \
+    && git config commit.gpgsign false )   # throwaway repo: never sign (headless)
+gadd() { ( cd "$GR" && mkdir -p "fleet/stacks/$1" && echo x > "fleet/stacks/$1/compose.yml" ); }
+gsha() { ( cd "$GR" && git rev-parse HEAD ); }
+
+gadd alpha; gadd beta
+( cd "$GR" && git add -A && git commit -qm one ); C1="$(gsha)"
+
+# first push: zero SHA and empty BEFORE both -> all present stacks (ls-tree)
+got="$(cd "$GR" && BEFORE="0000000000000000000000000000000000000000" AFTER="$C1" bash "$SCRIPT")"
+[ "$got" = '["alpha","beta"]' ] || fail "first-push(zero): got $got"
+got="$(cd "$GR" && BEFORE="" AFTER="$C1" bash "$SCRIPT")"
+[ "$got" = '["alpha","beta"]' ] || fail "first-push(empty BEFORE): got $got"
+
+# normal diff: only the newly added server
+gadd gamma; ( cd "$GR" && git add -A && git commit -qm two ); C2="$(gsha)"
+got="$(cd "$GR" && BEFORE="$C1" AFTER="$C2" bash "$SCRIPT")"
+[ "$got" = '["gamma"]' ] || fail "normal-diff: expected [gamma], got $got"
+
+# inventory-only change -> [] (pairs with the workflow's if: != '[]' guard)
+( cd "$GR" && mkdir -p fleet && echo i > fleet/inventory.ini && git add -A && git commit -qm three ); C3="$(gsha)"
+got="$(cd "$GR" && BEFORE="$C2" AFTER="$C3" bash "$SCRIPT")"
+[ "$got" = '[]' ] || fail "inventory-only: expected [], got $got"
+
+# unknown/garbage base (force-push to a gone SHA) -> deploy all (fail-safe)
+got="$(cd "$GR" && BEFORE="deadbeefdeadbeefdeadbeefdeadbeefdeadbeef" AFTER="$C3" bash "$SCRIPT")"
+[ "$got" = '["alpha","beta","gamma"]' ] || fail "unknown-base: expected all, got $got"
+
+# non-ancestor base WITH a merge-base -> diff merge-base..after
+( cd "$GR" && git checkout -q -b div "$C1" && mkdir -p fleet/stacks/divsrv && echo x > fleet/stacks/divsrv/c.yml && git add -A && git commit -qm div ); CDIV="$(gsha)"
+got="$(cd "$GR" && BEFORE="$CDIV" AFTER="$C3" bash "$SCRIPT")"
+[ "$got" = '["gamma"]' ] || fail "non-ancestor(merge-base C1..C3): expected [gamma], got $got"
+
+echo "ALL DISCOVER TESTS PASSED"


### PR DESCRIPTION
## What

A `workflow_call` workflow (`.github/workflows/deploy.yml`) that a fleet repo's
~5-line caller invokes on push. It discovers which servers' `fleet/stacks/<server>/`
changed and runs one matrix job per server, each bound to `environment: <server>`
so it reads only that server's GitHub Environment SSH secret — no lateral movement.

- **discover-changed-servers.sh** — maps a push's changed paths to a validated,
  deduped JSON array of server names; handles first push / force-push / orphan
  history (fails safe to deploy-all); strict name allowlist under `LC_ALL=C`.
- **deploy-server.sh** — per-run SSH key in a temp dir; host-key pin (when
  `SSH_KNOWN_HOSTS` is set) else accept-new; rsync excluding `.env`/`*.env` and
  pruning removed stacks; registry login; compose up (auto-discovers any canonical
  compose filename); best-effort teardown of removed stacks. Fails closed on
  missing secrets / invalid inputs.

## Security properties (lint-enforced)

Per-server isolation via `environment: ${{ matrix.server }}`; `permissions:
contents: read`; no `pull_request_target`; SHA-pinned actions; `fail-fast: false`;
empty-matrix guard; secrets only via `env:` (never in a `run:` string); no shell
tracing / ssh|rsync verbosity. `tests/deploy_workflow_lint_test.sh` asserts these.

## Testing

`tests/discover_changed_servers_test.sh` (path mapping + all git-range edge cases,
mutation-proven) and `tests/deploy_workflow_lint_test.sh` (structure + secret
hygiene + regression guards), both wired into CI; `shellcheck -S error` and
`actionlint` clean. Runtime behavior on a real host is covered by the end-to-end
acceptance.