### PR TITLE
docs: describe the fleet deployment model + rename the template repo

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 Ansible-based bootstrap for secure Docker infrastructure on bare metal servers.
 
-miuOps provisions a server with Docker, Traefik, Cloudflare Tunnel, and a ufw firewall — then gets out of the way. Day-to-day service deployment is handled by your own private GitOps stack repo via GitHub Actions.
+miuOps provisions a server with Docker, Traefik, Cloudflare Tunnel, and a ufw firewall — then gets out of the way. Day-to-day service deployment is handled by your own private GitOps **fleet repo** via GitHub Actions.
 
 ## Architecture Overview
 
@@ -37,12 +37,14 @@ miuOps provisions a server with Docker, Traefik, Cloudflare Tunnel, and a ufw fi
 ## Quick Start
 
 ```bash
-git clone https://github.com/tianshanghong/miuops
-cd miuops
-CF_API_TOKEN=your_token ./miuops up root@203.0.113.10 example.com example.org
+# 1. Create your private fleet repo from miuops-fleet-template ("Use this template"),
+#    then clone it and cd in — this is where your fleet's config + stacks live.
+# 2. Install the CLI: clone this repo and put `miuops` on your PATH.
+# 3. From your fleet repo, bootstrap a server (the CLI reads config from ./fleet):
+CF_API_TOKEN=your_token miuops up root@203.0.113.10 example.com example.org
 ```
 
-That's it. Pass one or more domains — the CLI handles Cloudflare Tunnel creation, DNS route registration, config generation, and runs the playbook.
+Pass one or more domains — the CLI creates the Cloudflare Tunnel + DNS routes, writes the server's config into `fleet/`, and converges the host. Commit and push `fleet/`, and GitHub Actions deploys your stacks over SSH.
 
 ### Prerequisites
 
@@ -64,10 +66,10 @@ You also need:
 
 ```bash
 # Preview what would happen without making changes
-CF_API_TOKEN=your_token ./miuops up --dry-run root@203.0.113.10 example.com example.org
+CF_API_TOKEN=your_token miuops up --dry-run root@203.0.113.10 example.com example.org
 
 # SSH user defaults to root if omitted
-CF_API_TOKEN=your_token ./miuops up 203.0.113.10 example.com
+CF_API_TOKEN=your_token miuops up 203.0.113.10 example.com
 ```
 
 ## Commands
@@ -83,9 +85,10 @@ All commands accept `--dry-run` (preview) and `--no-apply` (change config/DNS bu
 
 ## Managing multiple servers
 
-Each server is one line in `inventory.ini` plus one `host_vars/<name>.yml` (its
-`domains` + `tunnel_id`). Run `miuops up` once per server in a single checkout —
-they coexist, and you converge any subset:
+Your fleet repo describes the whole fleet: each server is one line in
+`fleet/inventory.ini` plus one `fleet/host_vars/<name>.yml` (its `domains` +
+`tunnel_id`). The CLI reads `fleet/` from the current directory, so run it from your
+fleet repo — servers coexist and you converge any subset:
 
 ```bash
 miuops apply server-a          # one server
@@ -93,9 +96,6 @@ miuops apply                   # the whole fleet
 ```
 
 Day-to-day domain/converge commands are in [Daily Operations](docs/DAILY_OPS.md).
-See **[Scaling & advanced patterns](docs/SCALING.md)** for migrating from a
-single-server setup and optional patterns (env grouping, SOPS, YubiKey, a
-management-CIDR SSH allowlist).
 
 ## What Gets Deployed
 
@@ -113,7 +113,7 @@ management-CIDR SSH allowlist).
 
 ## Deploy Services
 
