### PR TITLE
fix(backup): auto-install age-plugin-yubikey for YubiKey recipients

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -27,10 +27,12 @@ jobs:
             .github/scripts/discover-changed-servers.sh .github/scripts/deploy-server.sh \
             tests/ssh_deploy_key_validation_test.sh \
             scripts/test/iam-policy-check.sh scripts/setup-s3-backup.sh \
-            tests/sops_test.sh tests/setup_s3_backup_noninteractive_test.sh
+            tests/sops_test.sh tests/setup_s3_backup_noninteractive_test.sh \
+            tests/backup_role_lint_test.sh
           bash tests/cli_test.sh
           bash tests/discover_changed_servers_test.sh
           bash tests/deploy_workflow_lint_test.sh
+          bash tests/backup_role_lint_test.sh
           bash tests/ssh_deploy_key_validation_test.sh
           bash scripts/test/iam-policy-check.sh
           bash tests/setup_s3_backup_noninteractive_test.sh

--- a/roles/backup/README.md
+++ b/roles/backup/README.md
@@ -108,6 +108,13 @@ AWS credentials are **not** in host_vars — export them as environment variable
 `/etc/miuops-backup/backup.env` (mode `0600`, root) and sourced by the script,
 so they never appear in `ps` / the process table.
 
+When `backup_age_recipients` includes a YubiKey identity (`age1yubikey1...`), the
+role installs **age-plugin-yubikey** on the host automatically (pinned `.deb` +
+checksum; amd64 only — `age` cannot encrypt to a plugin recipient without it).
+Encryption uses only the public key, so the host needs no YubiKey and the daily
+backup runs unattended — the YubiKey is required only to *decrypt* at restore
+time, on the operator's machine.
+
 ## Files on the host
 
 | Path | Mode | Purpose |

--- a/roles/backup/defaults/main.yml
+++ b/roles/backup/defaults/main.yml
@@ -56,6 +56,16 @@ backup_randomized_delay_sec: "45m"
 backup_encryption: "none"
 backup_age_recipients: []
 
+# When a recipient is a YubiKey identity (age1yubikey1...), the host needs
+# age-plugin-yubikey -- plain `age` cannot wrap a key for a plugin recipient
+# without it. The role installs it automatically in that case. Encryption uses
+# only the public key, so NO YubiKey is needed on the server (the daily backup
+# runs unattended); the YubiKey is required only to DECRYPT at restore time, on
+# the operator's machine. Pinned to the last release that ships a Linux .deb
+# (v0.5.1 dropped the Linux build); amd64 only -- no prebuilt arm64 Linux binary.
+backup_age_plugin_yubikey_version: "0.5.0"
+backup_age_plugin_yubikey_deb_sha256: "bf7a02418de04b3d3df9791e185d493eb344829bca4009247a41bc4d7630b47f"
+
 # --- AWS credentials --------------------------------------------------------
 # Supplied via environment variables at apply time so secrets stay env-only and
 # never get written into the repo. Export before running, e.g.:

--- a/roles/backup/defaults/main.yml
+++ b/roles/backup/defaults/main.yml
@@ -61,9 +61,13 @@ backup_age_recipients: []
 # without it. The role installs it automatically in that case. Encryption uses
 # only the public key, so NO YubiKey is needed on the server (the daily backup
 # runs unattended); the YubiKey is required only to DECRYPT at restore time, on
-# the operator's machine. Pinned to the last release that ships a Linux .deb
-# (v0.5.1 dropped the Linux build); amd64 only -- no prebuilt arm64 Linux binary.
+# the operator's machine. Pinned to the last release that ships a Linux .deb:
+# v0.5.1 DROPPED the Linux build, and the binary is amd64-only (no arm64 Linux
+# build) -- this release is effectively frozen upstream. For a newer build use a
+# distro package or `cargo install age-plugin-yubikey`. A version bump must change
+# version + deb_revision + sha256 TOGETHER (the .deb filename embeds the revision).
 backup_age_plugin_yubikey_version: "0.5.0"
+backup_age_plugin_yubikey_deb_revision: "1"
 backup_age_plugin_yubikey_deb_sha256: "bf7a02418de04b3d3df9791e185d493eb344829bca4009247a41bc4d7630b47f"
 
 # --- AWS credentials --------------------------------------------------------

