### PR TITLE
fix(secrets): make the copied tunnel credential writable before sops --in-place

### DIFF
--- a/miuops
+++ b/miuops
@@ -125,7 +125,10 @@ sops_encrypt_tunnel_cred() {  # $1 = tunnel_id
     [[ -f "$src" ]] || die "Tunnel credential not found at ${src}"
     mkdir -p "$SECRETS_DIR"; chmod 700 "$SECRETS_DIR"
     if [[ -f "$dst" ]]; then info "Encrypted tunnel credential already present: ${dst}"; return 0; fi
+    # cloudflared writes the tunnel credential read-only (0400); `cp` preserves that, so
+    # `sops --in-place` cannot rewrite it. Make our copy writable before encrypting.
     if ! ( cd "$FLEET_ROOT" && cp "$src" "fleet/secrets/${tid}.json" \
+            && chmod 600 "fleet/secrets/${tid}.json" \
             && sops --encrypt --input-type json --output-type json --in-place "fleet/secrets/${tid}.json" ); then
         rm -f "$dst"
         die "sops encrypt failed for ${tid}.json

--- a/tests/sops_test.sh
+++ b/tests/sops_test.sh
@@ -212,4 +212,24 @@ grep -q 'trap _sops_cleanup EXIT INT TERM' "$ROOT/miuops" || fail "CLI must arm 
 ) || fail "_sops_cleanup did not shred a registered temp"
 echo "ok: leak hygiene (no RETURN trap, no top-level trap, cleanup shreds registered temps)"
 
+# ── 8. encrypt handles a READ-ONLY source credential. cloudflared writes the tunnel
+# credential 0400 (read-only); `cp` preserves that, so `sops --in-place` cannot rewrite
+# the copy unless we make it writable first. Regression test for that real-VPS bug. ──
+ro_home="$TMP/ro-home"; mkdir -p "$ro_home/.cloudflared"
+ro_tid="ro000000-1111-2222-3333-444455556666"
+printf '{"AccountTag":"acct","TunnelSecret":"c2VjcmV0","TunnelID":"%s"}\n' "$ro_tid" > "$ro_home/.cloudflared/${ro_tid}.json"
+chmod 400 "$ro_home/.cloudflared/${ro_tid}.json"   # mimic cloudflared's read-only cred
+ro_out="$(
+  export HOME="$ro_home" MIUOPS_FLEET_DIR="$TMP/fleet"
+  # shellcheck source=/dev/null
+  source "$ROOT/miuops" --source-only
+  set +e +o pipefail
+  sops_encrypt_tunnel_cred "$ro_tid" 2>&1
+)" || true
+if [ -f "$TMP/fleet/secrets/${ro_tid}.json" ] && grep -q 'ENC\[' "$TMP/fleet/secrets/${ro_tid}.json"; then
+  echo "ok: encrypt handles a read-only (0400) source credential -> ciphertext"
+else
+  fail "encrypt failed on a read-only (0400) source cred — the cloudflared case: ${ro_out}"
+fi
+
 echo "ALL SOPS TESTS PASSED"


### PR DESCRIPTION
## Problem

`miuops up` aborts at the SOPS encryption step on a fresh bootstrap:

```
Could not open in-place file for writing: open fleet/secrets/<id>.json: permission denied
error: sops encrypt failed for <id>.json
```

`cloudflared tunnel create` writes the tunnel credential **read-only (0400)**.
`sops_encrypt_tunnel_cred` then `cp`s it into `fleet/secrets/<id>.json` — and `cp`
preserves the source mode — so the copy is also 0400. `sops --encrypt --in-place`
can't reopen that copy for writing, and the bootstrap dies before writing
`host_vars` or converging. (Confirmed: `cp` preserves 0400 on both macOS and
Linux; `sops -i` opens the file for writing, so a 0400 file fails closed.)

## Fix

`chmod 600` the copied credential after `cp`, before `sops --in-place` (one line).
The committed result is ciphertext, so 0600 is the right resting mode.

## How it was found

The end-to-end acceptance run, against a fresh VPS — not the unit suite. The
existing `sops_test.sh` built its fixtures with a writable `printf` redirect, so
it never exercised the read-only-source path that `cloudflared` actually produces.

## Regression test

`tests/sops_test.sh` gains check 8: a read-only (0400) source credential must
still encrypt to ciphertext. Mutation-verified — dropping the `chmod` line makes
check 8 fail with the exact `permission denied` above.

## Testing

- `tests/sops_test.sh` — green (incl. new check 8)
- `tests/cli_test.sh` — green
- `shellcheck -S error miuops tests/sops_test.sh` — clean
- After the fix, the same `miuops up` converged the fresh VPS clean
  (`ok=66 changed=42 failed=0`), and the idempotency re-run reported `changed=0`.