### PR TITLE
fix(deploy): reusable workflow checks out miuops for its own deploy scripts

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -14,12 +14,18 @@ name: Deploy fleet stacks
 #       # mutable ref (a branch) would be a server-takeover supply-chain risk.
 #       # A release TAG is the minimum; a full commit SHA is strongest.
 #       uses: tianshanghong/miuops/.github/workflows/deploy.yml@v1
+#       with:
+#         # MUST equal the @ref above. This workflow loads its deploy scripts from
+#         # miuops at this ref, so they are the SAME immutable version as the
+#         # workflow. (A reusable workflow can't read its own @ref at run time --
+#         # github.job_workflow_ref is empty on current runners -- so it's passed.)
+#         miuops_ref: v1
 #       secrets: inherit
 #
 # Per-server secret isolation: each changed server gets its own matrix job with a
 # job-level `environment: <server>`, so it loads ONLY that server's Environment
 # secrets (SSH_HOST/SSH_USER/SSH_PORT/SSH_PRIVATE_KEY/SSH_KNOWN_HOSTS). A matrix
-# job for one server cannot reference another's secrets — that is the isolation.
+# job for one server cannot reference another's secrets -- that is the isolation.
 # `on.workflow_call` cannot declare an environment, so the binding is at job level
 # (where the matrix context is available). `secrets: inherit` lets this workflow
 # reference secrets at all; the `environment:` binding (not inherit) is what
@@ -29,6 +35,18 @@ name: Deploy fleet stacks
 on:
   workflow_call:
     inputs:
+      miuops_ref:
+        description: >-
+          Ref of the miuops repo to load the deploy scripts from. MUST match the
+          @<ref> this workflow is pinned to in the caller, so the scripts are the
+          same immutable version as the workflow itself.
+        type: string
+        required: true
+      miuops_repo:
+        description: Repository that holds the deploy scripts (override only for a fork).
+        type: string
+        required: false
+        default: tianshanghong/miuops
       stacks_dir:
         description: Path prefix in the fleet repo that holds per-server stacks.
         type: string
@@ -64,6 +82,18 @@ jobs:
         with:
           fetch-depth: 0
 
+      # This is a REUSABLE workflow: the checkout above is the CALLER's fleet repo,
+      # which has no deploy scripts (they live here, in miuops). Check out miuops at
+      # the caller-supplied ref (== the @pin) so the machinery is that exact version.
+      # The scripts still operate on the caller's checkout (GITHUB_WORKSPACE).
+      - name: Check out miuops machinery (deploy scripts)
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+        with:
+          repository: ${{ inputs.miuops_repo }}
+          ref: ${{ inputs.miuops_ref }}
+          path: .miuops-machinery
+          persist-credentials: false
+
       - name: Scan changed servers
         id: scan
         env:
@@ -75,7 +105,7 @@ jobs:
           STACKS_DIR: ${{ inputs.stacks_dir }}
         run: |
           set -euo pipefail
-          servers="$(bash "${GITHUB_WORKSPACE}/.github/scripts/discover-changed-servers.sh")"
+          servers="$(bash "${GITHUB_WORKSPACE}/.miuops-machinery/.github/scripts/discover-changed-servers.sh")"
           printf 'servers=%s\n' "$servers" >> "$GITHUB_OUTPUT"
           printf 'Changed servers: %s\n' "$servers"
 
@@ -102,6 +132,16 @@ jobs:
     steps:
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
 
+      # Same as the discover job: pull the deploy scripts from miuops at the pinned
+      # ref (the caller's checkout above has only the fleet's stacks, no scripts).
+      - name: Check out miuops machinery (deploy scripts)
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+        with:
+          repository: ${{ inputs.miuops_repo }}
+          ref: ${{ inputs.miuops_ref }}
+          path: .miuops-machinery
+          persist-credentials: false
+
       - name: Deploy ${{ matrix.server }}
         env:
           # Resolve from environment: ${{ matrix.server }} -- this one server only.
@@ -115,4 +155,4 @@ jobs:
           SERVER: ${{ matrix.server }}
           STACKS_DIR: ${{ inputs.stacks_dir }}
           REMOTE_STACKS_DIR: ${{ inputs.remote_stacks_dir }}
