### PR TITLE
feat(backup): per-server S3 prefix + prefix-scoped IAM user for fleet backups

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -25,11 +25,13 @@ jobs:
           command -v shellcheck >/dev/null 2>&1 || { sudo apt-get update -qq && sudo apt-get install -y shellcheck >/dev/null; }
           shellcheck -S error miuops tests/stack_policy_check_test.sh \
             .github/scripts/discover-changed-servers.sh .github/scripts/deploy-server.sh \
-            tests/ssh_deploy_key_validation_test.sh
+            tests/ssh_deploy_key_validation_test.sh \
+            scripts/test/iam-policy-oracle.sh scripts/setup-s3-backup.sh
           bash tests/cli_test.sh
           bash tests/discover_changed_servers_test.sh
           bash tests/deploy_workflow_lint_test.sh
           bash tests/ssh_deploy_key_validation_test.sh
+          bash scripts/test/iam-policy-oracle.sh
 
       - name: Install Ansible
         run: pip install ansible

--- a/roles/backup/README.md
+++ b/roles/backup/README.md
@@ -24,9 +24,10 @@ the writer first.
 
 ## Quick start
 
-1. Create the S3 bucket + IAM user (Object Lock + lifecycle):
-   `scripts/setup-s3-backup.sh` (one bucket is shared with WAL-G — see the repo
-   README).
+1. Create the shared S3 bucket + this server's scoped IAM user (Object Lock +
+   lifecycle): `scripts/setup-s3-backup.sh --server <server>` (one bucket is
+   shared by the whole fleet and with WAL-G; each server gets its own prefix +
+   IAM user — see the repo README and the **Fleet isolation** section below).
 2. Export the AWS credentials in the shell you run miuOps from:
 
    ```bash
@@ -44,8 +45,8 @@ the writer first.
 |---|---|---|
 | `backup_enabled` | `false` | Master switch. Role is a no-op when false. |
 | `backup_volumes` | `[]` | List of `{ name, stop }` items (below). |
-| `backup_s3_bucket` | `""` | Destination bucket name (no `s3://`). Required. |
-| `backup_s3_prefix` | `"vol"` | Key prefix. Objects land under `<prefix>/<volume>/`. |
+| `backup_s3_bucket` | `""` | Destination bucket name (no `s3://`). One bucket for the whole fleet. Required. |
+| `backup_s3_prefix` | `"{{ inventory_hostname }}/vol"` | Key prefix, rooted at this server's name. Objects land under `<server>/vol/<volume>/`. Must start with `<inventory_hostname>/` (the role asserts it). |
 | `backup_schedule` | `"*-*-* 02:00:00"` | systemd `OnCalendar` expression. |
 | `backup_randomized_delay_sec` | `"45m"` | `RandomizedDelaySec` to smear the start. |
 | `backup_encryption` | `"none"` | `none` \| `age`. |
@@ -85,8 +86,10 @@ until the next manual intervention.
 ```yaml
 # host_vars/<host>.yml
 backup_enabled: true
-backup_s3_bucket: "myproject-backup"
-backup_s3_prefix: "vol"
+backup_s3_bucket: "myfleet-backup"      # one bucket for the whole fleet
+# backup_s3_prefix defaults to "{{ inventory_hostname }}/vol" — leave it unset
+# unless you have a reason to change the trailing segment (keep the
+# "<server>/" root or the role's assert fails).
 backup_schedule: "*-*-* 02:00:00"
 backup_encryption: "age"
 backup_age_recipients:
@@ -118,9 +121,31 @@ so they never appear in `ps` / the process table.
 ## Object naming
 
 ```