--- a/roles/backup/tasks/main.yml
+++ b/roles/backup/tasks/main.yml
@@ -42,9 +42,12 @@
     that:
       - backup_encryption in ['none', 'age']
       - not (backup_encryption == 'age' and (backup_age_recipients | length == 0))
+      - not (backup_encryption == 'none' and (backup_age_recipients | length > 0))
     fail_msg: >-
       Invalid encryption config. backup_encryption must be one of none|age;
-      age requires backup_age_recipients.
+      'age' requires backup_age_recipients; and recipients set with encryption
+      'none' would upload PLAINTEXT -- set backup_encryption: age, or clear
+      backup_age_recipients.
     quiet: true
   when: backup_enabled | bool
   tags: ['backup']
@@ -97,8 +100,8 @@
 
     - name: Download age-plugin-yubikey .deb (pinned + checksum)
       ansible.builtin.get_url:
-        url: "https://github.com/str4d/age-plugin-yubikey/releases/download/v{{ backup_age_plugin_yubikey_version }}/age-plugin-yubikey_{{ backup_age_plugin_yubikey_version }}-1_amd64.deb"
-        dest: "/tmp/age-plugin-yubikey_{{ backup_age_plugin_yubikey_version }}-1_amd64.deb"
+        url: "https://github.com/str4d/age-plugin-yubikey/releases/download/v{{ backup_age_plugin_yubikey_version }}/age-plugin-yubikey_{{ backup_age_plugin_yubikey_version }}-{{ backup_age_plugin_yubikey_deb_revision }}_amd64.deb"
+        dest: "/tmp/age-plugin-yubikey_{{ backup_age_plugin_yubikey_version }}-{{ backup_age_plugin_yubikey_deb_revision }}_amd64.deb"
         checksum: "sha256:{{ backup_age_plugin_yubikey_deb_sha256 }}"
         mode: '0644'
       register: _apy_deb

--- a/roles/backup/tasks/main.yml
+++ b/roles/backup/tasks/main.yml
@@ -73,6 +73,40 @@
     - backup_encryption == 'age'
   tags: ['backup']
 
+# age can encrypt to a YubiKey identity (age1yubikey1...) only via the plugin --
+# plain `age` errors "age-plugin-yubikey: executable file not found". Encryption
+# needs ONLY the public key, so the host needs no YubiKey (the daily backup stays
+# unattended); the key is required only to DECRYPT at restore time, on the
+# operator's machine. So we install it here, gated on a YubiKey recipient.
+- name: Install age-plugin-yubikey (only for YubiKey recipients)
+  when:
+    - backup_enabled | bool
+    - backup_encryption == 'age'
+    - backup_age_recipients | select('match', '^age1yubikey') | list | length > 0
+  tags: ['backup']
+  block:
+    - name: Assert a prebuilt age-plugin-yubikey exists for this architecture
+      ansible.builtin.assert:
+        that: ansible_facts['architecture'] in ['x86_64', 'amd64']
+        fail_msg: >-
+          A YubiKey backup recipient (age1yubikey1...) needs age-plugin-yubikey,
+          which upstream ships for amd64 Linux only (this host is
+          {{ ansible_facts['architecture'] }}). Use a native age recipient, or
+          install age-plugin-yubikey for this architecture yourself.
+        quiet: true
+
+    - name: Download age-plugin-yubikey .deb (pinned + checksum)
+      ansible.builtin.get_url:
+        url: "https://github.com/str4d/age-plugin-yubikey/releases/download/v{{ backup_age_plugin_yubikey_version }}/age-plugin-yubikey_{{ backup_age_plugin_yubikey_version }}-1_amd64.deb"
+        dest: "/tmp/age-plugin-yubikey_{{ backup_age_plugin_yubikey_version }}-1_amd64.deb"
+        checksum: "sha256:{{ backup_age_plugin_yubikey_deb_sha256 }}"
+        mode: '0644'
+      register: _apy_deb
+
+    - name: Install age-plugin-yubikey (apt resolves the libpcsclite dependency)
+      ansible.builtin.apt:
+        deb: "{{ _apy_deb.dest }}"
+
 # ---- Config + secrets --------------------------------------------------------
 - name: Create backup config directory
   ansible.builtin.file:

--- a/roles/backup/tasks/main.yml
+++ b/roles/backup/tasks/main.yml
@@ -41,13 +41,15 @@
   ansible.builtin.assert:
     that:
       - backup_encryption in ['none', 'age']
