### PR TITLE
chore: rename iam-policy oracle test to check; drop "oracle" from test terminology

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -26,13 +26,13 @@ jobs:
           shellcheck -S error miuops tests/stack_policy_check_test.sh \
             .github/scripts/discover-changed-servers.sh .github/scripts/deploy-server.sh \
             tests/ssh_deploy_key_validation_test.sh \
-            scripts/test/iam-policy-oracle.sh scripts/setup-s3-backup.sh \
+            scripts/test/iam-policy-check.sh scripts/setup-s3-backup.sh \
             tests/sops_test.sh
           bash tests/cli_test.sh
           bash tests/discover_changed_servers_test.sh
           bash tests/deploy_workflow_lint_test.sh
           bash tests/ssh_deploy_key_validation_test.sh
-          bash scripts/test/iam-policy-oracle.sh
+          bash scripts/test/iam-policy-check.sh
 
       - name: SOPS + age secret check (self-contained round-trip + tamper)
         # The check generates a throwaway age key and a temp .sops.yaml — no

--- a/docs/STRUCTURE.md
+++ b/docs/STRUCTURE.md
@@ -25,7 +25,7 @@ and stacks) lives in your **separate fleet repo**, created from `miuops-fleet-te
 ├── miuops                     # CLI entry point (miuops up)
 ├── scripts/
 │   └── setup-s3-backup.sh     # Shared S3 bucket + per-server prefix-scoped IAM
-├── tests/                     # CLI/oracle tests + the e2e acceptance harness
+├── tests/                     # CLI/unit tests + the e2e acceptance harness
 └── docs/                      # Documentation
 ```
 

--- a/roles/ssh/README.md
+++ b/roles/ssh/README.md
@@ -74,7 +74,7 @@ gh secret set SSH_PRIVATE_KEY --env <server> --body "$(cat deploy_<server>)"
 shred -u deploy_<server>   # private key now lives ONLY in the Environment
 ```
 
-The allowlist/refusal logic is covered by an oracle: `tests/ssh_deploy_key_validation_test.sh`.
+The allowlist/refusal logic is covered by a test: `tests/ssh_deploy_key_validation_test.sh`.
 
 ## Requirements
 

--- a/roles/ssh/tasks/main.yml
+++ b/roles/ssh/tasks/main.yml
@@ -23,7 +23,7 @@
       # Positive allowlist. The four space-delimited types need a trailing space so a
       # glued suffix ('ssh-rsaEVIL...') and a bare type with no key body are refused;
       # the ecdsa types keep a bare prefix (a curve name follows). Mirrors the test
-      # oracle exactly so role and test share one accept/refuse boundary.
+      # check exactly so role and test share one accept/refuse boundary.
       - >-
         item is match('^(ssh-rsa |ssh-ed25519 |ssh-dss |ecdsa-sha2-|sk-ssh-ed25519@openssh\.com |sk-ecdsa-sha2-)')
       # Fail-closed, case-insensitive: refuse anything carrying private-key material.

--- a/scripts/setup-s3-backup.sh
+++ b/scripts/setup-s3-backup.sh
@@ -63,7 +63,7 @@ gen_iam_policy() {
 EOF
 }
 
-# When sourced as a library (by the oracle test), define the functions above and
+# When sourced as a library (by the iam-policy check), define the functions above and
 # stop here -- do NOT run the interactive provisioning flow or touch AWS.
 if [ -n "${MIUOPS_S3_SETUP_LIB:-}" ]; then
     # `return` when sourced; the `exit` is the fallback if run directly with the

--- a/scripts/test/iam-policy-check.sh
+++ b/scripts/test/iam-policy-check.sh
@@ -1,6 +1,6 @@
 #!/usr/bin/env bash
 #
-# Oracle for the per-server backup IAM policy emitted by scripts/setup-s3-backup.sh.
+# Check for the per-server backup IAM policy emitted by scripts/setup-s3-backup.sh.
 #
 # It GENERATES the inline policy for a sample bucket + server (by sourcing the
 # setup script and calling its gen_iam_policy function), then asserts the exact
@@ -130,7 +130,7 @@ assert_false_jq "no other-server (${OTHER_SERVER}/*) object resource" "$POLICY" 
 # --- negative fixtures: prove each assertion CAN fail ------------------------
 # A bad policy that regressed to bucket-wide + added Delete + a Deny + s3:*.
 # Running the SAME filters against it must flip every result; if any of these
-# "negative" checks passes against the bad fixture, the oracle itself is broken.
+# "negative" checks passes against the bad fixture, the check itself is broken.
 echo "== negative fixtures (each must trip the matching assertion) =="
 BAD_POLICY=$(cat <<EOF
 {
@@ -185,8 +185,8 @@ echo "== summary =="
 echo "positive assertions: ${pass} ok, ${fail} fail"
 echo "negative fixtures:   ${neg_ok} ok, ${neg_bad} fail"
 if [ "$fail" -ne 0 ] || [ "$neg_bad" -ne 0 ]; then
-  echo "ORACLE: FAIL"
+  echo "IAM POLICY CHECK: FAIL"
   exit 1
 fi
-echo "ORACLE: PASS"
+echo "IAM POLICY CHECK: PASS"
 exit 0

--- a/tests/ssh_deploy_key_validation_test.sh
+++ b/tests/ssh_deploy_key_validation_test.sh
@@ -1,5 +1,5 @@
 #!/usr/bin/env bash
-# Oracle for the ssh role's deploy-key validation (fail-closed).
+# Check for the ssh role's deploy-key validation (fail-closed).
 #
 # The ssh role installs only PUBLIC keys into a server's authorized_keys. It must
 # POSITIVELY validate every supplied value against an allowlist of public-key


### PR DESCRIPTION
## What

Renames `scripts/test/iam-policy-oracle.sh` → `scripts/test/iam-policy-check.sh` and drops
the word "oracle" from test-context terminology across the public repo.

"Oracle" in the AI-agent sense means an external data/capability provider; using it for our
unit/acceptance tests is confusing, so test references now say "check"/"test".

## Changes (no logic — filenames, comments, strings, docs only)

- `iam-policy-oracle.sh` → `iam-policy-check.sh` (+ header, an internal comment, and the
  `ORACLE: PASS/FAIL` output → `IAM POLICY CHECK: PASS/FAIL`)
- `.github/workflows/ci.yml` — both references updated
- `tests/ssh_deploy_key_validation_test.sh`, `roles/ssh/README.md`, `roles/ssh/tasks/main.yml`,
  `docs/STRUCTURE.md`, `scripts/setup-s3-backup.sh` — "oracle" → "check"/"test"/"unit"

## Testing

- `scripts/test/iam-policy-check.sh` passes; `tests/ssh_deploy_key_validation_test.sh` passes
- `shellcheck -S error` clean on the changed shell files

## Note

Touches `ci.yml` and `setup-s3-backup.sh`, which the open backup-non-interactive fix also
touches — whichever merges second may need a trivial rebase.