### PR TITLE
feat(ssh): install operator-supplied CI deploy public keys (fail-closed)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -24,10 +24,12 @@ jobs:
         run: |
           command -v shellcheck >/dev/null 2>&1 || { sudo apt-get update -qq && sudo apt-get install -y shellcheck >/dev/null; }
           shellcheck -S error miuops tests/stack_policy_check_test.sh \
-            .github/scripts/discover-changed-servers.sh .github/scripts/deploy-server.sh
+            .github/scripts/discover-changed-servers.sh .github/scripts/deploy-server.sh \
+            tests/ssh_deploy_key_validation_test.sh
           bash tests/cli_test.sh
           bash tests/discover_changed_servers_test.sh
           bash tests/deploy_workflow_lint_test.sh
+          bash tests/ssh_deploy_key_validation_test.sh
 
       - name: Install Ansible
         run: pip install ansible

--- a/roles/ssh/README.md
+++ b/roles/ssh/README.md
@@ -33,9 +33,55 @@ which runs just before this role. fail2ban and a tight `MaxAuthTries` are intent
 omitted — key-only already makes password brute-force pointless, and a low `MaxAuthTries`
 breaks legitimate multi-key SSH agents.
 
+## CI deploy keys (`deploy_public_keys`)
+
+Before the lockout guard runs, the role installs each entry of the `deploy_public_keys`
+host_var into the **connecting user's** `authorized_keys` — the same user (root by default)
+that the guard checks and that CI/rsync connects as. This is how a per-server CI deploy key
+gets onto the host.
+
+```yaml
+# fleet/host_vars/<server>.yml
+deploy_public_keys:
+  - "ssh-ed25519 AAAA... ci-deploy@<server>"   # PUBLIC key ONLY
+```
+
+Key properties:
+
+- **PUBLIC keys only.** The operator generates the keypair; the tool only ever handles the
+  **public** key. Every entry is positively matched against an allowlist of public-key types
+  (`ssh-rsa`, `ssh-ed25519`, `ssh-dss`, `ecdsa-sha2-`, `sk-ssh-ed25519@openssh.com`,
+  `sk-ecdsa-sha2-`) **and** refused if it contains `PRIVATE KEY`. A private key fed in by
+  mistake **fails the converge** (fail-closed) and is never written.
+- **Additive, not exclusive.** Keys are added with `exclusive: false`, so the operator's
+  existing bootstrap key (which the lockout guard depends on) is preserved. Rotation: add the
+  new key, update the Environment secret, converge, then remove the old key from both the list
+  and `authorized_keys`.
+- **Installed before the guard.** The install runs above the key-only lockout guard, so a
+  host that only had the operator's bootstrap key also gains the CI key and the guard still
+  passes.
+- **No-op by default.** `deploy_public_keys` defaults to `[]`, so an Ansible-only `apply`
+  without the CLI still converges and existing servers are unaffected.
+
+The matching **private** key never enters this repo and never touches the tool. The operator
+puts it into the per-server **GitHub Environment** as a secret:
+
+```sh
+ssh-keygen -t ed25519 -f deploy_<server> -C "ci-deploy@<server>" -N ""
+# deploy_<server>.pub  -> deploy_public_keys in fleet/host_vars/<server>.yml
+# deploy_<server>      -> GitHub Environment <server>, secret SSH_PRIVATE_KEY:
+gh secret set SSH_PRIVATE_KEY --env <server> --body "$(cat deploy_<server>)"
+shred -u deploy_<server>   # private key now lives ONLY in the Environment
+```
+
+The allowlist/refusal logic is covered by an oracle: `tests/ssh_deploy_key_validation_test.sh`.
+
 ## Requirements
 
 - A working SSH **key** in the deploy user's `authorized_keys` BEFORE this runs — once
   password auth is off, only keys work. The role **asserts** this and fails fast (no lockout)
