### PR TITLE
fix(backup): make setup-s3-backup.sh non-interactive (--region/--yes)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -27,12 +27,13 @@ jobs:
             .github/scripts/discover-changed-servers.sh .github/scripts/deploy-server.sh \
             tests/ssh_deploy_key_validation_test.sh \
             scripts/test/iam-policy-oracle.sh scripts/setup-s3-backup.sh \
-            tests/sops_test.sh
+            tests/sops_test.sh tests/setup_s3_backup_noninteractive_test.sh
           bash tests/cli_test.sh
           bash tests/discover_changed_servers_test.sh
           bash tests/deploy_workflow_lint_test.sh
           bash tests/ssh_deploy_key_validation_test.sh
           bash scripts/test/iam-policy-oracle.sh
+          bash tests/setup_s3_backup_noninteractive_test.sh
 
       - name: SOPS + age secret check (self-contained round-trip + tamper)
         # The check generates a throwaway age key and a temp .sops.yaml — no

--- a/scripts/setup-s3-backup.sh
+++ b/scripts/setup-s3-backup.sh
@@ -78,6 +78,10 @@ set -e
 
 SERVER="${MIUOPS_SERVER:-}"
 PROJECT_NAME="${MIUOPS_PROJECT:-}"
+# Honour a pre-set region (env or --region); prompt only if still unset + interactive.
+AWS_REGION="${AWS_REGION:-${MIUOPS_REGION:-}}"
+# --yes / MIUOPS_ASSUME_YES skips the confirm prompt so the script runs non-interactively.
+ASSUME_YES="${MIUOPS_ASSUME_YES:-false}"
 
 while [[ $# -gt 0 ]]; do
     case "$1" in
@@ -97,11 +101,25 @@ while [[ $# -gt 0 ]]; do
             PROJECT_NAME="${1#*=}"
             shift
             ;;
+        --region)
+            AWS_REGION="$2"
+            shift 2
+            ;;
+        --region=*)
+            AWS_REGION="${1#*=}"
+            shift
+            ;;
+        -y | --yes)
+            ASSUME_YES=true
+            shift
+            ;;
         -h | --help)
-            echo "Usage: $0 [--project <name>] [--server <name>]"
+            echo "Usage: $0 [--project <name>] [--server <name>] [--region <r>] [--yes]"
             echo "  --project <name>  fleet/bucket prefix (bucket = <name>-backup)"
             echo "  --server <name>   per-server identity (IAM user + S3 prefix)"
-            echo "Env: MIUOPS_PROJECT, MIUOPS_SERVER mirror the flags."
+            echo "  --region <r>      AWS region (default us-west-2; skips the region prompt)"
+            echo "  -y, --yes         assume yes — skip the confirm prompt (non-interactive)"
+            echo "Env: MIUOPS_PROJECT, MIUOPS_SERVER, MIUOPS_REGION, MIUOPS_ASSUME_YES mirror the flags."
             exit 0
             ;;
         *)
@@ -180,7 +198,9 @@ BUCKET_NAME="${PROJECT_NAME}-backup"
 # pair scoped to its own "<server>/" prefix only.
 IAM_USER="${BUCKET_NAME}-${SERVER}"
 
-read -rp "Enter AWS region [us-west-2]: " AWS_REGION
+if [[ -z "$AWS_REGION" && -t 0 && "$ASSUME_YES" != true ]]; then
+    read -rp "Enter AWS region [us-west-2]: " AWS_REGION
+fi
 AWS_REGION=${AWS_REGION:-us-west-2}
 
 echo ""
@@ -191,10 +211,17 @@ echo "  - S3 prefix:  ${SERVER}/  (this server's keyspace)"
 echo "  - Object Lock: Governance mode, 30-day retention"
 echo "  - Lifecycle:   Glacier after 30 days, expire after 90 days"
 echo ""
-read -rp "Continue? (y/N): " CONFIRM
-if [[ "$CONFIRM" != "y" && "$CONFIRM" != "Y" ]]; then
-    echo "Aborted."
-    exit 0
+if [[ "$ASSUME_YES" != true ]]; then
+    if [[ ! -t 0 ]]; then
+        echo "Refusing to proceed without confirmation in a non-interactive shell." >&2
+        echo "Re-run with --yes (or MIUOPS_ASSUME_YES=true) to confirm." >&2
+        exit 1
+    fi
+    read -rp "Continue? (y/N): " CONFIRM
+    if [[ "$CONFIRM" != "y" && "$CONFIRM" != "Y" ]]; then
+        echo "Aborted."
+        exit 0
+    fi
 fi
 
 # -- Create bucket ------------------------------------------------------------