-After bootstrap, create your private stack repo from the **[miuops-stack-template](https://github.com/tianshanghong/miuops-stack-template)** — it includes example stacks and a GitHub Actions pipeline that deploys your services on push to `main`.
+After bootstrap, create one private **fleet repo** from the **[miuops-fleet-template](https://github.com/tianshanghong/miuops-fleet-template)** ("Use this template"). The fleet repo describes your whole fleet — `fleet/inventory.ini`, `fleet/host_vars/<server>.yml`, SOPS-encrypted secrets under `fleet/secrets/`, and your per-server Compose stacks under `fleet/stacks/<server>/<stack>/`. It consumes miuOps as a dependency: a ~5-line caller workflow that calls the miuOps reusable `deploy.yml` (pinned to a tag, `secrets: inherit`) — there is no tool code to fork. On push to `main`, GitHub Actions discovers the changed servers and deploys each over SSH.
 
 ## Infrastructure Upgrades
 
@@ -137,19 +137,19 @@ ansible-playbook playbook.yml --tags docker
 
 ## Tunnel Management
 
-- `./miuops up` automatically creates and configures a Cloudflare Tunnel
+- `miuops up` automatically creates and configures a Cloudflare Tunnel
 - DNS CNAME records are created by the CLI via Cloudflare API
-- Re-running `./miuops up` with additional domains adds them (additive — never drops)
-- `./miuops add-domain <host> <domain…>` / `remove-domain <host> <domain…>` manage domains on a live server (remove-domain also deletes the orphaned CNAMEs)
+- Re-running `miuops up` with additional domains adds them (additive — never drops)
+- `miuops add-domain <host> <domain…>` / `remove-domain <host> <domain…>` manage domains on a live server (remove-domain also deletes the orphaned CNAMEs)
 - A domain belongs to exactly one server; assigning it to a second is refused
 - To delete a tunnel, see [Deleting a tunnel](docs/DAILY_OPS.md#deleting-a-tunnel)
 
 ## Backup Setup
 
-- `scripts/setup-s3-backup.sh` — Create an S3 bucket (Object Lock + lifecycle) and IAM user for backups
+- `scripts/setup-s3-backup.sh --server <server>` — Create the shared S3 bucket (Object Lock + lifecycle) and a per-server, prefix-scoped IAM user for backups
 - `images/postgres-walg/` — Custom PostgreSQL 17 + WAL-G image for continuous WAL archiving to S3
 
-The setup script creates a single `{project}-backup` bucket used by both the host-side `backup` role (volume tarballs under `vol/`) and WAL-G (database backups under `db/`). The volume backup is a host `systemd` timer — no container, no `docker.sock` mount; see [roles/backup/README.md](roles/backup/README.md). Object Lock (Governance, 30 days) prevents deletion; S3 lifecycle transitions to Glacier at 30 days and expires at 90 days.
+One shared `{project}-backup` bucket holds every server's backups under a per-server prefix (`<server>/…`); each server gets its own IAM user scoped to only its prefix (no Delete, no cross-prefix access), so a compromised server's key can touch only its own backups. Within a server's prefix the host-side `backup` role stores volume tarballs under `<server>/vol/` and WAL-G stores database backups under `<server>/db/`. The volume backup is a host `systemd` timer — no container, no `docker.sock` mount; see [roles/backup/README.md](roles/backup/README.md). Object Lock (Governance, 30 days) prevents deletion; S3 lifecycle transitions to Glacier at 30 days and expires at 90 days.
 
 ## Security
 
@@ -165,7 +165,7 @@ The setup script creates a single `{project}-backup` bucket used by both the hos
 
 - [Architecture](docs/ARCHITECTURE.md) — Design decisions, network model, and system diagram
 - [Installation Guide](docs/INSTALLATION.md) — Full end-to-end setup walkthrough
-- [Scaling & Advanced](docs/SCALING.md) — Migration to a fleet + optional patterns (env grouping, SOPS, YubiKey)
+- [Scaling & Advanced](docs/SCALING.md) — Optional patterns (env grouping, SOPS, YubiKey)
 - [Repository Structure](docs/STRUCTURE.md) — Directory layout and role descriptions
 - [Disaster Recovery](docs/DISASTER_RECOVERY.md) — Backup restore procedures for all failure scenarios
 - [Daily Operations](docs/DAILY_OPS.md) — Quick reference for day-to-day server management

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -7,20 +7,26 @@ Design rationale and internal architecture of miuOps.
 | Component | Decision | Rationale |
 |---|---|---|
 | Ansible | Keep for day-0 bootstrap + infra upgrades | Firewall, Docker, cloudflared, and Traefik upgrades are infrastructure — not appropriate for GitOps. |
-| GitHub Actions | GitOps for service deployment | Sync compose files via SSH + rsync, `docker compose up -d`. Server never pulls from git. |
+| GitHub Actions | GitOps for service deployment | The fleet repo's caller workflow invokes the miuOps reusable `deploy.yml`, which syncs compose files via SSH + rsync and runs `docker compose up -d`. Server never pulls from git. |
 | Cloudflare Tunnel | Zero exposed ports | All ingress flows through Cloudflare. No public-facing ports on the server. |
 | Traefik | Stateless reverse proxy | Label-based service discovery, no config files to manage per-service. |
 | WAL-G | PostgreSQL backup | Physical backup + continuous WAL archiving to S3, baked into a custom PG image. |
 | Host-side volume backup | Docker volume backup | A host `systemd` timer (Ansible `backup` role) tars each volume and streams it to S3. No container, no `docker.sock` mount — the daemon socket is root-equivalent, so nothing gets it. |
-| Single S3 bucket | Backup storage | One bucket, one IAM user, prefixes separate data types. Simplifies lifecycle and Object Lock config. |
-| Two repos | Public tool + private config | miuOps is open-source; user infrastructure is private. Different lifecycles, different audiences. |
-| Registry auth | Stack repo deploy workflow, not Ansible | Registry credentials are deployment-specific (which registries, which tokens). The bootstrap layer shouldn't know about private image registries. Credentials live in `.env` on the server. |
+| Tool as dependency | Public tool + private fleet repo | miuOps is open-source; the fleet config is private. The fleet repo consumes miuOps as a referenced dependency (reusable workflows + the CLI), so it never forks the tool. |
+| Single bucket per fleet | Per-server prefix + scoped IAM | One S3 bucket for the whole fleet, a per-server prefix, and a per-server prefix-scoped IAM user — a compromised server reaches only its own backups. One lifecycle + Object-Lock config to manage. |
+| Registry auth | Fleet repo secrets, not Ansible | Registry credentials are deployment-specific (which registries, which tokens). The bootstrap layer shouldn't know about private image registries. Credentials live in the per-server `.env` on the server (decrypted from `fleet/secrets/<server>.env`). |
 | userns-remap | Container root ≠ host root | Containers run with `userns-remap: default`, so a container breakout maps to an unprivileged host UID (100000+), not real root. Stacks must use **named volumes** — a remapped container cannot read a root-owned host bind-mount. The read-only docker-socket-proxy is the one component that opts out (`--userns=host`) so it can read the root-owned `docker.sock`. |
 | No backward compat | Clean break | No migration paths, shims, or old-structure support. |
 
-## Two-Repo Architecture
+## Tool-as-Dependency Architecture
 
-**Why two repos?** miuOps is an open-source tool. A user's infrastructure config is private, user-specific data with a different lifecycle and audience. If combined, users would fork miuOps and could never cleanly pull upstream updates.
+miuOps splits into three pieces:
+
+- **miuOps** (public tool) — the Ansible roles, the `miuops` CLI, and the reusable GitHub workflows (`deploy.yml`, the policy-check). The shared deploy machinery lives here, once.
+- **miuops-fleet-template** (public, tiny) — the `fleet/` skeleton, a ~5-line caller workflow, `.env.example`, and `.sops.yaml`. No tool code. "Use this template" creates your private fleet repo.
+- **Your fleet repo** (private) — the entire fleet definition: inventory, per-server config, encrypted secrets, and per-server stacks.
+
+**Why a separate fleet repo?** miuOps is an open-source tool; your fleet config is private, fleet-specific data with a different lifecycle and audience. The fleet repo consumes miuOps as a **referenced dependency** (the reusable workflows + the installed CLI) rather than forking it, so adding or upgrading servers and tracking upstream changes stay friction-free.
 
 **Git auth is a non-issue.** The server never pulls from git. GitHub Actions SSHes into the server and pushes files via rsync/scp. The server has no idea git exists.
 
@@ -30,7 +36,7 @@ The tool. Users clone this to bootstrap their server.
 
 ```
 miuOps/
-├── miuops                    # CLI entrypoint (./miuops up)
+├── miuops                    # CLI entrypoint (miuops up)
 ├── roles/                    # Ansible roles for bootstrap + upgrades
 │   ├── docker/               #   Docker engine + hardened daemon
 │   ├── firewall/             #   ufw host firewall (IPv4 + IPv6)
@@ -49,29 +55,39 @@ miuOps/
 └── docs/
 ```
 
-### User's stack repo (private)
+### User's fleet repo (private)
 
-Created from the [miuops-stack-template](https://github.com/tianshanghong/miuops-stack-template). Contains compose files, GitHub Actions workflow, and `.env.example`.
+Created from the [miuops-fleet-template](https://github.com/tianshanghong/miuops-fleet-template). Holds per-server config, SOPS-encrypted secrets, and per-server stacks — plus a thin caller workflow that delegates to the miuOps reusable `deploy.yml`.
 
 ```
-my-infra/
-├── stacks/
-│   ├── traefik/
-│   ├── backup/
-│   └── <user-apps>/
+my-fleet/
 ├── .github/workflows/
-│   └── deploy.yml            # SSH + rsync + docker compose up
-├── .env.example
-└── .gitignore                # .env never committed
+│   └── deploy.yml            # ~5-line caller -> miuops reusable deploy.yml (pinned tag, secrets: inherit)
+├── .sops.yaml                # age recipients for fleet/secrets/*
+├── .env.example              # cleartext template for fleet/secrets/<server>.env
+└── fleet/
+    ├── inventory.ini         # which servers exist (plaintext config)
+    ├── host_vars/
+    │   └── <server>.yml      # per-server domains + tunnel_id (plaintext config)
+    ├── secrets/
+    │   ├── <server>.env      # SOPS+age-encrypted app/stack env
+    │   └── <tunnel_id>.json  # SOPS+age-encrypted Cloudflare tunnel credential
+    └── stacks/
+        └── <server>/
+            └── <stack>/
+                └── docker-compose.yml
 ```
+
+The deploy logic is the **reusable workflow** from miuOps, pinned to a tag. Per-server secret isolation comes from per-server [GitHub Environments](https://docs.github.com/actions/deployment/targeting-different-environments/using-environments-for-deployment) (`SSH_HOST`, `SSH_USER`, `SSH_PORT`, `SSH_PRIVATE_KEY`, `SSH_KNOWN_HOSTS`): each server's deploy job reads only its own environment's secrets, so a compromised deploy holds one server's key — no lateral movement. The age key that decrypts `fleet/secrets/` is never in CI; SOPS decryption happens locally at setup, so a shared decrypt key never undercuts per-server isolation. The operator generates the SSH and deploy keypairs; the tool only ever installs the **public** key.
 
 ## System Diagram
 
 ```
 ┌─────────────────────────────────────────────────────────────┐
 │  CONTROL PLANE (your laptop)                                │
-│  - Editor for compose files                                 │
-│  - Git push to GitHub (stack repo)                          │
+│  - Editor for the fleet repo (config + compose)             │
+│  - SOPS+age encrypt/decrypt of fleet/secrets (local only)   │
+│  - Git push to GitHub (fleet repo)                          │
 │  - Ansible (miuOps) for bootstrap + infra upgrades          │
 │  - LazyDocker via docker context + SSH                      │
 └──────────┬──────────────┬───────────────────┬───────────────┘
@@ -82,19 +98,20 @@ my-infra/
 │                    │  │                                    │
 │  miuOps (public)   │  │  [infra — Ansible-owned]           │
 │  - Ansible roles   │  │  ├─ ufw firewall                   │
-│  - scripts         │  │  ├─ Docker engine                  │
-│                    │  │  ├─ cloudflared (systemd)          │
-│                    │  │  ├─ Traefik (host binary)          │
-│  my-infra (private)│  │  └─ docker-socket-proxy (RO)       │
-│  - compose files   │  │  [apps — GitOps-owned]             │
-│  - GH Actions  ───────▶  ├─ App containers                 │
-│  - .env (secrets)  │SSH│  │   (per-stack networks)         │
-│                    │  │  ├─ PG + WAL-G ──────┐              │
-│                    │  │  ├─ volume backup ───┤  (systemd    │
-│                    │  │  │                   │   timer,     │
+│  - reusable        │  │  ├─ Docker engine                  │
+│    deploy.yml      │  │  ├─ cloudflared (systemd)          │
+│  - scripts         │  │  ├─ Traefik (host binary)          │
+│                    │  │  └─ docker-socket-proxy (RO)       │
+│  fleet repo (priv) │  │  [apps — GitOps-owned]             │
+│  - fleet/stacks    │  │  ├─ App containers                 │
+│  - caller deploy ─────▶  │   (per-stack networks)         │
+│    (per-server     │SSH│  ├─ PG + WAL-G ──────┐              │
+│     Environment)   │  │  ├─ volume backup ───┤  (systemd    │
+│  - SOPS secrets    │  │  │                   │   timer,     │
 │                    │  │  └─ Docker volumes   │   host-side) │
 └────────────────────┘  │                      ▼              │
-                        │        S3: {project}-backup         │
+                        │     S3: {project}-backup            │
+                        │     └─ <server>/                    │
                         │        ├─ db/* (WAL-G)              │
                         │        └─ vol/* (volume tarballs)   │
                         └────────────────────────────────────┘
@@ -171,13 +188,19 @@ but intra-stack lateral movement is the application developer's responsibility.
 
 ## Backup Design
 
-Single S3 bucket, single IAM user. Prefixes separate data by type.
+One S3 bucket for the whole fleet, with a per-server prefix. Within a server's
+prefix, sub-prefixes separate data by type.
 
 ```
 s3://{project}-backup/
-  ├── db/{app-name}/        ← WAL-G (base backups + WAL segments)
-  └── vol/{volume}/         ← host-side volume tarballs (backup role)
+  └── <server>/
+      ├── db/{app-name}/    ← WAL-G (base backups + WAL segments)
+      └── vol/{volume}/     ← host-side volume tarballs (backup role)
 ```
+
+Each server gets its own IAM user scoped to its prefix (Put/Get/List on
+`<server>/*` only, no Delete), so a compromised server can read and write only
+its own backups — never another server's.
 
 **Volume backups run on the host, not in a container.** The Ansible `backup`
 role installs a `systemd` timer that runs a bash script directly on the host.
@@ -200,9 +223,9 @@ caches) can be listed with an empty stop-set for a hot copy. PostgreSQL is best
 handled by WAL-G (continuous archiving) rather than a stop-the-world tar of its
 data volume.
 
-**Why one bucket?** All credentials live on the same server — separate buckets with separate IAM users don't improve security if the server is compromised (the attacker gets all credentials). One lifecycle policy, one Object Lock config, one bucket to manage. Adding a database means picking a new `WALG_S3_PREFIX`, no AWS operations needed.
+**Why one bucket for the fleet?** One lifecycle policy and one Object Lock config to manage, rather than one per server. Per-server isolation comes from the prefix layout and the per-server scoped IAM user, not from separate buckets. Adding a database means picking a new `WALG_S3_PREFIX` under that server's prefix, no AWS operations needed.
 
-**Why one IAM user?** Same reasoning. The IAM user gets Put, Get, List permissions only — no Delete. The backup job itself never deletes; retention is enforced entirely by S3 (Object Lock + lifecycle), so a compromised host cannot erase history. Object Lock (Governance, 30 days) prevents deletion by anyone without the `s3:BypassGovernanceRetention` permission. Volume backups can optionally be encrypted client-side (age) before upload — see [Backup Encryption](BACKUP_ENCRYPTION.md).
+**Why a per-server scoped IAM user?** Each server holds only its own access key, scoped to its own prefix — Put, Get, List on `<server>/*`, no Delete. The backup job itself never deletes; retention is enforced entirely by S3 (Object Lock + lifecycle), so a compromised host cannot erase history (its own or any other server's). Object Lock (Governance, 30 days) prevents deletion by anyone without the `s3:BypassGovernanceRetention` permission. Volume backups can optionally be encrypted client-side (age) before upload — see [Backup Encryption](BACKUP_ENCRYPTION.md).
 
 For role configuration see [roles/backup/README.md](../roles/backup/README.md); for restore procedures, see [Disaster Recovery](DISASTER_RECOVERY.md).
 

--- a/docs/BACKUP_ENCRYPTION.md
+++ b/docs/BACKUP_ENCRYPTION.md
@@ -128,7 +128,7 @@ For a big backup, avoid round-tripping it through your laptop. Two options:
   there, and pipe the plaintext tar back over SSH:
 
   ```bash
-  aws s3 cp s3://PROJECT-backup/vol/VOLUME/backup-TS.tar.age - --region REGION \
+  aws s3 cp s3://PROJECT-backup/<server>/vol/VOLUME/backup-TS.tar.age - --region REGION \
     | age --decrypt -i ~/.ssh/id_ed25519 \
     | ssh user@server 'cat > /tmp/backup-TS.tar'
   ```
@@ -147,8 +147,8 @@ systemctl start miuops-backup.service
 journalctl -u miuops-backup.service -f
 
 # Check S3 for the encrypted object
-aws s3 ls s3://PROJECT-backup/vol/ --recursive --region REGION
-# Should show: vol/<volume>/backup-YYYYMMDDTHHMMSSZ.tar.age
+aws s3 ls s3://PROJECT-backup/<server>/vol/ --recursive --region REGION
+# Should show: <server>/vol/<volume>/backup-YYYYMMDDTHHMMSSZ.tar.age
 ```
 
 ## Restoring encrypted backups
@@ -159,7 +159,7 @@ aws s3 ls s3://PROJECT-backup/vol/ --recursive --region REGION
 
 ```bash
 # Download
-aws s3 cp s3://PROJECT-backup/vol/VOLUME/backup-YYYYMMDDTHHMMSSZ.tar.age . --region REGION
+aws s3 cp s3://PROJECT-backup/<server>/vol/VOLUME/backup-YYYYMMDDTHHMMSSZ.tar.age . --region REGION
 
 # Decrypt (age — identity file, SSH private key, or YubiKey)
 age --decrypt -i key.txt -o backup-YYYYMMDDTHHMMSSZ.tar backup-YYYYMMDDTHHMMSSZ.tar.age

--- a/docs/DAILY_OPS.md
+++ b/docs/DAILY_OPS.md
@@ -102,15 +102,15 @@ systemctl list-timers miuops-backup.timer
 docker compose exec postgres wal-g backup-list
 
 # Volume tarballs in S3 (one prefix per volume)
-aws s3 ls s3://PROJECT-backup/vol/ --recursive --region REGION
+aws s3 ls s3://PROJECT-backup/<server>/vol/ --recursive --region REGION
 ```
 
 ## Deploying changes
 
-Push to your stack repo's `main` branch. GitHub Actions handles deployment automatically:
+Push to your fleet repo's `main` branch. GitHub Actions handles deployment automatically:
 
 ```bash
-# From your stack repo (local machine)
+# From your fleet repo (local machine)
 git add -A && git commit -m "Update config" && git push
 ```
 
@@ -126,12 +126,12 @@ Use `add-domain` — it's additive: only the new domain's DNS is created, existi
 domains are untouched.
 
 ```bash
-CF_API_TOKEN=your_token ./miuops add-domain <host> newdomain.com
+CF_API_TOKEN=your_token miuops add-domain <host> newdomain.com
 ```
 
-`<host>` is the server's alias in `inventory.ini`. This creates the `newdomain.com`
-and `*.newdomain.com` CNAMEs, merges the domain into the host's `host_vars`, and
-re-converges. Then **add Traefik labels** in your stack repo's compose file with
+`<host>` is the server's alias in `fleet/inventory.ini`. This creates the `newdomain.com`
+and `*.newdomain.com` CNAMEs, merges the domain into the host's `fleet/host_vars`, and
+re-converges. Then **add Traefik labels** in your fleet repo's compose file with
 ``Host(`sub.newdomain.com`)`` and deploy.
 
 The Cloudflare API token needs DNS edit permission for the domain's zone (set this
@@ -139,11 +139,11 @@ when [creating the token](INSTALLATION.md#create-a-cloudflare-api-token)).
 
 ## Removing a domain
 
-Use `remove-domain` — it drops the domain from the host's `host_vars`, **deletes the
+Use `remove-domain` — it drops the domain from the host's `fleet/host_vars`, **deletes the
 orphaned CNAMEs** (`d` and `*.d`) for you, and re-converges:
 
 ```bash
-CF_API_TOKEN=your_token ./miuops remove-domain <host> example.org
+CF_API_TOKEN=your_token miuops remove-domain <host> example.org
 ```
 
 No manual Cloudflare dashboard cleanup needed. A server must keep at least one
@@ -169,16 +169,16 @@ For each domain, delete the two CNAME records pointing to `<tunnel-id>.cfargotun
 **3. Clean up local files:**
 
 ```bash
-rm -f files/<tunnel-id>.json
-rm -f host_vars/<host>.yml
-# remove the host's line from inventory.ini — or `rm -f inventory.ini` only if it was your only server
+rm -f fleet/secrets/<tunnel-id>.json
+rm -f fleet/host_vars/<host>.yml
+# remove the host's line from fleet/inventory.ini — or `rm -f fleet/inventory.ini` only if it was your only server
 ```
 
-The next `./miuops up` will create a fresh tunnel.
+The next `miuops up` will create a fresh tunnel.
 
 ## Reconfiguring servers (apply)
 
-Re-converge a server (or the whole fleet) after changing `host_vars` or pulling
+Re-converge a server (or the whole fleet) after changing `fleet/host_vars` or pulling
 tool updates — run from your local machine. `apply` only re-runs the playbook; it
 doesn't touch DNS, so no `CF_API_TOKEN` is needed.
 

--- a/docs/DISASTER_RECOVERY.md
+++ b/docs/DISASTER_RECOVERY.md
@@ -33,16 +33,17 @@ Ensure SSH access from your control machine. The server must run Debian or Ubunt
 
 ### 2. Restore this host's config
 
-Edit `inventory.ini` with the new server's IP and SSH user:
+Edit `fleet/inventory.ini` with the new server's IP and SSH user:
 
 ```ini
 [bare_metal]
 server1 ansible_host=NEW_IP ansible_user=admin
 ```
 
-Ensure `host_vars/server1.yml` (its `domains` + `tunnel_id`) exists, and restore the
-tunnel credentials to `files/<tunnel_id>.json` (reuse the same tunnel ID — no need
-to recreate it in Cloudflare).
+Ensure `fleet/host_vars/server1.yml` (its `domains` + `tunnel_id`) exists and the
+SOPS-encrypted tunnel credential `fleet/secrets/<tunnel_id>.json` is committed (reuse the
+same tunnel ID — no need to recreate it in Cloudflare; it is decrypted locally and pushed to
+the server at deploy).
 
 ### 3. Run the bootstrap playbook
 
@@ -54,26 +55,28 @@ This installs Docker, Traefik, cloudflared, and the firewall — same as initial
 setup. (`--limit server1` scopes the run to the rebuilt host; omit it to converge
 the whole fleet.)
 
-### 4. Update GitHub Actions secrets
+### 4. Update the server's deploy environment secrets
 
-In your stack repo (Settings > Secrets > Actions), update:
+In your fleet repo, open the per-server GitHub Environment (Settings > Environments >
+`<server>`) and update:
 
 | Secret | New value |
 |---|---|
 | `SSH_HOST` | New server IP or hostname |
 | `SSH_USER` | New SSH user (if changed) |
 | `SSH_PRIVATE_KEY` | New SSH private key (if changed) |
+| `SSH_KNOWN_HOSTS` | Re-pin the new host keys (`ssh-keyscan -p <port> <host>`) — a rebuilt server has new host keys |
 
-The stack's `.env` lives on the **server** at `/opt/stacks/.env` (not a GitHub
-secret) — recreate it on the rebuilt server as in [INSTALLATION.md](INSTALLATION.md)
-(the Ansible bootstrap pre-creates it with secure permissions; fill in your values).
+The app `.env` lives on the **server** at `/opt/stacks/.env` (provisioned locally from the
+SOPS-encrypted `fleet/secrets/<server>.env`, never a GitHub secret) — restore it on the
+rebuilt server as in [INSTALLATION.md](INSTALLATION.md).
 
 ### 5. Deploy stacks
 
-Push to your stack repo's `main` branch (or re-run the last workflow):
+Push to your fleet repo's `main` branch (or re-run the last workflow):
 
 ```bash
-# From your stack repo
+# From your fleet repo
 git commit --allow-empty -m "Redeploy to new server" && git push
 ```
 
@@ -184,7 +187,7 @@ numbers — deterministic ownership even when the restore host has a different
 **1. List backups for the volume:**
 
 ```bash
-aws s3 ls s3://PROJECT-backup/vol/VOLUME_NAME/ --region REGION
+aws s3 ls s3://PROJECT-backup/<server>/vol/VOLUME_NAME/ --region REGION
 ```
 
 If encrypted, files have a `.age` extension (e.g. `backup-YYYYMMDDTHHMMSSZ.tar.age`).
@@ -193,10 +196,10 @@ If encrypted, files have a `.age` extension (e.g. `backup-YYYYMMDDTHHMMSSZ.tar.a
 
 ```bash
 # Unencrypted
-aws s3 cp s3://PROJECT-backup/vol/VOLUME_NAME/backup-YYYYMMDDTHHMMSSZ.tar . --region REGION
+aws s3 cp s3://PROJECT-backup/<server>/vol/VOLUME_NAME/backup-YYYYMMDDTHHMMSSZ.tar . --region REGION
 
 # Encrypted (include the .age extension)
-aws s3 cp s3://PROJECT-backup/vol/VOLUME_NAME/backup-YYYYMMDDTHHMMSSZ.tar.age . --region REGION
+aws s3 cp s3://PROJECT-backup/<server>/vol/VOLUME_NAME/backup-YYYYMMDDTHHMMSSZ.tar.age . --region REGION
 ```
 
 **3. Decrypt the backup (if encrypted):**
@@ -317,7 +320,7 @@ Backups that haven't been tested are not backups. Periodically verify:
 3. **Volume backup list** — Confirm recent volume tarballs exist in S3 (one
    prefix per volume):
    ```bash
-   aws s3 ls s3://PROJECT-backup/vol/ --recursive --region REGION
+   aws s3 ls s3://PROJECT-backup/<server>/vol/ --recursive --region REGION
    ```
    You can also trigger a run on demand and watch it:
    ```bash

--- a/docs/INSTALLATION.md
+++ b/docs/INSTALLATION.md
@@ -18,7 +18,7 @@ End-to-end walkthrough: from bare server to running services. For a condensed ve
 2. Click **Create Token**
 3. Use the **Edit zone DNS** template
 4. Scope it to the zone(s) you'll use
-5. Save the token — you'll pass it as `CF_API_TOKEN` when running `./miuops up`
+5. Save the token — you'll pass it as `CF_API_TOKEN` when running `miuops up`
 
 ### Install local tools
 
@@ -45,17 +45,29 @@ unzip awscliv2.zip && sudo ./aws/install
 aws configure
 ```
 
-## Step 1: Bootstrap the server
+## Step 1: Create your fleet repo
+
+Go to **[miuops-fleet-template](https://github.com/tianshanghong/miuops-fleet-template)**,
+click **Use this template** > **Create a new repository** (private), then clone it. This is
+your fleet repo — it describes every server you run (`fleet/inventory.ini`,
+`fleet/host_vars/<server>.yml`, encrypted `fleet/secrets/`, and per-server stacks under
+`fleet/stacks/<server>/<stack>/`) and consumes miuOps as a dependency.
+
+Install the `miuops` CLI locally (clone [miuops](https://github.com/tianshanghong/miuops) and
+put it on your `PATH`, or symlink the `miuops` script). The CLI reads the fleet config from the
+fleet repo's working directory.
+
+## Step 2: Bootstrap the server
+
+From your fleet repo root, run the CLI with your Cloudflare token and the domains this server
+serves:
 
 ```bash
-git clone https://github.com/tianshanghong/miuops
-cd miuops
-
 # Single domain
-CF_API_TOKEN=your_token ./miuops up root@203.0.113.10 example.com
+CF_API_TOKEN=your_token miuops up root@203.0.113.10 example.com
 
 # Multiple domains
-CF_API_TOKEN=your_token ./miuops up root@203.0.113.10 example.com example.org
+CF_API_TOKEN=your_token miuops up root@203.0.113.10 example.com example.org
 ```
 
 The CLI handles everything:
@@ -63,7 +75,8 @@ The CLI handles everything:
 2. Looks up the Cloudflare Zone ID for each domain
 3. Creates a Cloudflare Tunnel (or reuses an existing one)
 4. Creates DNS CNAME records for all domains (Cloudflare API)
-5. Writes `inventory.ini` and `host_vars/<host>.yml`
+5. Writes `fleet/inventory.ini` and `fleet/host_vars/<server>.yml` (plaintext config), and
+   stores the tunnel credential SOPS-encrypted at `fleet/secrets/<tunnel_id>.json`
 6. Installs Ansible Galaxy dependencies
 7. Runs the playbook
 
@@ -81,12 +94,13 @@ The playbook provisions the server with:
 Preview what would happen without making changes:
 
 ```bash
-CF_API_TOKEN=your_token ./miuops up --dry-run root@203.0.113.10 example.com example.org
+CF_API_TOKEN=your_token miuops up --dry-run root@203.0.113.10 example.com example.org
 ```
 
 ### Manual setup (alternative)
 
-If you prefer to configure things manually instead of using the CLI:
+If you prefer to configure things manually instead of using the CLI, edit the fleet repo's
+`fleet/` config directly:
 
 <details>
 <summary>Click to expand manual steps</summary>
@@ -95,18 +109,16 @@ If you prefer to configure things manually instead of using the CLI:
 # Install Ansible requirements
 ansible-galaxy collection install -r requirements.yml
 
-# Configure
-cp inventory.ini.template inventory.ini
-cp host_vars/server1.yml.example host_vars/<host>.yml   # <host> = inventory alias
-# Edit inventory.ini with your server details (the host alias)
-# Edit host_vars/<host>.yml with that host's domains and tunnel ID
+# Configure (in your fleet repo)
+# Add the server's line to fleet/inventory.ini (the host alias)
+# Create fleet/host_vars/<server>.yml with that host's domains and tunnel ID
 
-# Create Cloudflare Tunnel (handled automatically by ./miuops up)
+# Create Cloudflare Tunnel (handled automatically by miuops up)
 cloudflared tunnel create miuops-203-0-113-10
 # Create DNS CNAME records in Cloudflare dashboard for each domain:
 #   example.com     -> <tunnel-id>.cfargotunnel.com (Proxied)
 #   *.example.com   -> <tunnel-id>.cfargotunnel.com (Proxied)
-# Copy tunnel credentials JSON into files/
+# SOPS-encrypt the tunnel credential JSON to fleet/secrets/<tunnel_id>.json
 
 # Bootstrap server
 ansible-playbook playbook.yml
@@ -114,7 +126,7 @@ ansible-playbook playbook.yml
 
 </details>
 
-## Step 2: Set up backups
+## Step 3: Set up backups
 
 ```bash
 ./scripts/setup-s3-backup.sh
@@ -123,32 +135,57 @@ ansible-playbook playbook.yml
 The script prompts for a project name and AWS region (default: `us-west-2`), then creates:
 - S3 bucket `{project}-backup` with Object Lock (Governance, 30 days)
 - Lifecycle rules: transition to Glacier at 30 days, expire at 90 days
-- IAM user `{project}-backup` with PutObject/GetObject/ListBucket only (no Delete)
+- IAM user with PutObject/GetObject/ListBucket only (no Delete)
 - Access key credentials
 
-Save the output — you'll need `AWS_ACCESS_KEY_ID`, `AWS_SECRET_ACCESS_KEY`, `AWS_REGION`, and the bucket name for your stack repo's `.env` file.
+One bucket serves the whole fleet; each server backs up under its own
+`<server>/` prefix (`<server>/db/…` for WAL-G, `<server>/vol/…` for volume
+tarballs), with a per-server prefix-scoped IAM user so a compromised server can
+touch only its own backups.
 
-## Step 3: Create your stack repo
+Save the output — you'll need `AWS_ACCESS_KEY_ID`, `AWS_SECRET_ACCESS_KEY`,
+`AWS_REGION`, and the bucket name for the server's encrypted
+`fleet/secrets/<server>.env`.
 
-1. Go to **[miuops-stack-template](https://github.com/tianshanghong/miuops-stack-template)** and click **Use this template** > **Create a new repository** (private)
+## Step 4: Wire the deploy environment and app secrets
 
-2. Configure GitHub Actions secrets in your new repo (Settings > Secrets > Actions):
+Each server deploys through its own [GitHub Environment](https://docs.github.com/actions/deployment/targeting-different-environments/using-environments-for-deployment),
+so a compromised or buggy deploy holds only that one server's key — no lateral movement.
 
-   | Secret | Value |
-   |---|---|
-   | `SSH_HOST` | Your server IP or hostname |
-   | `SSH_USER` | SSH user (same as `ansible_user`) |
-   | `SSH_PRIVATE_KEY` | Contents of your SSH private key |
+1. **Generate a deploy keypair and install only the public half.** You generate the keypair
+   (`ssh-keygen`); the tool installs the **public** key into the deploy user's
+   `authorized_keys`. The tool never handles a private key.
 
-3. SSH into the server and fill in `/opt/stacks/.env` (pre-created by the Ansible bootstrap with secure permissions):
+2. **Create a per-server GitHub Environment** named after the server handle (e.g. `server-01`,
+   matching `fleet/inventory.ini`), and set these environment secrets (Settings > Environments):
+
+   | Secret | Required | Value |
+   |--------|----------|-------|
+   | `SSH_HOST` | Yes | Server IP or hostname |
+   | `SSH_USER` | Yes | SSH username (the deploy user) |
+   | `SSH_PRIVATE_KEY` | Yes | The deploy **private** key (full PEM) |
+   | `SSH_PORT` | No | SSH port (default: 22) |
+   | `SSH_KNOWN_HOSTS` | No | Pinned host keys (`ssh-keyscan -p <port> <host>`); set it for production |
+
+   The deploy workflow targets `environment: <server>`, so each server reads only its own
+   environment's secrets.
+
+3. **Fill in app secrets, encrypted.** Copy the env template, fill in real values (domains,
+   backup credentials from Step 3, and service-specific variables), encrypt it in place with
+   SOPS, and commit the ciphertext:
 
    ```bash
-   ssh root@your-server nano /opt/stacks/.env
+   cp .env.example fleet/secrets/server-01.env
+   #   …edit fleet/secrets/server-01.env…
+   sops -e -i fleet/secrets/server-01.env
+   git add fleet/secrets/server-01.env
    ```
 
-   Copy variables from `.env.example` and fill in real values — domains, backup credentials (from Step 2), and service-specific variables.
+   The encrypted file is committed; it is unreadable without your age key. The age key never
+   enters CI — SOPS decryption happens locally at setup, and the per-server `.env` is installed
+   to `/opt/stacks/.env` on the server (the deploy excludes it from the sync).
 
-## Step 4: Deploy
+## Step 5: Deploy
 
 Push to `main` to trigger the GitHub Actions deploy pipeline:
 
@@ -156,7 +193,9 @@ Push to `main` to trigger the GitHub Actions deploy pipeline:
 git add -A && git commit -m "Initial deploy" && git push
 ```
 
-Verify your services are running:
+The caller workflow invokes the miuOps reusable `deploy.yml`, which discovers the servers whose
+stacks changed and syncs each changed server's `fleet/stacks/<server>/` over SSH. Verify your
+services are running:
 
 ```bash
 curl -I https://yourdomain.com
@@ -164,15 +203,16 @@ curl -I https://yourdomain.com
 
 You should see a response from Traefik routing to your services through Cloudflare Tunnel.
 
-## Step 5: Add your first app
+## Step 6: Add your first app
 
-The stack template README documents how to add compose stacks for new services. The general pattern:
+The fleet template README documents how to add compose stacks for new services. The general
+pattern:
 
-1. Create a compose file in `stacks/`
+1. Create a compose file at `fleet/stacks/<server>/<stack>/docker-compose.yml`
 2. Add Traefik labels for routing
 3. Push to `main` — GitHub Actions deploys automatically
 
-See the [stack template documentation](https://github.com/tianshanghong/miuops-stack-template) for compose patterns and examples.
+See the [fleet template documentation](https://github.com/tianshanghong/miuops-fleet-template) for compose patterns and examples.
 
 ## Troubleshooting
 

--- a/docs/OBSERVABILITY.md
+++ b/docs/OBSERVABILITY.md
@@ -48,7 +48,7 @@ observability_enabled: true
 With the env vars from step 2 exported in your shell:
 
 ```bash
-./miuops apply <host>      # or: ansible-playbook playbook.yml --limit <host> --tags observability
+miuops apply <host>        # or: ansible-playbook playbook.yml --limit <host> --tags observability
 ```
 
 Within a few minutes the host's metrics and logs appear in Grafana Cloud. Enable the

--- a/docs/SCALING.md
+++ b/docs/SCALING.md
@@ -1,23 +1,12 @@
-# Scaling to a fleet — migration & advanced patterns
+# Scaling & advanced patterns
 
-MiuOps manages multiple servers from one checkout: a flat `inventory.ini` plus one
-`host_vars/<host>.yml` per server (its `domains` + `tunnel_id`); globals come from
-role defaults. See [STRUCTURE.md](STRUCTURE.md) for the layout and
+Your private fleet repo (created from miuops-fleet-template) describes the whole
+fleet: `fleet/inventory.ini` plus one `fleet/host_vars/<server>.yml` per server (its
+`domains` + `tunnel_id`), with SOPS-encrypted tunnel creds + `<server>.env` under
+`fleet/secrets/`. See [STRUCTURE.md](STRUCTURE.md) for the layout and
 [DAILY_OPS.md](DAILY_OPS.md) for the day-to-day commands (`apply`, `add-domain`,
-`remove-domain`). This page covers the **one-time migration** and **optional
-advanced patterns** — none of which the tool requires.
-
-## Migrating an existing single-server setup
-
-1. `mkdir -p host_vars`
-2. Create `host_vars/<inventory_hostname>.yml` with the `domains` and `tunnel_id`
-   from your old `group_vars/all.yml` (see `host_vars/server1.yml.example`).
-3. Delete `group_vars/all.yml`.
-4. Ensure `inventory.ini` lists the host (flat, under `[bare_metal]`).
-5. `ansible-playbook playbook.yml --limit <host>` — should report `changed=0`.
-
-From separate clones: do the above once per server in a single checkout, import
-each server's `files/<tunnel_id>.json`, then retire the old clones.
+`remove-domain`). This page covers **optional advanced patterns** — none of which the
+tool requires.
 
 ## Per-server firewall posture
 
@@ -25,7 +14,7 @@ Each server's exposure is data in its `host_vars`. Defaults are generic-safe (SS
 rate-limited via `ufw limit`). To harden a specific server:
 
 ```yaml
-# host_vars/prod-a.yml
+# fleet/host_vars/prod-a.yml
 firewall_management_networks_v4: ["203.0.113.0/24"]   # allow SSH from these CIDRs
 firewall_ssh_ratelimit_enabled: false                 # then the rate-limiter is optional
 ```
@@ -69,14 +58,11 @@ compose `env_file:` instead of the shared `.env`.
 All optional — the tool never requires them.
 
 - **Environment grouping.** If several servers should share a posture, group them
-  in `inventory.ini` and put shared vars in `group_vars/<group>.yml` (standard
-  Ansible), then `miuops apply <group>` / `ansible-playbook --limit <group>`.
-- **Separate private config repo.** Keep `inventory.ini`, `host_vars/`, and
-  `files/*.json` in a private repo that consumes this public tool: point Ansible at
-  it with `ansible-playbook -i /path/to/fleet/inventory.ini playbook.yml`.
-- **SOPS-encrypted secrets.** Gitignored plaintext is readable by any agent on your
-  machine. Encrypting `host_vars`/`files` with [SOPS](https://github.com/getsops/sops)
-  stores ciphertext in git instead. With a **YubiKey-backed age key for sensitive
-  servers**, an agent cannot decrypt them at all (no hardware) — so it can neither
-  read nor deploy those hosts. (At deploy time the value is decrypted to be used;
-  SOPS protects it at rest.)
+  in `fleet/inventory.ini` and put shared vars in `fleet/group_vars/<group>.yml`
+  (standard Ansible), then `miuops apply <group>`.
+- **YubiKey-backed age key for sensitive servers.** The fleet repo already encrypts
+  tunnel creds + `<server>.env` with [SOPS](https://github.com/getsops/sops),
+  decrypted only on your machine. Backing the age key with a **YubiKey** means an
+  agent on your box cannot decrypt those secrets at all (no hardware) — it can neither
+  read nor deploy those hosts. (At deploy time the value is decrypted locally to be
+  used; SOPS protects it at rest.)

--- a/docs/STRUCTURE.md
+++ b/docs/STRUCTURE.md
@@ -1,29 +1,31 @@
 # Repository Structure
 
+This is the **miuOps tool** repo — the Ansible roles, the `miuops` CLI, and the reusable
+GitHub workflows. Your fleet's configuration (inventory, per-server vars, encrypted secrets,
+and stacks) lives in your **separate fleet repo**, created from `miuops-fleet-template`.
+
 ```
 .
 ├── ansible.cfg                # Ansible configuration
 ├── playbook.yml               # Main Ansible playbook
 ├── requirements.yml           # Ansible Galaxy requirements
-├── inventory.ini.template     # Example inventory file (flat host list)
-├── host_vars/
-│   └── server1.yml.example    # Per-server config example (domains + tunnel_id)
 ├── roles/
 │   ├── firewall/              # ufw host firewall (default-deny inbound)
 │   ├── docker/                # Docker engine + hardened daemon
-│   ├── ssh/                   # Key-only SSH
+│   ├── ssh/                   # Key-only SSH + operator-supplied deploy keys
 │   ├── traefik/               # Non-root host binary + read-only socket-proxy
 │   ├── cloudflared/           # Cloudflare Tunnel + DNS records
 │   ├── metadata-block/        # Block containers from the cloud metadata endpoint
 │   ├── observability/         # Grafana Alloy host binary (opt-in)
 │   ├── backup/                # Host-side Docker volume backup (systemd timer)
 │   └── unattended-upgrades/   # Automatic security upgrades
-├── files/                     # Tunnel credentials (gitignored)
+├── .github/workflows/         # Reusable deploy.yml + the stack policy-check
 ├── images/
 │   └── postgres-walg/         # PostgreSQL 17 + WAL-G Docker image
-├── miuops                     # CLI entry point (./miuops up)
+├── miuops                     # CLI entry point (miuops up)
 ├── scripts/
-│   └── setup-s3-backup.sh     # S3 backup bucket + IAM user creation
+│   └── setup-s3-backup.sh     # Shared S3 bucket + per-server prefix-scoped IAM
+├── tests/                     # CLI/oracle tests + the e2e acceptance harness
 └── docs/                      # Documentation
 ```
 

--- a/miuops
+++ b/miuops
@@ -699,7 +699,7 @@ ${existing}
             info "Domain: *.${domain} -> Cloudflare Tunnel -> Traefik"
         done
         echo ""
-        info "Next: create your stack repo from miuops-stack-template"
+        info "Next: create your private fleet repo from miuops-fleet-template"
     fi
 }
 


### PR DESCRIPTION
## What

Brings the miuOps docs in line with the fleet deployment model and renames the template
repo reference (`miuops-stack-template` → `miuops-fleet-template`).

- **README** — Quick Start / Options / Managing multiple servers / Backup rewritten for the
  fleet model: config lives in your **fleet repo** under `fleet/` (the CLI reads `fleet/`
  from the current directory); backups use one shared bucket with a **per-server prefix** and
  a **per-server, prefix-scoped IAM** user.
- **ARCHITECTURE / INSTALLATION** — the two-repo, tool-as-dependency model: a ~5-line caller
  workflow → the miuOps reusable `deploy.yml` pinned to a tag; per-server **GitHub
  Environments**; SOPS+age secrets decrypted **locally, never in CI**; operator-held SSH keys.
- **Day-2 / recovery / structure / backup-encryption / observability docs** — aligned to the
  fleet repo, per-server GitHub Environments (Settings → Environments, not repo Secrets), and
  per-server S3 prefixes; `miuops` on `PATH` (not `./miuops`).
- The CLI's "Next:" hint now points at `miuops-fleet-template`.
- Present tense throughout; no migration language.

## Notes

The GitHub repo rename is an operator action (GitHub auto-redirects the old name). The
reusable-workflow tag the template's caller pins is cut separately.

## Testing

`tests/cli_test.sh` green (covers the CLI hint change). Docs reviewed for accuracy against the
model and for zero residual `miuops-stack-template` / old per-stack-repo phrasing.