-s3://<bucket>/<prefix>/<volume>/backup-<UTC ISO8601>.tar[.age]
-# e.g. s3://myproject-backup/vol/app_uploads/backup-20260624T020000Z.tar.age
+s3://<bucket>/<server>/vol/<volume>/backup-<UTC ISO8601>.tar[.age]
+# e.g. s3://myfleet-backup/web1/vol/app_uploads/backup-20260624T020000Z.tar.age
 ```
+
+The leading `<server>/` segment is `inventory_hostname` (the same identity used
+for `host_vars/<server>.yml` and the GitHub Environment). WAL-G database backups
+share the bucket under the symmetric `s3://<bucket>/<server>/db/<app>` prefix.
+
+## Fleet isolation
+
+One S3 bucket serves the whole fleet. Each server gets its own top-level prefix
+`<server>/` **and** its own per-server IAM user `"<bucket>-<server>"` (created by
+`scripts/setup-s3-backup.sh --server <server>`) whose inline policy is scoped to
+that prefix only:
+
+- `s3:ListBucket` on the bucket, **conditioned** to `s3:prefix` `<server>/*`;
+- `s3:PutObject` + `s3:GetObject` on `arn:aws:s3:::<bucket>/<server>/*`;
+- **no** `s3:DeleteObject`, **no** `s3:*`, **no** explicit `Deny`.
+
+AWS default-deny means a compromised host's key can read/write **only** its own
+backups — a `PutObject` to another server's prefix simply matches no `Allow` and
+is denied. Immutability is enforced by omitting Delete and by the bucket Object
+Lock. (Listing the bucket root from a server key is intentionally denied; an
+operator lists their own data with `aws s3 ls s3://<bucket>/<server>/` and uses
+an admin profile for a fleet-wide view.)
 
 ## Retention
 
@@ -141,8 +166,8 @@ journalctl -u miuops-backup.service -f
 # When does it next fire?
 systemctl list-timers miuops-backup.timer
 
-# What got uploaded?
-aws s3 ls s3://<bucket>/vol/ --recursive --region <region>
+# What got uploaded? (this server's prefix)
+aws s3 ls s3://<bucket>/<server>/vol/ --recursive --region <region>
 ```
 
 ## Restore
@@ -152,10 +177,10 @@ round-trip).
 
 ```bash
 # 1. Pick a backup
-aws s3 ls s3://<bucket>/vol/<volume>/ --region <region>
+aws s3 ls s3://<bucket>/<server>/vol/<volume>/ --region <region>
 
 # 2. Download it
-aws s3 cp s3://<bucket>/vol/<volume>/backup-<ts>.tar.age . --region <region>
+aws s3 cp s3://<bucket>/<server>/vol/<volume>/backup-<ts>.tar.age . --region <region>
 
 # 3. Decrypt (skip if unencrypted)
 #    age (identity file, SSH private key, or YubiKey-backed identity):

--- a/roles/backup/defaults/main.yml
+++ b/roles/backup/defaults/main.yml
@@ -26,10 +26,14 @@ backup_volumes: []
 #     stop: []
 
 # --- Destination ------------------------------------------------------------
-# S3 bucket (name only, no s3:// prefix) and key prefix. Objects land at
-#   s3://<bucket>/<prefix>/<volume>/backup-<UTC ISO8601>.tar[.age]
+# S3 bucket (name only, no s3:// prefix) and key prefix. ONE bucket is shared by
+# the whole fleet; every key is rooted at this server's name so the per-server
+# IAM user (scoped to "<server>/*") is authorized to write it. Objects land at
+#   s3://<bucket>/<server>/vol/<volume>/backup-<UTC ISO8601>.tar[.age]
+# Keep the "<inventory_hostname>/" root if you override this (the role asserts
+# it) so a host cannot write outside its own prefix.
 backup_s3_bucket: ""
-backup_s3_prefix: "vol"
+backup_s3_prefix: "{{ inventory_hostname }}/vol"
 
 # --- Schedule ---------------------------------------------------------------
 # systemd OnCalendar expression for the timer. Default: daily at ~02:00 local.

--- a/roles/backup/tasks/main.yml
+++ b/roles/backup/tasks/main.yml
@@ -21,6 +21,22 @@
   when: backup_enabled | bool
   tags: ['backup']
 
+- name: Ensure the S3 prefix is rooted at this server's name
+  ansible.builtin.assert:
+    that:
+      - backup_s3_prefix is string
+      - backup_s3_prefix.startswith(inventory_hostname ~ '/')
+    fail_msg: >-
+      backup_s3_prefix ('{{ backup_s3_prefix }}') must start with
+      '{{ inventory_hostname }}/' so this host writes only inside its own
+      fleet prefix. The per-server backup IAM user is scoped to
+      '{{ inventory_hostname }}/*'; a prefix outside it would fail at backup
+      time with AccessDenied (a silent 02:00 gap). Set
+      backup_s3_prefix: "{{ inventory_hostname }}/vol" (the default).
+    quiet: true
+  when: backup_enabled | bool
+  tags: ['backup']
+
 - name: Validate encryption mode
   ansible.builtin.assert:
     that:

