### PR TITLE
feat(secrets): encrypt fleet tunnel creds + app .env with SOPS+age

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -26,12 +26,26 @@ jobs:
           shellcheck -S error miuops tests/stack_policy_check_test.sh \
             .github/scripts/discover-changed-servers.sh .github/scripts/deploy-server.sh \
             tests/ssh_deploy_key_validation_test.sh \
-            scripts/test/iam-policy-oracle.sh scripts/setup-s3-backup.sh
+            scripts/test/iam-policy-oracle.sh scripts/setup-s3-backup.sh \
+            tests/sops_test.sh
           bash tests/cli_test.sh
           bash tests/discover_changed_servers_test.sh
           bash tests/deploy_workflow_lint_test.sh
           bash tests/ssh_deploy_key_validation_test.sh
           bash scripts/test/iam-policy-oracle.sh
+
+      - name: SOPS + age secret oracle (self-contained round-trip + tamper)
+        # The oracle generates a throwaway age key and a temp .sops.yaml — no
+        # repo key is used and CI never decrypts real secrets. It proves the
+        # encrypt/decrypt round-trip, that a tampered ciphertext fails closed,
+        # and that the CLI's sops helpers behave (require_sops, 0600 provisioning).
+        run: |
+          command -v sops >/dev/null 2>&1 || {
+            curl -fsSL -o /tmp/sops https://github.com/getsops/sops/releases/download/v3.13.1/sops-v3.13.1.linux.amd64
+            sudo install -m 0755 /tmp/sops /usr/local/bin/sops
+          }
+          command -v age-keygen >/dev/null 2>&1 || sudo apt-get install -y age >/dev/null
+          bash tests/sops_test.sh
 
       - name: Install Ansible
         run: pip install ansible

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -34,8 +34,8 @@ jobs:
           bash tests/ssh_deploy_key_validation_test.sh
           bash scripts/test/iam-policy-oracle.sh
 
-      - name: SOPS + age secret oracle (self-contained round-trip + tamper)
-        # The oracle generates a throwaway age key and a temp .sops.yaml — no
+      - name: SOPS + age secret check (self-contained round-trip + tamper)
+        # The check generates a throwaway age key and a temp .sops.yaml — no
         # repo key is used and CI never decrypts real secrets. It proves the
         # encrypt/decrypt round-trip, that a tampered ciphertext fails closed,
         # and that the CLI's sops helpers behave (require_sops, 0600 provisioning).