-  if none is present. (Fresh hosts are provisioned with the operator's key.)
+  if none is present. (Fresh hosts are provisioned with the operator's key; a
+  `deploy_public_keys` entry is installed just above, so it also satisfies the guard.)
+- `ansible.posix` collection (already a declared dependency in `requirements.yml`) for the
+  `authorized_key` module.
 - Debian/Ubuntu with the `sshd_config.d/` drop-in directory (default on current releases).

--- a/roles/ssh/defaults/main.yml
+++ b/roles/ssh/defaults/main.yml
@@ -1,0 +1,16 @@
+---
+# Per-server CI deploy PUBLIC keys to install into the connecting user's
+# authorized_keys (additive). PUBLIC keys only — the operator generates the
+# keypair and keeps the PRIVATE key out of this repo and out of the tool; the
+# private key lives ONLY in the per-server GitHub Environment as a secret.
+#
+# Default is an empty list, so the role is a NO-OP when no key is supplied: an
+# Ansible-only `apply` without the CLI still converges and existing servers are
+# unaffected. Set it per host in fleet/host_vars/<server>.yml, e.g.:
+#
+#   deploy_public_keys:
+#     - "ssh-ed25519 AAAA... ci-deploy@<server>"   # PUBLIC key ONLY
+#
+# Each entry is validated against a public-key allowlist AND refused if it
+# contains 'PRIVATE KEY' (fail-closed) before anything is written.
+deploy_public_keys: []

--- a/roles/ssh/tasks/main.yml
+++ b/roles/ssh/tasks/main.yml
@@ -4,6 +4,49 @@
 # pointless (keys only). Deployed as a drop-in so the distro's base sshd_config is untouched.
 # SSH rate-limiting (ufw limit) lives in roles/firewall, which runs just before this.
 
+# --- CI deploy public keys -------------------------------------------------------
+# Install operator-supplied PUBLIC deploy keys BEFORE the key-only lockout guard, so
+# a host that only had the operator's bootstrap key also gains the CI key and the
+# guard below still passes (authorized_keys is non-empty). The install is additive
+# (exclusive: false) so the operator's existing key is preserved. PUBLIC keys only:
+# every entry is positively matched against an allowlist of public-key types AND
+# refused if it contains 'PRIVATE KEY' — fail-closed, so a private key fed in by
+# mistake is rejected and never written. Default deploy_public_keys is [] (no-op).
+
+- name: Validate each deploy key is a PUBLIC key (never handle a private key)
+  ansible.builtin.assert:
+    that:
+      # One list entry == one key. ansible.posix.authorized_key splits on newlines
+      # and installs EACH line as a separate key, so a multi-line value could smuggle
+      # a second (back-door) key past a valid first line. Require exactly one line.
+      - "(item.splitlines() | length) == 1"
+      # Positive allowlist. The four space-delimited types need a trailing space so a
+      # glued suffix ('ssh-rsaEVIL...') and a bare type with no key body are refused;
+      # the ecdsa types keep a bare prefix (a curve name follows). Mirrors the test
+      # oracle exactly so role and test share one accept/refuse boundary.
+      - >-
+        item is match('^(ssh-rsa |ssh-ed25519 |ssh-dss |ecdsa-sha2-|sk-ssh-ed25519@openssh\.com |sk-ecdsa-sha2-)')
+      # Fail-closed, case-insensitive: refuse anything carrying private-key material.
+      - "'PRIVATE KEY' not in (item | upper)"
+    fail_msg: >-
+      deploy_public_keys entries must be PUBLIC keys (ssh-ed25519/ssh-rsa/ecdsa-sha2-/
+      sk-...). Refusing — this tool never handles private keys. Put the private key in
+      the server's GitHub Environment as a secret, not here.
+    quiet: true
+  loop: "{{ deploy_public_keys }}"
+  when: deploy_public_keys | length > 0
+
+- name: Install CI deploy public key(s) into authorized_keys (additive)
+  ansible.posix.authorized_key:
+    user: "{{ ansible_user_id }}"
+    key: "{{ item }}"
+    state: present
+    exclusive: false   # ADD — never clobber the operator's bootstrap key
+    manage_dir: true
+  loop: "{{ deploy_public_keys }}"
+  when: deploy_public_keys | length > 0
+  become: true
+
 - name: Check the deploy user has an authorized key (lockout guard)
   ansible.builtin.stat:
     path: "{{ ansible_env.HOME }}/.ssh/authorized_keys"

--- a/tests/ssh_deploy_key_validation_test.sh
+++ b/tests/ssh_deploy_key_validation_test.sh
@@ -67,7 +67,13 @@ refuse() { # $1=label  $2=value : the value MUST be refused
   fi
 }
 
-# --- Positive controls: real public keys, every allowlisted type, accepted -------
+# All key fixtures below are SYNTHETIC: real-FORMAT headers / type-prefixes (so the
+# allowlist + the 'PRIVATE KEY' guard are exercised honestly) with literal
+# 'testkey' / 'legit' / 'backdoor' filler bodies. NO real, usable, or in-use key
+# material exists anywhere in this file — the private-key blocks are recognizable
+# stubs (e.g. the OpenSSH one is ~132B vs ~400B for a real ed25519 key; its secret
+# scalar is literally 'testkey…'), not generated or copied keys.
+# --- Positive controls: well-formed PUBLIC keys (synthetic), every allowlisted type, accepted ---
 accept "ssh-ed25519" \
   "ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAIGtESTKEYtestkeytestkeytestkeytestkey ci-deploy@web1"
 accept "ssh-rsa" \
@@ -82,13 +88,14 @@ accept "sk-ecdsa-sha2 (FIDO2)" \
   "sk-ecdsa-sha2-nistp256@openssh.com AAAAInNrLWVjZHNhLXNoYTItbmlzdHAyNTZ0estkey deploy@web1"
 
 # --- Negative controls: bad inputs, each refused ---------------------------------
-# A real OpenSSH PRIVATE KEY block fed in by mistake — the exact thing we must refuse.
+# A synthetic OpenSSH PRIVATE KEY block (recognizable header, filler body) — the kind of
+# value an operator might paste by mistake, which we must refuse.
 refuse "OpenSSH private key block" \
   "-----BEGIN OPENSSH PRIVATE KEY-----
 b3BlbnNzaC1rZXktdjEAAAAABG5vbmUAAAAEbm9uZQAAAAAAAAABAAAAMwAAAAtzc2gtZWQy
 NTUxOQAAACDtestkeytestkeytestkeytestkeytestkeytestkeytestkey
 -----END OPENSSH PRIVATE KEY-----"
-# A classic PEM RSA private key (different banner, same 'PRIVATE KEY' substring).
+# A synthetic PEM RSA private key (different banner, same 'PRIVATE KEY' substring).
 refuse "PEM RSA private key block" \
   "-----BEGIN RSA PRIVATE KEY-----
 MIIEpAIBAAKCAQEAtestkeytestkeytestkeytestkeytestkeytestkeytestkey

--- a/tests/ssh_deploy_key_validation_test.sh
+++ b/tests/ssh_deploy_key_validation_test.sh
@@ -1,0 +1,124 @@
+#!/usr/bin/env bash
+# Oracle for the ssh role's deploy-key validation (fail-closed).
+#
+# The ssh role installs only PUBLIC keys into a server's authorized_keys. It must
+# POSITIVELY validate every supplied value against an allowlist of public-key
+# prefixes AND refuse anything containing the substring 'PRIVATE KEY' — so a private
+# key fed in by mistake is rejected, never written, never committed.
+#
+# This script reimplements the EXACT same allowlist/refusal logic that
+# roles/ssh/tasks/main.yml asserts, then exercises it with good keys (accepted) and
+# bad inputs (refused). Each assertion can genuinely FAIL: a positive control that
+# refused, or a negative control that was accepted, flips `fail` to 1 and exits 1.
+#
+# Keeping the predicate here in lockstep with the Ansible assert means a regression
+# in either (loosening the allowlist, dropping the PRIVATE KEY guard) is caught by a
+# fixture that this test asserts on.
+set -u
+
+fail=0
+
+# is_public_key <value> -> exit 0 if the value is an acceptable PUBLIC key, else 1.
+#
+# Mirrors the role assert, which requires BOTH:
+#   (a) the value starts with one of the allowlisted public-key types, AND
+#   (b) the value does NOT contain the substring 'PRIVATE KEY'.
+# Any value failing either clause (including unrecognized forms) is refused.
+is_public_key() {
+  local v="$1"
+
+  # one entry == one key: reject any multi-line value. ansible.posix.authorized_key
+  # splits on newlines and installs each line separately, so a multi-line value
+  # could smuggle a back-door key past a valid first line. Count lines with Python
+  # splitlines() -- the SAME boundary the role assert (item.splitlines()) and the
+  # install module (key.splitlines()) use -- so the test tracks the gate on exotic
+  # separators too (\r, \f, \v, U+2028, U+0085), not only \n.
+  [ "$(printf '%s' "$v" | python3 -c 'import sys;print(len(sys.stdin.read().splitlines()))')" -le 1 ] || return 1
+
+  # fail-closed, CASE-INSENSITIVE: never accept anything carrying private-key material.
+  printf '%s' "$v" | grep -qi 'PRIVATE KEY' && return 1
+
+  # positive allowlist of public-key prefixes (the only accepted forms; trailing
+  # space on the space-delimited types so a glued suffix / bare type is refused).
+  case "$v" in
+    "ssh-rsa "*) return 0 ;;
+    "ssh-ed25519 "*) return 0 ;;
+    "ssh-dss "*) return 0 ;;
+    "ecdsa-sha2-"*) return 0 ;;
+    "sk-ssh-ed25519@openssh.com "*) return 0 ;;
+    "sk-ecdsa-sha2-"*) return 0 ;;
+    *) return 1 ;;
+  esac
+}
+
+accept() { # $1=label  $2=value : the value MUST be accepted
+  if is_public_key "$2"; then
+    echo "ok   (accept): $1"
+  else
+    echo "FAIL (accept): expected '$1' to be accepted but it was refused"; fail=1
+  fi
+}
+
+refuse() { # $1=label  $2=value : the value MUST be refused
+  if is_public_key "$2"; then
+    echo "FAIL (refuse): expected '$1' to be refused but it was accepted"; fail=1
+  else
+    echo "ok   (refuse): $1"
+  fi
+}
+
+# --- Positive controls: real public keys, every allowlisted type, accepted -------
+accept "ssh-ed25519" \
+  "ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAIGtESTKEYtestkeytestkeytestkeytestkey ci-deploy@web1"
+accept "ssh-rsa" \
+  "ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABgQDtestkeytestkeytestkeytestkey deploy@web1"
+accept "ssh-dss" \
+  "ssh-dss AAAAB3NzaC1kc3MAAACBtestkeytestkeytestkeytestkey deploy@web1"
+accept "ecdsa-sha2-nistp256" \
+  "ecdsa-sha2-nistp256 AAAAE2VjZHNhLXNoYTItbmlzdHAyNTZtestkey deploy@web1"
+accept "sk-ssh-ed25519 (FIDO2)" \
+  "sk-ssh-ed25519@openssh.com AAAAGnNrLXNzaC1lZDI1NTE5QG9wZW5zc2guY29ttestkey deploy@web1"
+accept "sk-ecdsa-sha2 (FIDO2)" \
+  "sk-ecdsa-sha2-nistp256@openssh.com AAAAInNrLWVjZHNhLXNoYTItbmlzdHAyNTZ0estkey deploy@web1"
+
+# --- Negative controls: bad inputs, each refused ---------------------------------
+# A real OpenSSH PRIVATE KEY block fed in by mistake — the exact thing we must refuse.
+refuse "OpenSSH private key block" \
+  "-----BEGIN OPENSSH PRIVATE KEY-----
+b3BlbnNzaC1rZXktdjEAAAAABG5vbmUAAAAEbm9uZQAAAAAAAAABAAAAMwAAAAtzc2gtZWQy
+NTUxOQAAACDtestkeytestkeytestkeytestkeytestkeytestkeytestkey
+-----END OPENSSH PRIVATE KEY-----"
+# A classic PEM RSA private key (different banner, same 'PRIVATE KEY' substring).
+refuse "PEM RSA private key block" \
+  "-----BEGIN RSA PRIVATE KEY-----
+MIIEpAIBAAKCAQEAtestkeytestkeytestkeytestkeytestkeytestkeytestkey
+-----END RSA PRIVATE KEY-----"
+refuse "empty string"          ""
+refuse "random string"         "this is not a key at all"
+refuse "looks-like-but-bogus"  "ssh-elgamal AAAAsomethingbogus deploy@web1"
+# A value that LOOKS public but smuggles private-key material must still be refused.
+refuse "public prefix + PRIVATE KEY substring" \
+  "ssh-ed25519 AAAA... -----BEGIN OPENSSH PRIVATE KEY-----"
+# Glued suffix (no delimiter after the type) and a bare type with no key body.
+refuse "glued prefix (no delimiter)"    "ssh-rsaEVILSUFFIX"
+refuse "bare type, no key body"         "ssh-rsa"
+# Multi-line value: legit first line, back-door key on the second — the module would
+# install BOTH, so the whole value must be refused.
+refuse "multi-line smuggles a 2nd key"  "ssh-ed25519 AAAAlegit ci@web1
+ssh-rsa AAAAbackdoor attacker@evil"
+# Lower-case private-key banner must still be caught (case-insensitive guard).
+refuse "lowercase private-key banner"   "-----begin openssh private key-----"
+# Exotic separators (the boundary the install module's splitlines() actually uses):
+# a CR-glued back-door must be REFUSED, a single valid key with a trailing newline
+# must be ACCEPTED (it installs exactly one key — the trailing empty line is dropped).
+crval=$'ssh-ed25519 AAAAlegit ci@web1\rssh-rsa AAAAbackdoor attacker@evil'
+refuse "CR-glued back-door key"         "$crval"
+nlval=$'ssh-ed25519 AAAAvalidbody ci@web1\n'
+accept "valid key, trailing newline"    "$nlval"
+
+if [ "$fail" -eq 0 ]; then
+  echo "ALL SSH DEPLOY-KEY VALIDATION TESTS PASSED"
+else
+  echo "SSH DEPLOY-KEY VALIDATION TESTS FAILED"
+fi
+exit "$fail"