+      - backup_age_recipients is sequence and backup_age_recipients is not string
       - not (backup_encryption == 'age' and (backup_age_recipients | length == 0))
       - not (backup_encryption == 'none' and (backup_age_recipients | length > 0))
     fail_msg: >-
       Invalid encryption config. backup_encryption must be one of none|age;
-      'age' requires backup_age_recipients; and recipients set with encryption
-      'none' would upload PLAINTEXT -- set backup_encryption: age, or clear
-      backup_age_recipients.
+      backup_age_recipients must be a LIST (a bare string is split per-character
+      into bogus -r args); 'age' requires backup_age_recipients; recipients set
+      with encryption 'none' would upload PLAINTEXT -- set backup_encryption: age,
+      or clear backup_age_recipients.
     quiet: true
   when: backup_enabled | bool
   tags: ['backup']

--- a/tests/backup_role_lint_test.sh
+++ b/tests/backup_role_lint_test.sh
@@ -1,0 +1,41 @@
+#!/usr/bin/env bash
+# Lint the backup role's security-critical properties so a future edit that
+# weakens encryption gating or the pinned-binary supply chain fails CI. Pure
+# structural assertions over the YAML text -- the backup role is a no-op in the
+# CI converge (backup_enabled is false there), so nothing else exercises it.
+set -euo pipefail
+ROOT="$(cd "$(dirname "$0")/.." && pwd)"
+T="$ROOT/roles/backup/tasks/main.yml"
+D="$ROOT/roles/backup/defaults/main.yml"
+fail() { echo "FAIL: $1"; exit 1; }
+
+# Encryption gating must fail CLOSED both ways: 'age' needs recipients, AND
+# recipients with encryption=none must be rejected -- otherwise the backup
+# uploads PLAINTEXT while the operator believes it is encrypted.
+grep -qF "not (backup_encryption == 'age' and (backup_age_recipients | length == 0))" "$T" \
+    || fail "encryption assert must reject 'age' without recipients"
+grep -qF "not (backup_encryption == 'none' and (backup_age_recipients | length > 0))" "$T" \
+    || fail "encryption assert must reject recipients with encryption=none (plaintext-upload guard)"
+
+# age-plugin-yubikey is installed ONLY for a YubiKey recipient, and only with age.
+grep -qF "select('match', '^age1yubikey')" "$T" \
+    || fail "plugin install must be gated on a YubiKey (age1yubikey) recipient"
+grep -qF "backup_encryption == 'age'" "$T" \
+    || fail "plugin install must be gated on backup_encryption == 'age'"
+
+# Supply chain: the .deb is sha256-verified (fail-closed) and the version var is
+# the single source of truth (interpolated into BOTH url and dest -- no drift).
+grep -qE 'checksum:[[:space:]]*"sha256:' "$T" \
+    || fail "plugin .deb must be sha256-verified"
+ver_uses=$(grep -c 'backup_age_plugin_yubikey_version' "$T" || true)
+[ "${ver_uses:-0}" -ge 2 ] \
+    || fail "url + dest must both interpolate backup_age_plugin_yubikey_version (found ${ver_uses})"
+grep -qE 'backup_age_plugin_yubikey_deb_sha256:[[:space:]]*"[0-9a-f]{64}"' "$D" \
+    || fail "backup_age_plugin_yubikey_deb_sha256 must be a 64-hex sha256"
+
+# Architecture guard: upstream ships an amd64 Linux build only; a YubiKey
+# recipient on another arch must fail fast, not 404 mid-download.
+grep -qF "'x86_64'" "$T" \
+    || fail "plugin install must assert the host architecture (x86_64)"
+
+echo "ALL BACKUP ROLE LINT CHECKS PASSED"

--- a/tests/backup_role_lint_test.sh
+++ b/tests/backup_role_lint_test.sh
@@ -3,28 +3,42 @@
 # weakens encryption gating or the pinned-binary supply chain fails CI. Pure
 # structural assertions over the YAML text -- the backup role is a no-op in the
 # CI converge (backup_enabled is false there), so nothing else exercises it.
+#
+# This is a TRIPWIRE, not a proof: grep can be defeated by a determined edit
+# (e.g. commenting out a gate). It catches the realistic regressions -- a
+# dropped guard, a missing checksum, a drifted version, an off-pin URL, a
+# loosened comparator.
 set -euo pipefail
 ROOT="$(cd "$(dirname "$0")/.." && pwd)"
 T="$ROOT/roles/backup/tasks/main.yml"
 D="$ROOT/roles/backup/defaults/main.yml"
 fail() { echo "FAIL: $1"; exit 1; }
 