--- a/scripts/setup-s3-backup.sh
+++ b/scripts/setup-s3-backup.sh
@@ -1,10 +1,115 @@
 #!/bin/bash
 
-# Setup S3 backup bucket with Object Lock, lifecycle rules, and IAM user
-# Creates a single bucket for both WAL-G database and host-side volume backups
-# Idempotent — safe to re-run if a previous run failed partway through
+# Setup S3 backup bucket with Object Lock, lifecycle rules, and IAM user.
+#
+# ONE bucket is shared by the whole fleet; each server gets its own top-level
+# prefix "<server>/" and its own per-server IAM user "<bucket>-<server>" whose
+# inline policy is scoped to that prefix only (Put/Get on <server>/*, List on
+# the bucket conditioned to s3:prefix=<server>/*, and NO Delete). A compromised
+# server can read/write only its own backups.
+#
+# Usage:
+#   setup-s3-backup.sh                 interactive (prompts for project + server)
+#   setup-s3-backup.sh --server <name> non-interactive server (re-runnable per server)
+#   MIUOPS_PROJECT=<p> MIUOPS_SERVER=<s> setup-s3-backup.sh   fully non-interactive
+#
+# Idempotent — safe to re-run if a previous run failed partway through.
+
+# -- Pure policy generator (sourceable for tests) ----------------------------
+#
+# Emit the per-server inline IAM policy as JSON on stdout.
+#   $1 = bucket name   $2 = server name
+#
+# Shape (AWS-canonical prefix scoping, verified against the S3 user-policy
+# walkthrough):
+#   * s3:ListBucket  is a BUCKET-level action -> Resource is the bare bucket ARN
+#     (no /*), restricted to the server's keyspace via a Condition
+#     StringLike s3:prefix ["<server>/*"]  (StringLike because the value has *).
+#   * s3:PutObject + s3:GetObject are OBJECT-level -> scoped purely by the
+#     Resource ARN suffix /<server>/*  (s3:prefix governs ListBucket ONLY; it is
+#     a no-op on object ops, so the ARN is the real object scope -- do not add it
+#     to the object statement).
+#   * NO s3:DeleteObject and NO s3:* -> immutability by omission (the bucket
+#     Object-Lock backs this up). NO explicit Deny is needed: IAM default-deny
+#     already blocks any cross-prefix (other-server) access.
+gen_iam_policy() {
+    local bucket="$1" server="$2"
+    cat <<EOF
+{
+    "Version": "2012-10-17",
+    "Statement": [
+        {
+            "Sid": "ListOwnPrefixOnly",
+            "Effect": "Allow",
+            "Action": "s3:ListBucket",
+            "Resource": "arn:aws:s3:::${bucket}",
+            "Condition": {
+                "StringLike": {
+                    "s3:prefix": ["${server}/*"]
+                }
+            }
+        },
+        {
+            "Sid": "ReadWriteOwnObjectsOnly",
+            "Effect": "Allow",
+            "Action": [
+                "s3:PutObject",
+                "s3:GetObject"
+            ],
+            "Resource": "arn:aws:s3:::${bucket}/${server}/*"
+        }
+    ]
+}
+EOF
+}
+
+# When sourced as a library (by the oracle test), define the functions above and
+# stop here -- do NOT run the interactive provisioning flow or touch AWS.
+if [ -n "${MIUOPS_S3_SETUP_LIB:-}" ]; then
+    # `return` when sourced; the `exit` is the fallback if run directly with the
+    # flag set (shellcheck can't see the sourced path, hence the directive).
+    # shellcheck disable=SC2317
+    return 0 2>/dev/null || exit 0
+fi
 
 set -e
+
+# -- Argument parsing --------------------------------------------------------
+
+SERVER="${MIUOPS_SERVER:-}"
+PROJECT_NAME="${MIUOPS_PROJECT:-}"
+
+while [[ $# -gt 0 ]]; do
+    case "$1" in
+        --server)
+            SERVER="$2"
+            shift 2
+            ;;
+        --server=*)
+            SERVER="${1#*=}"
+            shift
+            ;;
+        --project)
+            PROJECT_NAME="$2"
+            shift 2
+            ;;
+        --project=*)
+            PROJECT_NAME="${1#*=}"
+            shift
+            ;;
+        -h | --help)
+            echo "Usage: $0 [--project <name>] [--server <name>]"
+            echo "  --project <name>  fleet/bucket prefix (bucket = <name>-backup)"
+            echo "  --server <name>   per-server identity (IAM user + S3 prefix)"
+            echo "Env: MIUOPS_PROJECT, MIUOPS_SERVER mirror the flags."
+            exit 0
+            ;;
+        *)
+            echo "Error: unknown argument '$1' (try --help)."
+            exit 1
+            ;;
+    esac
+done
 
 # -- Prerequisite checks -----------------------------------------------------
 