### PR DESCRIPTION
## What

The `ssh` role installs operator-supplied **public** deploy keys into the
connecting user's `authorized_keys`, so CI can deploy over SSH. The operator
generates the keypair; only the **public** key reaches the tool — the private
key goes in that server's GitHub Environment, never here.

## Fail-closed validation

Each `deploy_public_keys` entry must:
- match a public-key type allowlist (`ssh-ed25519`/`ssh-rsa`/`ssh-dss`/`ecdsa-sha2-`/
  `sk-…`) **with a trailing delimiter** (so a glued suffix or bare type is refused);
- be a **single line** — `ansible.posix.authorized_key` splits on newlines and
  installs each line as a key, so a multi-line/CR-glued value could otherwise smuggle
  a second (back-door) key past a valid first line;
- **not contain `PRIVATE KEY`** (case-insensitive).

Anything else aborts the converge. Default `deploy_public_keys: []` is a no-op
(backward-compatible); the existing key-only **lockout guard** is preserved and
still runs.

## Testing

`tests/ssh_deploy_key_validation_test.sh` reimplements the **identical** accept/refuse
boundary the role asserts (line count via `splitlines()`, the allowlist, the
case-insensitive private-key guard) and exercises it with good keys and bad inputs
(glued-prefix, bare-type, multi-line, CR-glued back-door, lowercase banner, real
private-key blocks). Wired into CI; `shellcheck -S error` + `actionlint` clean.