-# Encryption gating must fail CLOSED both ways: 'age' needs recipients, AND
-# recipients with encryption=none must be rejected -- otherwise the backup
-# uploads PLAINTEXT while the operator believes it is encrypted.
+# Encryption gating must fail CLOSED: 'age' needs recipients; recipients with
+# encryption=none must be rejected (else the backup uploads PLAINTEXT while the
+# operator believes it is encrypted); recipients must be a LIST (a bare string
+# is iterated per-character into bogus `-r` args -> a backup that fails only at
+# 02:00 while every up-front assert called the config valid).
 grep -qF "not (backup_encryption == 'age' and (backup_age_recipients | length == 0))" "$T" \
     || fail "encryption assert must reject 'age' without recipients"
 grep -qF "not (backup_encryption == 'none' and (backup_age_recipients | length > 0))" "$T" \
     || fail "encryption assert must reject recipients with encryption=none (plaintext-upload guard)"
+grep -qF "backup_age_recipients is sequence and backup_age_recipients is not string" "$T" \
+    || fail "encryption assert must require backup_age_recipients to be a list (not a bare string)"
 
-# age-plugin-yubikey is installed ONLY for a YubiKey recipient, and only with age.
-grep -qF "select('match', '^age1yubikey')" "$T" \
+# age-plugin-yubikey is installed ONLY for a YubiKey recipient, and only with
+# age. Pin the FULL gate expression (the comparator too) so a `> 0` -> `>= 0`
+# loosening that makes every host install the plugin is caught.
+grep -qF "select('match', '^age1yubikey') | list | length > 0" "$T" \
     || fail "plugin install must be gated on a YubiKey (age1yubikey) recipient"
 grep -qF "backup_encryption == 'age'" "$T" \
     || fail "plugin install must be gated on backup_encryption == 'age'"
 
-# Supply chain: the .deb is sha256-verified (fail-closed) and the version var is
-# the single source of truth (interpolated into BOTH url and dest -- no drift).
+# Supply chain: the .deb comes from the PINNED upstream repo, is sha256-verified
+# (fail-closed), and the version var is the single source of truth (interpolated
+# into BOTH url and dest -- no drift).
+grep -qF 'https://github.com/str4d/age-plugin-yubikey/releases/download/' "$T" \
+    || fail "plugin .deb must download from the pinned upstream repo (github.com/str4d/age-plugin-yubikey)"
 grep -qE 'checksum:[[:space:]]*"sha256:' "$T" \
     || fail "plugin .deb must be sha256-verified"
 ver_uses=$(grep -c 'backup_age_plugin_yubikey_version' "$T" || true)


### PR DESCRIPTION
## Problem

The backup role's docs and the `backup_age_recipients` schema offer YubiKey identities (`age1yubikey1...`) as an encryption recipient, but the role installed only plain `age`. Host-side encryption to a YubiKey recipient then failed at backup time:

```
age: failed to wrap key for recipient #0: yubikey plugin: couldn't start
plugin: exec: "age-plugin-yubikey": executable file not found in $PATH
```

`age` needs the plugin to wrap a key for a plugin recipient.

## Fix

Install `age-plugin-yubikey` (pinned `.deb` + sha256; the `.deb` pulls `libpcsclite`), gated on `encryption=age` **and** a recipient matching `^age1yubikey`, with an architecture assert (upstream ships an amd64 Linux build only). Pinned to **v0.5.0** — the last release that publishes a Linux artifact (v0.5.1 dropped it).

Encryption uses only the public key, so the host needs **no YubiKey** — the daily backup stays unattended; the key is required only to *decrypt* at restore time, on the operator's machine. The asymmetric "private key never on the server" property is preserved.

## Validation

Proven on a live host:
- **Before:** a YubiKey-recipient backup failed at the encrypt stage (above).
- **After:** the backup encrypts headless (no YubiKey on the server), uploads a non-empty `.tar.age`, and a restore round-trips a known marker file after YubiKey decryption.

YAML parses, the `select('match', '^age1yubikey')` gate matches only YubiKey recipients, and `ansible-playbook --syntax-check` passes.