@@ -38,23 +143,51 @@ echo "        S3 Backup Bucket Setup                "
 echo "=============================================="
 echo ""
 
-read -rp "Enter project name (used as bucket prefix, e.g. myproject): " PROJECT_NAME
+if [[ -z "$PROJECT_NAME" ]]; then
+    read -rp "Enter project name (used as bucket prefix, e.g. myproject): " PROJECT_NAME
+fi
 
 if [[ -z "$PROJECT_NAME" ]]; then
     echo "Error: Project name cannot be empty."
     exit 1
 fi
 
+if [[ -z "$SERVER" ]]; then
+    read -rp "Enter server name (per-server IAM user + S3 prefix, e.g. web1): " SERVER
+fi
+
+if [[ -z "$SERVER" ]]; then
+    echo "Error: Server name cannot be empty."
+    echo "One bucket is shared by the fleet; each server has its own prefix + IAM user."
+    exit 1
+fi
+
+# Fail-closed: validate both identifiers BEFORE they are interpolated into the IAM
+# policy JSON, AWS CLI arguments, the S3 prefix, and the IAM user name. A crafted
+# value (quotes, spaces, '..', shell/JSON metachars) must be rejected here, never
+# relied on being blocked incidentally by AWS's own naming rules.
+if [[ ! "$PROJECT_NAME" =~ ^[a-z0-9][a-z0-9-]*$ ]]; then
+    echo "Error: invalid project name '${PROJECT_NAME}' — use lowercase letters, digits, hyphens (the S3 bucket charset)."
+    exit 1
+fi
+if [[ ! "$SERVER" =~ ^[A-Za-z0-9][A-Za-z0-9._-]*$ ]]; then
+    echo "Error: invalid server name '${SERVER}' — use letters, digits, dot, dash, underscore (the inventory_hostname charset)."
+    exit 1
+fi
+
 BUCKET_NAME="${PROJECT_NAME}-backup"
-IAM_USER="${PROJECT_NAME}-backup"
+# Per-server IAM user: "<bucket>-<server>". Each server gets its own user + key
+# pair scoped to its own "<server>/" prefix only.
+IAM_USER="${BUCKET_NAME}-${SERVER}"
 
 read -rp "Enter AWS region [us-west-2]: " AWS_REGION
 AWS_REGION=${AWS_REGION:-us-west-2}
 
 echo ""
-echo "This will create:"
-echo "  - S3 bucket:  $BUCKET_NAME (region: $AWS_REGION)"
-echo "  - IAM user:   $IAM_USER (Put/Get/List only — no Delete)"
+echo "This will create / reuse:"
+echo "  - S3 bucket:  $BUCKET_NAME (region: $AWS_REGION) — shared by the fleet"
+echo "  - IAM user:   $IAM_USER (Put/Get/List on '${SERVER}/*' only — no Delete)"
+echo "  - S3 prefix:  ${SERVER}/  (this server's keyspace)"
 echo "  - Object Lock: Governance mode, 30-day retention"
 echo "  - Lifecycle:   Glacier after 30 days, expire after 90 days"
 echo ""
@@ -201,26 +334,7 @@ fi
 echo ""
 echo "--- Attaching backup policy ---"
 
-POLICY_DOCUMENT=$(cat <<EOF
-{
-    "Version": "2012-10-17",
-    "Statement": [
-        {
-            "Effect": "Allow",
-            "Action": [
-                "s3:PutObject",
-                "s3:GetObject",
-                "s3:ListBucket"
-            ],
-            "Resource": [
-                "arn:aws:s3:::${BUCKET_NAME}",
-                "arn:aws:s3:::${BUCKET_NAME}/*"
-            ]
-        }
-    ]
-}
-EOF
-)
+POLICY_DOCUMENT="$(gen_iam_policy "$BUCKET_NAME" "$SERVER")"
 
 aws iam put-user-policy \
     --user-name "$IAM_USER" \