--- a/tests/setup_s3_backup_noninteractive_test.sh
+++ b/tests/setup_s3_backup_noninteractive_test.sh
@@ -1,0 +1,49 @@
+#!/usr/bin/env bash
+# Verifies setup-s3-backup.sh runs non-interactively: --yes/--region (and the mirror
+# env vars MIUOPS_ASSUME_YES/MIUOPS_REGION) skip the prompts, while a non-interactive
+# shell WITHOUT --yes fails closed (refuses, creating nothing). `aws` is mocked so no
+# real AWS call ever happens — the credential check passes and any other call is
+# refused-and-recorded, which proves the script got PAST the prompts without creating
+# resources.
+set -euo pipefail
+ROOT="$(cd "$(dirname "$0")/.." && pwd)"
+SCRIPT="$ROOT/scripts/setup-s3-backup.sh"
+TMP="$(mktemp -d)"; trap 'rm -rf "$TMP"' EXIT
+fail() { printf 'FAIL: %s\n' "$1" >&2; exit 1; }
+
+cat > "$TMP/aws" <<'SH'
+#!/usr/bin/env bash
+if [[ "$*" == *"get-caller-identity"* ]]; then echo "arn:aws:iam::000000000000:user/Mock"; exit 0; fi
+echo "mock-aws-call: $*" >&2; exit 1
+SH
+chmod +x "$TMP/aws"
+
+# 1. --yes + --region: both prompts skipped, reaches a real (mocked) AWS call.
+out="$(PATH="$TMP:$PATH" bash "$SCRIPT" --project tx --server ty --region us-west-2 --yes </dev/null 2>&1 || true)"
+if ! printf '%s' "$out" | grep -q 'mock-aws-call:'; then
+  fail "--yes did not run non-interactively (never reached an AWS call): $out"
+fi
+if printf '%s' "$out" | grep -qiE 'Continue\?|Enter AWS region'; then
+  fail "--yes still printed an interactive prompt"
+fi
+echo "ok: --yes --region runs non-interactively (skips both prompts)"
+
+# 2. env vars mirror the flags.
+out="$(PATH="$TMP:$PATH" MIUOPS_PROJECT=tx MIUOPS_SERVER=ty MIUOPS_REGION=us-west-2 MIUOPS_ASSUME_YES=true \
+        bash "$SCRIPT" </dev/null 2>&1 || true)"
+if ! printf '%s' "$out" | grep -q 'mock-aws-call:'; then
+  fail "MIUOPS_ASSUME_YES/MIUOPS_REGION env did not run non-interactively: $out"
+fi
+echo "ok: MIUOPS_ASSUME_YES + MIUOPS_REGION env mirror the flags"
+
+# 3. non-interactive WITHOUT --yes: refuse clearly, create nothing (fail closed).
+out="$(PATH="$TMP:$PATH" bash "$SCRIPT" --project tx --server ty --region us-west-2 </dev/null 2>&1 || true)"
+if ! printf '%s' "$out" | grep -qi 'Refusing to proceed'; then
+  fail "non-interactive without --yes did not refuse clearly: $out"
+fi
+if printf '%s' "$out" | grep -q 'mock-aws-call:'; then
+  fail "non-interactive without --yes still reached an AWS call (not fail-closed)"
+fi
+echo "ok: non-interactive without --yes fails closed (no resources created)"
+
+echo "ALL SETUP-S3-BACKUP NON-INTERACTIVE TESTS PASSED"


### PR DESCRIPTION
## Problem

`setup-s3-backup.sh` accepts `--project`/`--server` (and `MIUOPS_PROJECT`/`MIUOPS_SERVER`)
for non-interactive use, but it still **blocks on two prompts** regardless:

- the AWS region — `read` unconditionally overwrote any pre-set `AWS_REGION`
- a `Continue? (y/N)` confirm

So a scripted run (CI, an acceptance harness, a fleet-bootstrap wrapper) hangs or aborts
on EOF even with every input supplied. Found while running the fleet acceptance e2e — the
automation couldn't drive it non-interactively without feeding `\n y \n` to stdin.

## Fix

- `--region <r>` / `MIUOPS_REGION` / a pre-set `AWS_REGION` → skip the region prompt (default `us-west-2`).
- `-y` / `--yes` / `MIUOPS_ASSUME_YES=true` → skip the confirm prompt.
- A non-interactive shell (no TTY) **without** `--yes` now refuses clearly and exits non-zero,
  instead of silently aborting on EOF — fail-closed, creating nothing.
- Interactive (TTY) use is unchanged: it still prompts.

## Testing

- New `tests/setup_s3_backup_noninteractive_test.sh` mocks `aws` (no real calls): `--yes`/`--region`
  and the env mirrors reach the first AWS call with no prompt; a non-TTY run without `--yes`
  fails closed before any AWS call. Mutation-verified (neutering `--yes` makes it fail). Wired into CI.
- `shellcheck -S error` clean.