-        run: bash "${GITHUB_WORKSPACE}/.github/scripts/deploy-server.sh"
+        run: bash "${GITHUB_WORKSPACE}/.miuops-machinery/.github/scripts/deploy-server.sh"

--- a/tests/deploy_workflow_lint_test.sh
+++ b/tests/deploy_workflow_lint_test.sh
@@ -20,6 +20,16 @@ grep -qF 'fromJSON(needs.discover.outputs.servers)' "$Y"    || fail "matrix must
 grep -qF "servers != '[]'" "$Y"                             || fail "deploy must guard against an empty matrix"
 grep -qF 'fail-fast: false' "$Y"                            || fail "matrix must set fail-fast: false (one server's failure must not cancel others)"
 
+# Machinery checkout: a reusable workflow runs in the CALLER's checkout (the fleet
+# repo, which has no deploy scripts), so it must check out miuops at the pinned ref
+# and run the scripts from there. Regression guard for the exit-127 "script not
+# found" bug (github.job_workflow_ref is empty on current runners, hence miuops_ref).
+grep -qE '^[[:space:]]*miuops_ref:' "$Y"                    || fail "must declare a miuops_ref input (the ref to load deploy scripts from)"
+grep -qF 'repository: ${{ inputs.miuops_repo }}' "$Y"       || fail "must check out the miuops machinery repo (inputs.miuops_repo)"
+grep -qF 'ref: ${{ inputs.miuops_ref }}' "$Y"               || fail "machinery checkout must use the caller-supplied miuops_ref"
+grep -qF '.miuops-machinery/.github/scripts/' "$Y"          || fail "deploy scripts must run from the checked-out miuops machinery"
+! grep -qF '${GITHUB_WORKSPACE}/.github/scripts/' "$Y"      || fail "scripts must NOT run from the caller's checkout (that path is the fleet repo, which lacks them)"
+
 # Supply chain: every real action use pinned to a 40-hex commit SHA, no tags.
 uses_count=$(grep -cE 'uses:[[:space:]]+[A-Za-z0-9_.-]+/[A-Za-z0-9_.-]+@[0-9a-f]{40}' "$Y" || true)
 [ "${uses_count:-0}" -ge 2 ]                                || fail "real action uses must be SHA-pinned (found ${uses_count})"


### PR DESCRIPTION
## Problem

The reusable deploy workflow ran its scripts from `\${GITHUB_WORKSPACE}/.github/scripts/`.
In a reusable-workflow context, `actions/checkout` (and `GITHUB_WORKSPACE`) is the **caller's**
fleet repo, which has none of those scripts — they live here, in miuops. So the `discover`
job died with `exit 127`:

```
bash: /home/runner/work/<fleet>/<fleet>/.github/scripts/discover-changed-servers.sh: No such file or directory
```

The GitOps deploy never worked for any adopter.

## Why it slipped through

The deploy-workflow lint test only parses the YAML; CI exercises the playbook on a dev host,
not the reusable workflow across repos. Only a real end-to-end run — a fleet repo calling this
workflow from GitHub Actions — surfaces it.

## Fix

Check out miuops (this repo) at a caller-supplied `miuops_ref` into `.miuops-machinery`, and run
the scripts from there. They still operate on the caller's checkout (`GITHUB_WORKSPACE`) for the
stacks and the git diff.

`github.job_workflow_ref` — the documented way for a reusable workflow to learn its own ref —
is **empty on current runners** (confirmed in a live run), so the ref can't be derived; the
caller passes it explicitly, and it MUST match the `@ref` pin.

### Caller change (template + adopters must add this)

```yaml
uses: tianshanghong/miuops/.github/workflows/deploy.yml@v1
with:
  miuops_ref: v1   # must match the @ref above
secrets: inherit
```

(The fleet template's caller is updated to match.)

## Tests

- `tests/deploy_workflow_lint_test.sh` gains regression guards: scripts must run from
  `.miuops-machinery`, never the caller's `.github/scripts/`; `miuops_ref` input present.
  Mutation-verified (reverting the path fails the test).
- Validated end-to-end: a fleet repo push → Deploy run green → the stack rsynced and
  `docker compose up` on a fresh VPS → served at `https://…` over a valid TLS chain.