@@ -256,7 +370,9 @@ echo "=============================================="
 echo ""
 echo "Bucket:          $BUCKET_NAME"
 echo "Region:          $AWS_REGION"
-echo "IAM User:        $IAM_USER"
+echo "Server:          $SERVER"
+echo "S3 prefix:       ${SERVER}/  (this server's keyspace)"
+echo "IAM User:        $IAM_USER  (scoped to '${SERVER}/*' — no Delete)"
 echo "Access Key ID:   $ACCESS_KEY_ID"
 echo "Secret Key:      $SECRET_ACCESS_KEY"
 echo ""
@@ -270,26 +386,27 @@ echo "export AWS_ACCESS_KEY_ID=$ACCESS_KEY_ID"
 echo "export AWS_SECRET_ACCESS_KEY=$SECRET_ACCESS_KEY"
 echo "export AWS_REGION=$AWS_REGION"
 echo ""
-echo "# Then in host_vars/<host>.yml:"
+echo "# Then in host_vars/${SERVER}.yml:"
 echo "#   backup_enabled: true"
 echo "#   backup_s3_bucket: \"$BUCKET_NAME\""
-echo "#   backup_s3_prefix: \"vol\""
+echo "#   backup_s3_prefix: \"${SERVER}/vol\"   # default already derives this from inventory_hostname"
 echo "#   backup_volumes: [ { name: <volume>, stop: [<container>] }, ... ]"
 echo ""
 echo "# WAL-G database backup still reads these from the server's .env"
-echo "# (/opt/stacks/.env), per stack:"
+echo "# (/opt/stacks/.env), per stack. Keep the '${SERVER}/' root so this"
+echo "# server's scoped IAM user is authorized to write it:"
 echo "#   AWS_ACCESS_KEY_ID=$ACCESS_KEY_ID"
 echo "#   AWS_SECRET_ACCESS_KEY=$SECRET_ACCESS_KEY"
 echo "#   AWS_REGION=$AWS_REGION"
-echo "#   WALG_S3_PREFIX=s3://${BUCKET_NAME}/db/<app-name>"
+echo "#   WALG_S3_PREFIX=s3://${BUCKET_NAME}/${SERVER}/db/<app-name>"
 echo ""
 echo "=============================================="
 echo "        Next Steps                            "
 echo "=============================================="
 echo ""
 echo "1. Configure + apply the volume backup role (see roles/backup/README.md):"
-echo "   set backup_* in host_vars/<host>.yml, export the AWS creds above, then"
-echo "   ./miuops apply <host>"
+echo "   set backup_* in host_vars/${SERVER}.yml, export the AWS creds above, then"
+echo "   ./miuops apply ${SERVER}"
 echo "2. For PostgreSQL, add the .env values above to /opt/stacks/.env and use"
 echo "   the pre-built postgres-walg image in your compose file:"
 echo "   image: ghcr.io/tianshanghong/postgres-walg:17"