--- a/docs/SOPS_SECRETS.md
+++ b/docs/SOPS_SECRETS.md
@@ -1,0 +1,183 @@
+# Secrets with SOPS + age
+
+miuops encrypts the secrets your fleet needs — the Cloudflare Tunnel credential
+and each server's application `.env` — with [SOPS](https://github.com/getsops/sops)
+and [age](https://github.com/FiloSottile/age). The ciphertext is safe to commit
+to your fleet repo under `fleet/secrets/`; the matching age **private key** lives
+only on your machine (or a YubiKey) and **never** enters CI.
+
+## Why
+
+- **Plaintext credentials never hit git.** The tunnel credential JSON and the app
+  `.env` are committed encrypted. A repo leak yields ciphertext, not secrets.
+- **All decryption is local.** miuops decrypts on your machine (the control node)
+  to a private temp file, hands the plaintext to Ansible over SSH, and shreds the
+  temp file. The server receives the plaintext over the SSH connection exactly as
+  before — only the *source* moved from a committed plaintext file to a locally
+  decrypted one.
+- **CI has no key.** The deploy/CI environment holds no age identity, so it
+  *cannot* decrypt `fleet/secrets/`. Tamper protection is built in: any change to
+  a ciphertext byte makes `sops -d` fail closed (MAC mismatch), so a corrupted or
+  altered secret is rejected rather than silently used.
+
+## Install the tools
+
+```bash
+# macOS
+brew install sops age
+
+# Linux: install the sops binary from the releases page, plus age:
+#   https://github.com/getsops/sops/releases
+sudo apt install age      # or build age from source
+```
+
+The miuops CLI requires `sops` (it runs a prereq check) and uses an age identity
+for decryption.
+
+## Generate an age key
+
+A software key — keep the private half off every server:
+
+```bash
+# Default location SOPS looks in (Linux):
+mkdir -p ~/.config/sops/age
+age-keygen -o ~/.config/sops/age/keys.txt
+# macOS default:
+#   ~/Library/Application Support/sops/age/keys.txt
+```
+
+`age-keygen` prints the **public** recipient (`age1...`); the file holds the
+private key. Store a copy somewhere safe (password manager / offline media) — if
+you lose the only identity that can decrypt a secret, that secret is
+unrecoverable.
+
+Derive the recipient again at any time:
+
+```bash
+age-keygen -y ~/.config/sops/age/keys.txt   # -> age1...
+```
+
+### YubiKey (hardware-backed identity)
+
+A YubiKey works with **no CLI change** — the identity is owned entirely by the
+SOPS env, and a software key file and a YubiKey identity are interchangeable.
+
+```bash
+age-plugin-yubikey            # interactive: create an identity on the key
+age-plugin-yubikey --list     # prints the recipient: age1yubikey1...
+```
+
+Put the recipient in `.sops.yaml` (below). Decryption later requires the YubiKey
+plugged in (touch/PIN) and `age-plugin-yubikey` on `PATH`. The miuops preflight
+*warns* (does not fail) when no software identity is found, because a YubiKey
+resolves only at touch time.
+
+## Where the key is resolved
+
+miuops sets **nothing** — it inherits your environment, and SOPS resolves the age
+identity in this order:
+
+1. `SOPS_AGE_KEY` — a literal `AGE-SECRET-KEY-1...` in the environment
+2. `SOPS_AGE_KEY_FILE` — a path to an identity file (overrides the default)
+3. the default file: `~/.config/sops/age/keys.txt` (Linux) /
+   `~/Library/Application Support/sops/age/keys.txt` (macOS)
+
+So a `keys.txt` holding either a software key or an `AGE-PLUGIN-YUBIKEY-...` line
+both work the same way.
+
+## `.sops.yaml` (lives at the fleet repo root)
+
+The fleet template ships `.sops.yaml` at the **root** of the fleet repo (the
+parent of `fleet/`). It names the recipient(s) your secrets are encrypted to and
+matches everything under `fleet/secrets/`:
+
+```yaml
+creation_rules:
+  # Tunnel credential JSON and app .env under fleet/secrets/.
+  - path_regex: ^fleet/secrets/.*\.(json|env)$
+    age: age1youroperatorrecipientxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx
+```
+
+Add more recipients (comma-separated, or one per `age:` list entry) for a
+backup/teammate/break-glass key — any **one** matching identity can then decrypt.
+A YubiKey recipient is just `age1yubikey1...` in the same spot.
+
+miuops always invokes `sops` with the working directory set to this repo root and
+passes repo-relative paths (`fleet/secrets/<file>`), so the `path_regex` above
+matches.
+
+## What miuops encrypts, and when
+
+- **`miuops up`** creates the tunnel, then encrypts its credential **in place**
+  into `fleet/secrets/<tunnel_id>.json`:
+
+  ```bash
+  sops --encrypt --input-type json --output-type json --in-place \
+      fleet/secrets/<tunnel_id>.json
+  ```
+
+  Commit the resulting ciphertext.
+
+- **At converge** (`up` / `apply`), miuops decrypts `fleet/secrets/<tunnel_id>.json`
+  to a private `0600` temp file and passes its path to Ansible via
+  `cloudflared_credentials_src`; the `cloudflared` role copies it to the server at
+  `0600` (`no_log`). When that variable is empty the role falls back to the legacy
+  plaintext `files/<tunnel_id>.json` for backward compatibility.
+
+- **The app `.env`** — if `fleet/secrets/<server>.env` exists, miuops decrypts it
+  locally and provisions it to the host's `/opt/stacks/.env` at mode `0600`
+  (root). Encrypt one yourself with:
+
+  ```bash
+  cp my.env fleet/secrets/<server>.env
+  sops --encrypt --input-type dotenv --output-type dotenv --in-place \
+      fleet/secrets/<server>.env
+  ```
+
+  SOPS encrypts only the **values** in a `.env`, so a `git diff` still shows which
+  keys changed without leaking their values.
+
+## Verify it works — round-trip and tamper
+
+Run from the fleet repo root (so `.sops.yaml` applies). These are the same checks
+the project's oracle automates.
+
+**Round-trip** (a secret encrypts, hides its value, and decrypts back):
+
+```bash
+# JSON tunnel credential
+sops --decrypt fleet/secrets/<tunnel_id>.json | jq -e '.TunnelID and .TunnelSecret'
+
+# app .env (value is encrypted on disk, decrypts to the original)
+grep -q '^FOO=secret$' fleet/secrets/<server>.env && echo "LEAK: value in plaintext"
+sops --decrypt --output-type dotenv fleet/secrets/<server>.env | grep '^FOO='
+```
+
+**Tamper fails closed** (a single flipped ciphertext byte is rejected). Flip one
+base64 character inside the `"mac"` field of an encrypted JSON, then:
+
+```bash
+sops --decrypt fleet/secrets/<tunnel_id>.json ; echo "exit=$?"
+# -> non-zero exit (51, MacMismatch); stderr mentions "MAC"; NO plaintext emitted.
+```
+
+A clean (un-tampered) file decrypts with exit `0`, so the check genuinely
+distinguishes good from tampered ciphertext.
+
+## CI never decrypts
+
+The deploy/CI environment must have **no** age identity (no `SOPS_AGE_KEY*`, no
+`keys.txt`, no YubiKey). Decryption there fails by design — secrets are only ever
+decrypted on an operator's machine. Never add the age private key to CI secrets.
+
+## Never commit plaintext
+
+- Commit only the **encrypted** files under `fleet/secrets/` (every committed
+  secret contains the `sops` metadata marker).
+- The temp file miuops decrypts to is `0600` and shredded after converge — do not
+  copy it into the repo.
+- A quick guard: every committed secret should contain `sops` metadata.
+
+  ```bash
+  git -C <fleet-repo> grep -L sops -- 'fleet/secrets/*' && echo "UNENCRYPTED above"
+  ```

--- a/docs/SOPS_SECRETS.md
+++ b/docs/SOPS_SECRETS.md
@@ -140,7 +140,7 @@ matches.
 ## Verify it works — round-trip and tamper
 
 Run from the fleet repo root (so `.sops.yaml` applies). These are the same checks
-the project's oracle automates.
+the project's tests automate.
 
 **Round-trip** (a secret encrypts, hides its value, and decrypts back):
 

--- a/miuops
+++ b/miuops
@@ -9,6 +9,22 @@ SCRIPT_DIR="${MIUOPS_TEST_SCRIPT_DIR:-$(cd "$(dirname "$0")" && pwd)}"
 # (run_apply additionally refuses to converge if the tool checkout still holds host_vars/
 # that Ansible would load at higher precedence than the fleet's.)
 FLEET_DIR="${MIUOPS_FLEET_DIR:-$(pwd)/fleet}"
+# Encrypted secrets (SOPS+age) live under fleet/secrets/. The repo's .sops.yaml
+# (shipped by the fleet template, not by us) sits at the fleet repo ROOT — the
+# parent of FLEET_DIR — and matches '^fleet/secrets/.*\.(json|env)$'. So we always
+# invoke sops with cwd = that ROOT and pass repo-relative 'fleet/secrets/<file>'.
+SECRETS_DIR="${FLEET_DIR}/secrets"
+FLEET_ROOT="$(dirname "$FLEET_DIR")"
+
+# Decrypted plaintext secrets live only in 0600 temp files; shred ALL of them on
+# ANY exit. A per-function RETURN trap does NOT fire when the script exits via die
+# or set -e (a failed converge would otherwise leave the cleartext credential on
+# disk), so every sops temp is registered here and one trap cleans them up.
+_SOPS_TMPS=()
+_sops_cleanup() { [ "${#_SOPS_TMPS[@]}" -gt 0 ] && rm -f "${_SOPS_TMPS[@]}"; return 0; }
+# The trap is armed INSIDE run_apply / sops_provision_env (the only functions that
+# create plaintext temps), NOT at top level — so sourcing the CLI (--source-only,
+# e.g. from a test) does not clobber the sourcer's own EXIT trap.
 
 RED='\033[0;31m'
 GREEN='\033[0;32m'
@@ -42,6 +58,106 @@ valid_domain() { local re='^[a-zA-Z0-9]([a-zA-Z0-9.-]*[a-zA-Z0-9])?\.[a-zA-Z]{2,
 valid_host_alias() { local re='^[A-Za-z0-9._-]+$'; [[ "$1" =~ $re ]]; }
 # Lowercase a domain (DNS is case-insensitive; portable — bash 3.2 lacks ${,,}).
 lc() { echo "$1" | tr '[:upper:]' '[:lower:]'; }
+
+# ── SOPS + age secret helpers ───────────────────────────────────────
+# All SOPS work is LOCAL (operator machine). The age identity is owned entirely
+# by the SOPS env (SOPS_AGE_KEY / SOPS_AGE_KEY_FILE / default keys.txt) — the CLI
+# sets NOTHING and inherits the operator env, so a software age key and an
+# age-plugin-yubikey identity are interchangeable. Plaintext only ever exists in
+# a private temp file (or stdin); it is never committed and never reaches CI.
+
+# Prereq: sops must be on PATH. Fail closed (die) — no secret op can proceed.
+require_sops() {
+    command -v sops >/dev/null 2>&1 || die "sops not found
+  macOS:  brew install sops age
+  Linux:  see https://github.com/getsops/sops/releases (and 'age' for the key)
+  SOPS encrypts tunnel credentials + the app .env into fleet/secrets/."
+    # The .sops.yaml creation_rules use path_regex ^fleet/secrets/..., resolved with
+    # cwd = the fleet repo root, so they only match when the fleet dir is named 'fleet'.
+    [[ "$(basename "$FLEET_DIR")" == "fleet" ]] \
+        || die "MIUOPS_FLEET_DIR must end in '/fleet' (got '$(basename "$FLEET_DIR")') — the SOPS .sops.yaml path_regex expects fleet/secrets/<…>."
+}
+
+# Warn (never die) when no age identity is resolvable. A YubiKey-only setup
+# resolves at touch time, so absence here is informational, not fatal.
+sops_age_default_keys() {
+    # SOPS's default identity file location (XDG on Linux, App Support on macOS).
+    if [[ "$(uname -s)" == "Darwin" ]]; then
+        echo "$HOME/Library/Application Support/sops/age/keys.txt"
+    else
+        echo "${XDG_CONFIG_HOME:-$HOME/.config}/sops/age/keys.txt"
+    fi
+}
+warn_no_age_identity() {
+    [[ -n "${SOPS_AGE_KEY:-}${SOPS_AGE_KEY_FILE:-}" || -f "$(sops_age_default_keys)" ]] && return 0
+    warn "no age identity found (SOPS_AGE_KEY / SOPS_AGE_KEY_FILE / $(sops_age_default_keys)).
+  SOPS decryption will fail unless a YubiKey (age-plugin-yubikey) resolves at touch time.
+  Generate one: see docs/SOPS_SECRETS.md."
+}
+
+# Decrypt a fleet/secrets/<file> to a private 0600 temp file; echo its path.
+# Caller is responsible for shredding the temp file (trap). sops runs with cwd =
+# the fleet repo ROOT so the repo's .sops.yaml applies; path is repo-relative.
+sops_decrypt_to_tmp() {  # $1 = absolute path under SECRETS_DIR
+    local enc="$1" rel tmp
+    [[ -f "$enc" ]] || die "Encrypted secret not found: ${enc}"
+    rel="${enc#"${FLEET_ROOT}"/}"
+    tmp="$(mktemp "${TMPDIR:-/tmp}/miuops.XXXXXX")" || die "mktemp failed"
+    chmod 600 "$tmp"
+    if ! ( cd "$FLEET_ROOT" && sops --decrypt "$rel" ) > "$tmp" 2>/dev/null; then
+        rm -f "$tmp"
+        die "sops decrypt failed for ${enc}
+  - Is an age identity available? (SOPS_AGE_KEY_FILE / default keys.txt / YubiKey plugged in)
+  - Is fleet/secrets present and committed encrypted? (see docs/SOPS_SECRETS.md)"
+    fi
+    printf '%s' "$tmp"
+}
+
+# Encrypt the freshly-created tunnel credential into fleet/secrets/<id>.json,
+# in place, using the recipients from the repo's .sops.yaml. Plaintext stays
+# only in ~/.cloudflared/; the repo only ever receives ciphertext.
+sops_encrypt_tunnel_cred() {  # $1 = tunnel_id
+    # Split the local decls: bash expands ALL `local` initializers before assigning,
+    # so a later var referencing an earlier one in the SAME statement reads the OUTER
+    # (here unset) value -> set -u abort. tid must be its own statement first.
+    local tid="$1"
+    local src="$HOME/.cloudflared/${tid}.json" dst="${SECRETS_DIR}/${tid}.json"
+    [[ -f "$src" ]] || die "Tunnel credential not found at ${src}"
+    mkdir -p "$SECRETS_DIR"; chmod 700 "$SECRETS_DIR"
+    if [[ -f "$dst" ]]; then info "Encrypted tunnel credential already present: ${dst}"; return 0; fi
+    if ! ( cd "$FLEET_ROOT" && cp "$src" "fleet/secrets/${tid}.json" \
+            && sops --encrypt --input-type json --output-type json --in-place "fleet/secrets/${tid}.json" ); then
+        rm -f "$dst"
+        die "sops encrypt failed for ${tid}.json
+  - Is .sops.yaml present at the fleet repo root with an age recipient?
+  - See docs/SOPS_SECRETS.md."
+    fi
+    info "Encrypted tunnel credential -> ${dst} (commit this)"
+}
+
+# The remote command that lands the decrypted .env at /opt/stacks/.env, mode
+# 0600, root-owned, atomically. Kept as a function so the oracle can assert the
+# mode/path without running ssh. install(1) sets the mode in one step.
+sops_env_install_cmd() {
+    echo "umask 077; install -m 0600 /dev/stdin /opt/stacks/.env"
+}
+
+# Decrypt fleet/secrets/<server>.env LOCALLY and push it to the host's
+# /opt/stacks/.env over SSH at 0600 (root). No plaintext is staged on disk
+# beyond the private temp file, which is shredded on return.
+sops_provision_env() {  # $1 = server (host alias)  $2 = ssh_user@host
+    local server="$1" sshtgt="$2"
+    local enc="${SECRETS_DIR}/${server}.env" tmp   # separate decl: enc needs server set first (set -u)
+    trap _sops_cleanup EXIT INT TERM   # shred the decrypted .env temp on exit/die/signal
+    [[ -f "$enc" ]] || { info "No ${server}.env in fleet/secrets — skipping .env provisioning"; return 0; }
+    if $DRY_RUN; then dry "Would provision /opt/stacks/.env on ${server} (0600, from fleet/secrets/${server}.env)"; return 0; fi
+    tmp="$(sops_decrypt_to_tmp "$enc")"
+    _SOPS_TMPS+=("$tmp")   # shredded by the global EXIT/INT/TERM trap, even on die/signal
+    if ! ssh -o BatchMode=yes "$sshtgt" "$(sops_env_install_cmd)" < "$tmp"; then
+        die "Failed to provision /opt/stacks/.env to ${server}"
+    fi
+    info "Provisioned /opt/stacks/.env on ${server} (0600)"
+}
 
 # ── Config helpers (host_vars + inventory) ──────────────────────────
 hv_path() { echo "${FLEET_DIR}/host_vars/$1.yml"; }
@@ -202,6 +318,7 @@ cf_delete_cname() {
 # Ensures Galaxy collections are installed first, so a fresh control machine can
 # run `apply` without having run `up` beforehand.
 run_apply() {
+    trap _sops_cleanup EXIT INT TERM   # shred decrypted secret temps on exit/die/signal
     local host="${1:-}"
     if $NO_APPLY; then info "--no-apply: skipping converge"; return 0; fi
     [[ -f "${FLEET_DIR}/inventory.ini" ]] \
@@ -222,6 +339,23 @@ run_apply() {
     export ANSIBLE_CONFIG="${SCRIPT_DIR}/ansible.cfg"
     local cmd=(ansible-playbook -i "${FLEET_DIR}/inventory.ini" "${SCRIPT_DIR}/playbook.yml")
     [[ -n "$host" ]] && cmd+=(--limit "$host")
+
+    # If a host is targeted and its tunnel credential is committed encrypted under
+    # fleet/secrets/, decrypt it LOCALLY to a private temp file and hand Ansible the
+    # path via cloudflared_credentials_src. The plaintext never enters git/CI and is
+    # shredded when this function returns. The server still just receives the JSON over
+    # SSH (the role copies the path); decryption happens only on this control node.
+    local _cred_tmp=""
+    if [[ -n "$host" ]]; then
+        local _tid; _tid="$(hv_tunnel "$host")"
+        if [[ -n "$_tid" && "$_tid" != "<would-be-created>" && -f "${SECRETS_DIR}/${_tid}.json" ]]; then
+            require_sops
+            _cred_tmp="$(sops_decrypt_to_tmp "${SECRETS_DIR}/${_tid}.json")"
+            _SOPS_TMPS+=("$_cred_tmp")   # shredded by the global EXIT/INT/TERM trap, even on die/signal
+            cmd+=(-e "cloudflared_credentials_src=${_cred_tmp}")
+        fi
+    fi
+
     if $DRY_RUN; then
         dry "Would install Ansible Galaxy requirements"
         dry "Would run: ${cmd[*]}"
@@ -244,6 +378,7 @@ cmd_apply() {
             *)  host="$1"; shift ;;
         esac
     done
+    [[ -z "$host" ]] || valid_host_alias "$host" || die "Invalid host '${host}'"
     run_apply "$host"
 }
 
@@ -367,6 +502,12 @@ cmd_up() {
         || die "jq not found
   macOS:  brew install jq
   Linux:  sudo apt install jq"
+    # sops is required: the tunnel credential is encrypted into fleet/secrets/ at
+    # bootstrap, and the app .env is decrypted locally before provisioning.
+    require_sops
+    # An age identity is needed to decrypt later; warn (not die) here because a
+    # YubiKey-only setup resolves at touch time, not at preflight.
+    warn_no_age_identity
 
     if ! ssh -o ConnectTimeout=5 -o BatchMode=yes -o StrictHostKeyChecking=no \
          "${ssh_user}@${ssh_host}" true 2>/dev/null; then
@@ -503,22 +644,13 @@ ${existing}
         fi
     fi
 
-    # Copy credentials
+    # Encrypt the tunnel credential into fleet/secrets/<tunnel_id>.json (SOPS+age).
+    # The plaintext stays only in ~/.cloudflared/; the repo only ever gets ciphertext,
+    # which is safe to commit. run_apply later decrypts a local copy at converge time.
     if ! $DRY_RUN; then
-        mkdir -p "${SCRIPT_DIR}/files"
-        if [[ ! -f "${SCRIPT_DIR}/files/${tunnel_id}.json" ]]; then
-            if [[ -f ~/.cloudflared/${tunnel_id}.json ]]; then
-                cp ~/.cloudflared/"${tunnel_id}.json" "${SCRIPT_DIR}/files/"
-                chmod 600 "${SCRIPT_DIR}/files/${tunnel_id}.json"
-                info "Tunnel credentials copied"
-            else
-                die "Credentials not found at ~/.cloudflared/${tunnel_id}.json
-  - Did 'cloudflared tunnel create' succeed?
-  - Check ~/.cloudflared/ for JSON files"
-            fi
-        fi
+        sops_encrypt_tunnel_cred "$tunnel_id"
     else
-        dry "Would copy tunnel credentials to files/"
+        dry "Would encrypt tunnel credential to fleet/secrets/${tunnel_id}.json (SOPS+age)"
     fi
 
     # ── Step 4: Create DNS records ───────────────────────────────────
@@ -551,6 +683,14 @@ ${existing}
         inventory_upsert "$ssh_host" "$ssh_host" "$ssh_user"
 
         run_apply "$ssh_host"   # installs Galaxy requirements, then converges
+
+        # Provision the app .env (if present, encrypted under fleet/secrets/) to the
+        # host's /opt/stacks/.env at 0600. Decryption is LOCAL; only the plaintext .env
+        # crosses the wire (over SSH), never the age key. CI deploy rsync excludes .env,
+        # so this operator-set file is authoritative.
+        if [[ -f "${SECRETS_DIR}/${ssh_host}.env" ]]; then
+            sops_provision_env "$ssh_host" "${ssh_user}@${ssh_host}"
+        fi
 
         echo ""
         info "${BOLD}Done!${NC} Server bootstrapped."

--- a/miuops
+++ b/miuops
@@ -136,7 +136,7 @@ sops_encrypt_tunnel_cred() {  # $1 = tunnel_id
 }
 
 # The remote command that lands the decrypted .env at /opt/stacks/.env, mode
-# 0600, root-owned, atomically. Kept as a function so the oracle can assert the
+# 0600, root-owned, atomically. Kept as a function so the test can assert the
 # mode/path without running ssh. install(1) sets the mode in one step.
 sops_env_install_cmd() {
     echo "umask 077; install -m 0600 /dev/stdin /opt/stacks/.env"

--- a/roles/cloudflared/defaults/main.yml
+++ b/roles/cloudflared/defaults/main.yml
@@ -1,6 +1,12 @@
 ---
 # cloudflared default variables
 cloudflared_dir: "/opt/cloudflared"
+# Local path to a tunnel credential the CONTROL node decrypted from
+# fleet/secrets/<tunnel_id>.json (SOPS+age). The miuops CLI sets this via
+# `-e cloudflared_credentials_src=<temp>` so the server receives the plaintext
+# JSON over SSH, never the age key. When empty, fall back to the legacy
+# plaintext at {{ playbook_dir }}/files/<tunnel_id>.json for backward-compat.
+cloudflared_credentials_src: ""
 cloudflared_gpg_key_url: "https://pkg.cloudflare.com/cloudflare-main.gpg"
 # Codenames Cloudflare publishes cloudflared packages for. New releases lag here
 # (e.g. Ubuntu 26.04 "resolute", Debian 13 "trixie"), so cloudflared_apt_release uses

--- a/roles/cloudflared/tasks/main.yml
+++ b/roles/cloudflared/tasks/main.yml
@@ -66,27 +66,42 @@
   register: cf_credentials
   tags: ['cloudflared']
 
+# Source of the LOCAL tunnel credential. The miuops CLI decrypts
+# fleet/secrets/<tunnel_id>.json (SOPS+age) to a private temp file on the control
+# node and passes that path as cloudflared_credentials_src. When unset, fall back
+# to the legacy plaintext at {{ playbook_dir }}/files/<tunnel_id>.json so older
+# fleets keep working. Decryption happens only on the control node; the server
+# just receives the plaintext JSON over the Ansible/SSH connection.
+- name: Resolve local tunnel credential source
+  set_fact:
+    cf_cred_src: >-
+      {{ cloudflared_credentials_src
+         if (cloudflared_credentials_src | default('') | length > 0)
+         else playbook_dir + '/files/' + tunnel_id + '.json' }}
+  tags: ['cloudflared']
+
 - name: Check for the local tunnel credentials file
   stat:
-    path: "{{ playbook_dir }}/files/{{ tunnel_id }}.json"
+    path: "{{ cf_cred_src }}"
   delegate_to: localhost
   become: false
   register: cf_local_credentials
   tags: ['cloudflared']
 
-- name: Require tunnel credentials (on the server or in files/)
+- name: Require tunnel credentials (on the server or locally)
   assert:
     that: cf_credentials.stat.exists or cf_local_credentials.stat.exists
     fail_msg: >-
       No tunnel credentials for {{ tunnel_id }}: not on the server at
-      {{ credentials_file }} and not in files/{{ tunnel_id }}.json. Create the
-      tunnel and place its JSON in files/ (see docs/INSTALLATION.md), then re-run.
+      {{ credentials_file }} and no local source at {{ cf_cred_src }}. Bootstrap
+      with the miuops CLI (it encrypts the credential into fleet/secrets/ — see
+      docs/SOPS_SECRETS.md), then re-run.
     quiet: true
   tags: ['cloudflared']
 
 - name: Copy tunnel credentials to the server
   copy:
-    src: "files/{{ tunnel_id }}.json"
+    src: "{{ cf_cred_src }}"
     dest: "{{ credentials_file }}"
     mode: '0600'
   no_log: true

--- a/tests/sops_test.sh
+++ b/tests/sops_test.sh
@@ -1,0 +1,215 @@
+#!/usr/bin/env bash
+# Oracle for the SOPS+age secret integration. Self-contained: it generates a
+# throwaway age key and a temp .sops.yaml so the round-trip needs no operator
+# key and never touches the real fleet repo. Proves, with each assertion able
+# to FAIL independently:
+#   1. ROUND-TRIP (tunnel cred JSON): encrypt -> ciphertext is not plaintext ->
+#      decrypt -> byte-identical to the original.
+#   2. ROUND-TRIP (app .env): values are encrypted on disk but decrypt back.
+#   3. TAMPER fails closed: flip one ciphertext byte -> `sops -d` exits non-zero,
+#      stderr mentions MAC, and NO plaintext is emitted on stdout.
+#   4. The CLI's sops helpers exist and behave: require_sops dies when sops is
+#      absent; the env-provisioning command targets mode 0600; the cloudflared
+#      role consumes a local decrypted source with a legacy fallback.
+set -euo pipefail
+ROOT="$(cd "$(dirname "$0")/.." && pwd)"
+TMP="$(mktemp -d)"; trap 'rm -rf "$TMP"' EXIT
+fail() { echo "FAIL: $1"; exit 1; }
+
+command -v sops >/dev/null 2>&1 || fail "sops not installed (brew install sops age)"
+command -v age-keygen >/dev/null 2>&1 || fail "age-keygen not installed (brew install age)"
+
+# ── Self-contained SOPS env: throwaway age key + temp .sops.yaml ────────────
+# The fleet repo ROOT is $TMP; secrets live under $TMP/fleet/secrets (the
+# authoritative convention: invoke sops with cwd = repo root, repo-relative
+# paths 'fleet/secrets/<file>', path_regex '^fleet/secrets/.*\.(json|env)$').
+export SOPS_AGE_KEY_FILE="$TMP/keys.txt"
+age-keygen -o "$SOPS_AGE_KEY_FILE" 2>/dev/null
+RECIPIENT="$(age-keygen -y "$SOPS_AGE_KEY_FILE")"
+[ -n "$RECIPIENT" ] || fail "could not derive age recipient"
+
+mkdir -p "$TMP/fleet/secrets"
+cat > "$TMP/.sops.yaml" <<EOF
+creation_rules:
+  - path_regex: ^fleet/secrets/.*\.(json|env)\$
+    age: ${RECIPIENT}
+EOF
+
+# ── 1. ROUND-TRIP: tunnel credential JSON ───────────────────────────────────
+TID="aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee"
+cat > "$TMP/orig-cred.json" <<EOF
+{"AccountTag":"acct123","TunnelID":"${TID}","TunnelName":"miuops-test","TunnelSecret":"c2VjcmV0LXZhbHVlLWhlcmU="}
+EOF
+cp "$TMP/orig-cred.json" "$TMP/fleet/secrets/${TID}.json"
+( cd "$TMP" && sops --encrypt --input-type json --output-type json --in-place "fleet/secrets/${TID}.json" ) \
+    || fail "sops encrypt failed for the tunnel cred JSON"
+# Ciphertext must NOT be plaintext: the raw secret value is gone, sops metadata present.
+grep -q 'c2VjcmV0LXZhbHVlLWhlcmU=' "$TMP/fleet/secrets/${TID}.json" \
+    && fail "tunnel secret left in plaintext after encrypt (encrypt no-op)"
+grep -q '"sops"' "$TMP/fleet/secrets/${TID}.json" \
+    || fail "no sops metadata in the encrypted tunnel cred (not encrypted)"
+# Decrypt and compare to the original. SOPS reformats JSON (pretty-prints) on
+# decrypt, so compare the CANONICAL form (jq -S -c) byte-for-byte: this still
+# catches a mangled/corrupted object or a changed value while tolerating
+# whitespace reformatting — and cloudflared only consumes the JSON content.
+( cd "$TMP" && sops --decrypt "fleet/secrets/${TID}.json" ) > "$TMP/dec-cred.json" \
+    || fail "sops decrypt failed for the tunnel cred JSON"
+cmp -s <(jq -S -c . "$TMP/orig-cred.json") <(jq -S -c . "$TMP/dec-cred.json") \
+    || fail "decrypted tunnel cred does not match the original (canonical JSON)"
+# The decrypted JSON is still valid and carries the expected fields/values.
+jq -e --arg s 'c2VjcmV0LXZhbHVlLWhlcmU=' '.TunnelID and .TunnelSecret == $s' "$TMP/dec-cred.json" >/dev/null \
+    || fail "decrypted tunnel cred lost a field/value"
+echo "ok: tunnel cred JSON round-trip (encrypt hides secret, decrypt restores content)"
+
+# ── 2. ROUND-TRIP: app .env (value-only encryption) ─────────────────────────
+SRV="server-a"
+printf 'FOO=bar123\n# a comment with = signs and spaces\nDB_URL=postgres://u:p@h/db\n' > "$TMP/orig.env"
+cp "$TMP/orig.env" "$TMP/fleet/secrets/${SRV}.env"
+( cd "$TMP" && sops --encrypt --input-type dotenv --output-type dotenv --in-place "fleet/secrets/${SRV}.env" ) \
+    || fail "sops encrypt failed for the app .env"
+# Value must be encrypted on disk...
+grep -q '^FOO=bar123$' "$TMP/fleet/secrets/${SRV}.env" \
+    && fail ".env value left in plaintext after encrypt"
+# ...but decrypt back to the exact value.
+( cd "$TMP" && sops --decrypt --input-type dotenv --output-type dotenv "fleet/secrets/${SRV}.env" ) > "$TMP/dec.env" \
+    || fail "sops decrypt failed for the app .env"
+grep -q '^FOO=bar123$' "$TMP/dec.env" \
+    || fail "decrypted .env lost the FOO=bar123 value"
+grep -q '^DB_URL=postgres://u:p@h/db$' "$TMP/dec.env" \
+    || fail "decrypted .env lost the DB_URL value"
+echo "ok: app .env round-trip (value encrypted on disk, decrypts back)"
+
+# ── 3. TAMPER: a flipped ciphertext byte must fail closed ───────────────────
+# Positive control first: the un-tampered file decrypts cleanly (exit 0).
+( cd "$TMP" && sops --decrypt "fleet/secrets/${TID}.json" ) >/dev/null 2>&1 \
+    || fail "positive control: un-tampered cred should decrypt (exit 0)"
+# Flip one base64 char inside the encrypted "mac" value (the integrity tag over
+# the whole tree). SOPS authenticates the tree against this MAC, so any change
+# makes decryption fail closed with a MAC error (exit code 51, MacMismatch).
+TAMPERED="$TMP/tampered.json"
+python3 - "$TMP/fleet/secrets/${TID}.json" "$TAMPERED" <<'PY'
+import re, sys
+src, dst = sys.argv[1], sys.argv[2]
+s = open(src).read()
+m = re.search(r'("mac": "ENC\[AES256_GCM,data:)([A-Za-z0-9+/])', s)
+if not m:
+    sys.exit("could not locate the mac data field to tamper")
+ch = m.group(2)
+new = 'B' if ch != 'B' else 'C'
+open(dst, 'w').write(s[:m.start(2)] + new + s[m.end(2):])
+PY
+cmp -s "$TMP/fleet/secrets/${TID}.json" "$TAMPERED" \
+    && fail "tamper mutation did not change the ciphertext (test would be vacuous)"
+mkdir -p "$TMP/tamper/fleet/secrets"
+cp "$TMP/.sops.yaml" "$TMP/tamper/.sops.yaml"
+cp "$TAMPERED" "$TMP/tamper/fleet/secrets/${TID}.json"
+set +e
+out="$( cd "$TMP/tamper" && sops --decrypt "fleet/secrets/${TID}.json" 2>"$TMP/tamper.err" )"
+rc=$?
+set -e
+[ "$rc" -ne 0 ] || fail "tampered ciphertext decrypted with exit 0 (did NOT fail closed)"
+# No plaintext leaked on stdout (the original secret must not appear).
+printf '%s' "$out" | grep -q 'c2VjcmV0LXZhbHVlLWhlcmU=' \
+    && fail "tampered decrypt emitted plaintext on stdout (must emit none)"
+# SOPS reports a MAC failure on a tampered tree.
+grep -qi 'MAC' "$TMP/tamper.err" \
+    || fail "tampered decrypt did not report a MAC error (stderr: $(cat "$TMP/tamper.err"))"
+echo "ok: tamper fails closed (non-zero exit ${rc}, MAC error, no plaintext)"
+
+# ── 4. CLI helper contract ──────────────────────────────────────────────────
+# Source the CLI offline (no dispatch) and exercise the sops helpers directly.
+export MIUOPS_TEST_SCRIPT_DIR="$TMP/tool"
+export MIUOPS_FLEET_DIR="$TMP/fleet"
+# shellcheck disable=SC1090
+source "$ROOT/miuops" --source-only
+
+# require_sops must exist and must DIE when sops is not on PATH. The helper uses
+# only the `command` builtin + die(), both already sourced, so we can run it in a
+# subshell with PATH pointed at an empty dir (sops absent) without losing bash.
+type require_sops >/dev/null 2>&1 || fail "require_sops helper is missing"
+mkdir -p "$TMP/emptybin"
+# die() calls exit, which terminates the subshell with non-zero — so the `|| true`
+# must guard the whole assignment (an inner `|| true` would never run).
+out="$( PATH="$TMP/emptybin" require_sops 2>&1 )" || true
+echo "$out" | grep -qi 'sops not found' \
+    || fail "require_sops must die with a clear 'sops not found' message when sops is absent (got: $out)"
+echo "ok: require_sops fails closed when sops is missing"
+
+# sops_decrypt_to_tmp must round-trip a fleet secret to a private temp file.
+type sops_decrypt_to_tmp >/dev/null 2>&1 || fail "sops_decrypt_to_tmp helper is missing"
+plain="$(sops_decrypt_to_tmp "${MIUOPS_FLEET_DIR}/secrets/${TID}.json")" \
+    || fail "sops_decrypt_to_tmp failed on a valid encrypted cred"
+[ -f "$plain" ] || fail "sops_decrypt_to_tmp did not produce a temp file"
+cmp -s <(jq -S -c . "$TMP/orig-cred.json") <(jq -S -c . "$plain") \
+    || fail "sops_decrypt_to_tmp output does not match the original cred (canonical JSON)"
+# The temp file must be 0600 (no plaintext readable by group/other).
+perm="$(stat -c '%a' "$plain" 2>/dev/null || stat -f '%Lp' "$plain")"
+[ "$perm" = "600" ] || fail "decrypt temp file not 0600 (got $perm)"
+rm -f "$plain"
+echo "ok: sops_decrypt_to_tmp round-trips to a 0600 temp file"
+
+# The .env provisioning command targets /opt/stacks/.env at mode 0600, root-owned.
+type sops_env_install_cmd >/dev/null 2>&1 || fail "sops_env_install_cmd helper is missing"
+cmd="$(sops_env_install_cmd)"
+echo "$cmd" | grep -q '/opt/stacks/.env'      || fail "env provision must target /opt/stacks/.env (got: $cmd)"
+echo "$cmd" | grep -qE '0600|install -m 0600' || fail "env provision must enforce mode 0600 (got: $cmd)"
+echo "ok: env provisioning targets /opt/stacks/.env at mode 0600"
+
+# CLI source must wire the decrypted cred into the playbook via cloudflared_credentials_src.
+grep -q 'cloudflared_credentials_src=' "$ROOT/miuops" \
+    || fail "CLI must pass -e cloudflared_credentials_src=<decrypted temp> to the playbook"
+
+# ── 5. cloudflared role consumes a local decrypted source, legacy fallback ───
+ROLE="$ROOT/roles/cloudflared/tasks/main.yml"
+DEFAULTS="$ROOT/roles/cloudflared/defaults/main.yml"
+grep -q 'cloudflared_credentials_src' "$DEFAULTS" \
+    || fail "defaults must declare cloudflared_credentials_src"
+grep -q 'cloudflared_credentials_src' "$ROLE" \
+    || fail "role must reference cloudflared_credentials_src"
+# Legacy fallback to files/<tunnel_id>.json must remain for backward-compat.
+grep -q "files/' + tunnel_id" "$ROLE" \
+    || fail "role must fall back to the legacy files/<tunnel_id>.json when src is empty"
+# The server-copy step must still land 0600 with no_log.
+grep -q "mode: '0600'" "$ROLE" || fail "role must copy the cred to the server at 0600"
+grep -q 'no_log: true'    "$ROLE" || fail "role cred copy must keep no_log: true"
+# YAML parses.
+python3 -c "import yaml,sys; yaml.safe_load(open('$ROLE')); yaml.safe_load(open('$DEFAULTS'))" \
+    || fail "cloudflared role/defaults YAML does not parse"
+echo "ok: cloudflared role consumes the local decrypted source with a legacy fallback"
+
+# ── 6. set -u safety: the sops helpers must reach their OWN preconditions, never die
+# at a `local` line with "unbound variable". bash expands ALL `local` initializers
+# before assigning, so a same-statement forward reference reads the outer/unset value
+# -> set -u abort (the helper would be dead on arrival, as the round-trip oracle can't
+# see). ──────────────────────────────────────────────────────────────────────────
+t6="$TMP/setu.out"
+( # encrypt helper under set -u: must REACH its own precondition, not die at a `local`.
+  # shellcheck source=/dev/null
+  source "$ROOT/miuops" --source-only; set +e +o pipefail
+  sops_encrypt_tunnel_cred no-such-tunnel-id ) >"$t6" 2>&1 || true
+grep -qi 'unbound variable' "$t6"        && fail "sops_encrypt_tunnel_cred dies under set -u (local-order bug)"
+grep -qi 'Tunnel credential not found' "$t6" || fail "sops_encrypt_tunnel_cred didn't reach its precondition: $(cat "$t6")"
+( # provision helper under set -u
+  # shellcheck source=/dev/null
+  source "$ROOT/miuops" --source-only; set +e +o pipefail
+  sops_provision_env no-such-server user@host ) >"$t6" 2>&1 || true
+grep -qi 'unbound variable' "$t6"         && fail "sops_provision_env dies under set -u (local-order bug)"
+grep -qi 'skipping .env provisioning' "$t6" || fail "sops_provision_env didn't reach its skip path: $(cat "$t6")"
+echo "ok: sops helpers are set -u safe (reach own preconditions, never 'unbound variable')"
+
+# ── 7. leak hygiene: NO per-function RETURN trap (never fires on die/set -e); the
+# cleanup is NOT armed at top level (so sourcing the CLI can't clobber the sourcer's
+# EXIT trap); and the cleanup actually shreds a registered temp. ──────────────────
+grep -qE '^[[:space:]]*trap[^#]*RETURN' "$ROOT/miuops" && fail "a RETURN trap remains -- leaks the decrypted secret on die/set -e"
+grep -qE '^trap[[:space:]]' "$ROOT/miuops" && fail "CLI arms a top-level trap -- would clobber a sourcer's EXIT trap"
+grep -q 'trap _sops_cleanup EXIT INT TERM' "$ROOT/miuops" || fail "CLI must arm the sops cleanup on EXIT INT TERM"
+(
+  # shellcheck source=/dev/null
+  source "$ROOT/miuops" --source-only
+  lt="$(mktemp)"; _SOPS_TMPS=("$lt"); _sops_cleanup
+  if [ -e "$lt" ]; then rm -f "$lt"; exit 3; fi
+  exit 0
+) || fail "_sops_cleanup did not shred a registered temp"
+echo "ok: leak hygiene (no RETURN trap, no top-level trap, cleanup shreds registered temps)"
+
+echo "ALL SOPS ORACLE TESTS PASSED"

--- a/tests/sops_test.sh
+++ b/tests/sops_test.sh
@@ -1,5 +1,5 @@
 #!/usr/bin/env bash
-# Oracle for the SOPS+age secret integration. Self-contained: it generates a
+# Verifies the SOPS+age secret integration. Self-contained: it generates a
 # throwaway age key and a temp .sops.yaml so the round-trip needs no operator
 # key and never touches the real fleet repo. Proves, with each assertion able
 # to FAIL independently:
@@ -180,7 +180,7 @@ echo "ok: cloudflared role consumes the local decrypted source with a legacy fal
 # ── 6. set -u safety: the sops helpers must reach their OWN preconditions, never die
 # at a `local` line with "unbound variable". bash expands ALL `local` initializers
 # before assigning, so a same-statement forward reference reads the outer/unset value
-# -> set -u abort (the helper would be dead on arrival, as the round-trip oracle can't
+# -> set -u abort (the helper would be dead on arrival, as the round-trip test can't
 # see). ──────────────────────────────────────────────────────────────────────────
 t6="$TMP/setu.out"
 ( # encrypt helper under set -u: must REACH its own precondition, not die at a `local`.
@@ -212,4 +212,4 @@ grep -q 'trap _sops_cleanup EXIT INT TERM' "$ROOT/miuops" || fail "CLI must arm 
 ) || fail "_sops_cleanup did not shred a registered temp"
 echo "ok: leak hygiene (no RETURN trap, no top-level trap, cleanup shreds registered temps)"
 
-echo "ALL SOPS ORACLE TESTS PASSED"
+echo "ALL SOPS TESTS PASSED"


### PR DESCRIPTION
## What

Encrypts the fleet's secrets with SOPS+age so they are committable to the fleet repo as
ciphertext, yet decrypted **only locally** — never in CI, and the age key never enters CI.

- At bootstrap, the freshly-created tunnel credential is encrypted in place into
  `fleet/secrets/<tunnel_id>.json` (plaintext stays in `~/.cloudflared/`; the repo only ever
  receives ciphertext).
- At converge, the tunnel credential and the per-server app `.env` are decrypted **locally**
  to a private 0600 temp and handed to the host over SSH (the credential via the Ansible
  `cloudflared_credentials_src` var; the `.env` installed at `/opt/stacks/.env`, mode 0600).
- The cloudflared role consumes the decrypted local source, with a backward-compatible
  fallback to the legacy `files/<tunnel_id>.json`.
- `.sops.yaml` (shipped by the fleet template) carries one rule
  `^fleet/secrets/.*\.(json|env)$`; sops runs with cwd = the fleet repo root.

## Security

- Plaintext exists only transiently in a 0600 temp, shredded on **any** exit — a
  process-wide cleanup armed inside the converge/provision functions, not a per-function
  `RETURN` trap (which would leak the cleartext on a failed converge or a signal).
- A tampered ciphertext fails closed (sops exits 51 / MAC error; no plaintext emitted).
- The age key is never referenced by any CI workflow.

## Testing

`tests/sops_test.sh` — a self-contained test (throwaway age key + temp `.sops.yaml`; CI
never decrypts real secrets): the encrypt→decrypt round-trip is byte-identical; a flipped
ciphertext byte fails closed; the helpers are `set -u`-safe (reach their own preconditions,
never "unbound variable"); leak hygiene (no `RETURN` trap; the cleanup shreds every
registered temp); env-provisioning targets mode 0600; the cloudflared role consumes the
local decrypted source with the legacy fallback. Wired into CI; `shellcheck -S error` +
`actionlint` clean.