--- a/scripts/test/iam-policy-oracle.sh
+++ b/scripts/test/iam-policy-oracle.sh
@@ -1,0 +1,192 @@
+#!/usr/bin/env bash
+#
+# Oracle for the per-server backup IAM policy emitted by scripts/setup-s3-backup.sh.
+#
+# It GENERATES the inline policy for a sample bucket + server (by sourcing the
+# setup script and calling its gen_iam_policy function), then asserts the exact
+# prefix-scoped, Allow-only shape required by the fleet contract:
+#
+#   * s3:ListBucket  -> Resource arn:aws:s3:::<bucket>  (bucket-level, no /*)
+#                       Condition StringLike s3:prefix == ["<server>/*"]
+#   * s3:PutObject + s3:GetObject (and ONLY those) -> Resource
+#                       arn:aws:s3:::<bucket>/<server>/*  (object-level)
+#   * NO s3:DeleteObject anywhere
+#   * NO "s3:*" wildcard anywhere
+#   * NO Deny statement anywhere
+#   * POSITIVE control: an own-prefix PutObject resource is present.
+#
+# Every assertion is paired with a negative fixture (a deliberately-bad policy)
+# proving it can FAIL, so a green run is meaningful. Pure structural checks via
+# jq; no AWS calls, so it runs in CI with no credentials.
+#
+# Exit 0 = all assertions held (and every negative fixture genuinely failed).
+# Exit 1 = a contract assertion failed (or a negative fixture did NOT fail).
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+SETUP_SCRIPT="${SCRIPT_DIR}/../setup-s3-backup.sh"
+
+command -v jq >/dev/null 2>&1 || { echo "FATAL: jq is required" >&2; exit 2; }
+[ -f "$SETUP_SCRIPT" ] || { echo "FATAL: setup script not found at $SETUP_SCRIPT" >&2; exit 2; }
+
+# Source the setup script in "library" mode: it must define gen_iam_policy and
+# return WITHOUT running the interactive bucket/IAM flow.
+# shellcheck source=/dev/null
+MIUOPS_S3_SETUP_LIB=1 . "$SETUP_SCRIPT"
+
+if ! declare -F gen_iam_policy >/dev/null 2>&1; then
+  echo "FATAL: setup-s3-backup.sh did not define gen_iam_policy (library mode)" >&2
+  exit 2
+fi
+
+SAMPLE_BUCKET="myfleet-backup"
+SAMPLE_SERVER="web1"
+OTHER_SERVER="web2"
+
+POLICY="$(gen_iam_policy "$SAMPLE_BUCKET" "$SAMPLE_SERVER")"
+
+# --- tiny assert harness ----------------------------------------------------
+pass=0
+fail=0
+ok()   { printf 'ok   - %s\n' "$1"; pass=$((pass + 1)); }
+bad()  { printf 'FAIL - %s\n' "$1"; fail=$((fail + 1)); }
+
+# assert_eq <description> <actual> <expected>
+assert_eq() {
+  if [ "$2" = "$3" ]; then ok "$1 (= '$3')"; else bad "$1: got '$2' expected '$3'"; fi
+}
+# assert_true_jq <description> <policy-json> <jq-filter-that-should-exit-0>
+assert_true_jq() {
+  if printf '%s' "$2" | jq -e "$3" >/dev/null 2>&1; then ok "$1"; else bad "$1"; fi
+}
+# assert_false_jq <description> <policy-json> <jq-filter-that-should-exit-NONZERO>
+assert_false_jq() {
+  if printf '%s' "$2" | jq -e "$3" >/dev/null 2>&1; then bad "$1 (filter unexpectedly matched)"; else ok "$1"; fi
+}
+
+# jq filters (reused for real policy AND bad fixtures so each can FAIL) --------
+F_VALID_JSON='type=="object"'
+F_OBJ_RESOURCE='[.Statement[]|select(.Action|tostring|test("PutObject"))|.Resource]|flatten|.[0]'
+F_LIST_RESOURCE='[.Statement[]|select((.Action|tostring)=="s3:ListBucket")|.Resource]|flatten|.[0]'
+F_LIST_PREFIX='[.Statement[]|select((.Action|tostring)=="s3:ListBucket")|.Condition.StringLike."s3:prefix"]|flatten|.[0]'
+# object actions, sorted+uniqued, must be EXACTLY [GetObject, PutObject]
+F_OBJ_ACTIONS_EXACT='([.Statement[]|select(.Resource|tostring|test("/'"$SAMPLE_SERVER"'/\\*"))|.Action]|flatten|sort|unique)==["s3:GetObject","s3:PutObject"]'
+# Pattern-based so variant/wildcard forms (s3:Delete*, s3:*Object, s3:DeleteObjectVersion,
+# s3:*) are caught across ALL statements, not only the exact "s3:DeleteObject"/"s3:*" strings.
+F_HAS_DELETE='[.Statement[].Action]|flatten|any(ascii_downcase|test("delete"))'
+F_HAS_WILDCARD='[.Statement[].Action]|flatten|any(test("[*]"))'
+# Strongest guard: the COMPLETE set of actions must be a subset of the three allowed ones,
+# so ANY unexpected action (a delete, a wildcard, a new grant) trips it.
+F_ACTIONS_SUBSET='(([.Statement[].Action]|flatten|unique)-["s3:GetObject","s3:ListBucket","s3:PutObject"])|length==0'
+F_HAS_DENY='[.Statement[].Effect]|any(.=="Deny")'
+F_HAS_OWN_PUT='[.Statement[]|select(.Resource|tostring|test("/'"$SAMPLE_SERVER"'/\\*"))|.Action]|flatten|any(.=="s3:PutObject")'
+
+echo "== generated policy for bucket=$SAMPLE_BUCKET server=$SAMPLE_SERVER =="
+printf '%s\n' "$POLICY"
+echo "== assertions =="
+
+# 1. valid, parseable IAM JSON
+assert_true_jq "policy is valid parseable JSON object" "$POLICY" "$F_VALID_JSON"
+
+# 2. object actions scoped to own prefix ARN
+assert_eq "object Resource is own-prefix ARN" \
+  "$(printf '%s' "$POLICY" | jq -r "$F_OBJ_RESOURCE")" \
+  "arn:aws:s3:::${SAMPLE_BUCKET}/${SAMPLE_SERVER}/*"
+
+# 3. object actions are EXACTLY PutObject + GetObject (no more)
+assert_true_jq "object actions are exactly Put+Get" "$POLICY" "$F_OBJ_ACTIONS_EXACT"
+
+# 4. ListBucket is bucket-level (no /*)
+assert_eq "ListBucket Resource is bare bucket ARN" \
+  "$(printf '%s' "$POLICY" | jq -r "$F_LIST_RESOURCE")" \
+  "arn:aws:s3:::${SAMPLE_BUCKET}"
+
+# 5. ListBucket prefix Condition is StringLike "<server>/*"
+assert_eq "ListBucket Condition s3:prefix == <server>/*" \
+  "$(printf '%s' "$POLICY" | jq -r "$F_LIST_PREFIX")" \
+  "${SAMPLE_SERVER}/*"
+
+# 6. NO DeleteObject
+assert_false_jq "no s3:DeleteObject anywhere" "$POLICY" "$F_HAS_DELETE"
+
+# 7. NO s3:* wildcard (any form)
+assert_false_jq "no s3:* wildcard anywhere" "$POLICY" "$F_HAS_WILDCARD"
+
+# 7b. STRONGEST: every action is within {ListBucket, GetObject, PutObject} — catches any
+# extra/variant grant (e.g. s3:Delete*, s3:*Object) that the specific guards above might miss.
+assert_true_jq "all actions are within the allowed set" "$POLICY" "$F_ACTIONS_SUBSET"
+
+# 8. NO Deny statement
+assert_false_jq "no Deny statement anywhere" "$POLICY" "$F_HAS_DENY"
+
+# 9. POSITIVE control: own-prefix PutObject resource present
+assert_true_jq "POSITIVE: own-prefix PutObject is present" "$POLICY" "$F_HAS_OWN_PUT"
+
+# 10. cross-server isolation: the OTHER server's prefix is NOT writable by this policy
+assert_false_jq "no other-server (${OTHER_SERVER}/*) object resource" "$POLICY" \
+  '[.Statement[]|select(.Resource|tostring|test("/'"$OTHER_SERVER"'/\\*"))]|length>0'
+
+# --- negative fixtures: prove each assertion CAN fail ------------------------
+# A bad policy that regressed to bucket-wide + added Delete + a Deny + s3:*.
+# Running the SAME filters against it must flip every result; if any of these
+# "negative" checks passes against the bad fixture, the oracle itself is broken.
+echo "== negative fixtures (each must trip the matching assertion) =="
+BAD_POLICY=$(cat <<EOF
+{
+  "Version": "2012-10-17",
+  "Statement": [
+    { "Effect": "Allow", "Action": "s3:ListBucket", "Resource": "arn:aws:s3:::${SAMPLE_BUCKET}/*" },
+    { "Effect": "Allow", "Action": ["s3:PutObject","s3:GetObject","s3:DeleteObject","s3:*"],
+      "Resource": "arn:aws:s3:::${SAMPLE_BUCKET}/*" },
+    { "Effect": "Deny", "Action": "s3:GetObject", "Resource": "arn:aws:s3:::${SAMPLE_BUCKET}/${OTHER_SERVER}/*" }
+  ]
+}
+EOF
+)
+
+neg_ok=0
+neg_bad=0
+# neg_expect_true  <desc> <cmd...>   : cmd MUST succeed against the bad fixture.
+# neg_expect_false <desc> <cmd...>   : cmd MUST fail   against the bad fixture.
+neg_expect_true() {
+  local desc="$1"; shift
+  if "$@" >/dev/null 2>&1; then echo "ok   - $desc"; neg_ok=$((neg_ok + 1))
+  else echo "FAIL - $desc (expected to detect, did not)"; neg_bad=$((neg_bad + 1)); fi
+}
+neg_expect_false() {
+  local desc="$1"; shift
+  if "$@" >/dev/null 2>&1; then echo "FAIL - $desc (unexpected match)"; neg_bad=$((neg_bad + 1))
+  else echo "ok   - $desc"; neg_ok=$((neg_ok + 1)); fi
+}
+# Invoked indirectly via neg_expect_* (passed as "$@"); shellcheck can't see that.
+# shellcheck disable=SC2329
+jq_on_bad() { printf '%s' "$BAD_POLICY" | jq -e "$1"; }
+
+# For the bad policy: the object Resource is bucket-wide (so the own-prefix ARN
+# filter must NOT find it), delete/wildcard/deny filters MUST match, and the
+# prefix Condition is absent.
+neg_expect_false "bad fixture: object Resource is NOT own-prefix" \
+  jq_on_bad "$F_OBJ_RESOURCE|tostring==\"arn:aws:s3:::${SAMPLE_BUCKET}/${SAMPLE_SERVER}/*\""
+neg_expect_true  "bad fixture: DeleteObject detected"        jq_on_bad "$F_HAS_DELETE"
+neg_expect_true  "bad fixture: s3:* detected"                jq_on_bad "$F_HAS_WILDCARD"
+neg_expect_true  "bad fixture: Deny detected"                jq_on_bad "$F_HAS_DENY"
+neg_expect_false "bad fixture: missing prefix Condition"     jq_on_bad "$F_LIST_PREFIX|tostring!=\"null\""
+# The four assertions that previously lacked a negative fixture (3, 4, 7b, 9, 10):
+neg_expect_false "bad fixture: object actions NOT exactly Put+Get"     jq_on_bad "$F_OBJ_ACTIONS_EXACT"
+neg_expect_false "bad fixture: ListBucket Resource NOT bare bucket"    jq_on_bad "$F_LIST_RESOURCE|tostring==\"arn:aws:s3:::${SAMPLE_BUCKET}\""
+neg_expect_true  "bad fixture: actions escape the allowed set"         jq_on_bad "($F_ACTIONS_SUBSET)|not"
+neg_expect_false "bad fixture: own-prefix PutObject absent"            jq_on_bad "$F_HAS_OWN_PUT"
+neg_expect_true  "bad fixture: other-server (${OTHER_SERVER}/*) resource present" \
+  jq_on_bad "[.Statement[]|select(.Resource|tostring|test(\"/${OTHER_SERVER}/[*]\"))]|length>0"
+
+# --- summary ----------------------------------------------------------------
+echo "== summary =="
+echo "positive assertions: ${pass} ok, ${fail} fail"
+echo "negative fixtures:   ${neg_ok} ok, ${neg_bad} fail"
+if [ "$fail" -ne 0 ] || [ "$neg_bad" -ne 0 ]; then
+  echo "ORACLE: FAIL"
+  exit 1
+fi
+echo "ORACLE: PASS"
+exit 0


### PR DESCRIPTION
## What

Fleet backups share **one** S3 bucket, isolated by a per-server prefix (`<server>/…`),
with a per-server IAM user whose policy is scoped to **only** that prefix.

- `scripts/setup-s3-backup.sh --server <handle>` creates/reuses the shared bucket and a
  per-server IAM user `<bucket>-<server>` whose inline policy allows `ListBucket` (scoped
  via an `s3:prefix` condition) and `GetObject`+`PutObject` on `<bucket>/<server>/*` **only**
  — no `Delete`, no wildcards, no cross-prefix access. The server handle is validated
  fail-closed.
- `roles/backup` writes under the per-server prefix (`backup_s3_prefix` defaults to
  `<inventory_hostname>/vol`).

## Why prefix + scoped IAM

One bucket keeps operations simple; the per-server prefix plus a deny-by-omission policy
means a compromised server's key can read/write **only its own** prefix — it cannot reach
or delete another server's backups.

## Testing

`scripts/test/iam-policy-oracle.sh` sources `gen_iam_policy` from the setup script and
asserts the emitted policy with `jq`: **11 positive** assertions + **10 negative** fixtures
(wildcard-`Delete`, cross-prefix `Deny`, over-broad actions, and a bare-bucket object
resource are all rejected; object actions are exactly `{GetObject, PutObject}` and the
action set ⊆ `{ListBucket, GetObject, PutObject}`). Wired into CI; `shellcheck -S error`
clean on both the setup script and the oracle.