### PR TITLE
fix(cli): resolve symlinked invocation for SCRIPT_DIR

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -28,8 +28,9 @@ jobs:
             tests/ssh_deploy_key_validation_test.sh \
             scripts/test/iam-policy-check.sh scripts/setup-s3-backup.sh \
             tests/sops_test.sh tests/setup_s3_backup_noninteractive_test.sh \
-            tests/backup_role_lint_test.sh
+            tests/backup_role_lint_test.sh tests/script_dir_resolution_test.sh
           bash tests/cli_test.sh
+          bash tests/script_dir_resolution_test.sh
           bash tests/discover_changed_servers_test.sh
           bash tests/deploy_workflow_lint_test.sh
           bash tests/backup_role_lint_test.sh

--- a/miuops
+++ b/miuops
@@ -1,7 +1,27 @@
 #!/usr/bin/env bash
 set -euo pipefail
 
-SCRIPT_DIR="${MIUOPS_TEST_SCRIPT_DIR:-$(cd "$(dirname "$0")" && pwd)}"
+# Resolve the tool's real dir even when invoked through a symlink (e.g. a
+# /usr/local/bin/miuops symlink into the checkout), so assets are found relative
+# to the real script, not the symlink. A PATH-invoked $0 may be a bare name --
+# resolve it via PATH first, then follow the symlink chain (portable: no
+# readlink -f, which macOS lacks). Use logical `cd` (not `cd -P`) so SCRIPT_DIR
+# keeps the same form as FLEET_DIR (logical $(pwd)); the shadow guard below
+# compares the two by string, and -P would make a symlinked path (e.g. macOS
+# /tmp -> /private/tmp) spuriously differ.
+if [[ -n "${MIUOPS_TEST_SCRIPT_DIR:-}" ]]; then
+    SCRIPT_DIR="$MIUOPS_TEST_SCRIPT_DIR"
+else
+    _src="${BASH_SOURCE[0]}"
+    [[ -e "$_src" ]] || _src="$(command -v -- "$_src" 2>/dev/null || printf '%s' "$_src")"
+    while [[ -L "$_src" ]]; do
+        _dir="$(cd "$(dirname "$_src")" && pwd)"
+        _src="$(readlink "$_src")"
+        [[ "$_src" == /* ]] || _src="${_dir}/${_src}"
+    done
+    SCRIPT_DIR="$(cd "$(dirname "$_src")" && pwd)"
+    unset _src _dir
+fi
 # Tool assets (playbook, roles, ansible.cfg, requirements) live under SCRIPT_DIR — the
 # installed tool. Fleet config (inventory + host_vars) lives under FLEET_DIR — the fleet
 # repo in the current directory. Keeping them apart lets the tool be a referenced
@@ -402,6 +422,9 @@ Usage:
 
   ./miuops remove-domain [--dry-run] [--no-apply] [--force] <host> <domain> [domain ...]
       Remove domain(s) from a host and delete their Cloudflare CNAMEs.
+
+  ./miuops version
+      Print the tool version and the resolved tool/fleet directories.
 
 Options:
   --dry-run     Show what would happen without making changes
@@ -808,6 +831,13 @@ cmd_remove_domain() {
     run_apply "$host"
 }
 
+# Print the tool version + the resolved tool/fleet dirs. Diagnoses where miuops
+# loads its assets from -- notably when invoked through a symlink on PATH.
+cmd_version() {
+    local v; v="$(git -C "$SCRIPT_DIR" describe --tags --always --dirty 2>/dev/null || echo dev)"
+    printf 'miuops %s\ntool dir:  %s\nfleet dir: %s\n' "$v" "$SCRIPT_DIR" "$FLEET_DIR"
+}
+
 # ── Main ───────────────────────────────────────────────────────────
 if [[ "${1:-}" != "--source-only" ]]; then
     case "${1:-}" in
@@ -815,6 +845,7 @@ if [[ "${1:-}" != "--source-only" ]]; then
         apply)         shift; cmd_apply "$@" ;;
         add-domain)    shift; cmd_add_domain "$@" ;;
         remove-domain) shift; cmd_remove_domain "$@" ;;
+        version|--version|-v) cmd_version ;;
         *)             usage ;;
     esac
 fi

--- a/tests/script_dir_resolution_test.sh
+++ b/tests/script_dir_resolution_test.sh
@@ -1,0 +1,33 @@
+#!/usr/bin/env bash
+# A symlinked invocation (e.g. /usr/local/bin/miuops -> the checkout) must still
+# resolve SCRIPT_DIR to the REAL tool dir, so assets (playbook/roles/requirements)
+# are found relative to the real script, not the symlink. Regression for the
+# "requirements file '/usr/local/bin/requirements.yml' does not exist" bug.
+# `miuops version` reports the resolved tool dir; we assert it via a PATH symlink.
+set -euo pipefail
+ROOT="$(cd "$(dirname "$0")/.." && pwd)"
+fail() { echo "FAIL: $1"; exit 1; }
+
+tmp="$(mktemp -d)"; trap 'rm -rf "$tmp"' EXIT
+mkdir -p "$tmp/bin"
+ln -s "$ROOT/miuops" "$tmp/bin/miuops"
+
+# Invoke via the PATH symlink, from an unrelated cwd, with NO MIUOPS_TEST_SCRIPT_DIR
+# override -- so the real resolution (line 4) runs.
+got="$(cd "$tmp" && PATH="$tmp/bin:$PATH" MIUOPS_TEST_SCRIPT_DIR='' miuops version 2>/dev/null \
+        | sed -n 's/^tool dir:[[:space:]]*//p')"
+[ "$got" = "$ROOT" ] \
+    || fail "symlinked 'miuops version' reported tool dir '$got', expected '$ROOT'"
+
+# 2) argv[0] spoofed to a bare name via `exec -a` -- bash still sets
+#    BASH_SOURCE[0] to the resolved script path, so this confirms argv[0] spoofing
+#    does not break resolution. (The command -v fallback at miuops:~16 is reachable
+#    only by a *sourced* bare name; the --source-only path uses the override there,
+#    so that branch is defensive and verified by reasoning, not exercised here.)
+got2="$(cd / && PATH="$tmp/bin:$PATH" MIUOPS_TEST_SCRIPT_DIR='' \
+        bash -c 'exec -a miuops miuops version' 2>/dev/null \
+        | sed -n 's/^tool dir:[[:space:]]*//p')"
+[ "$got2" = "$ROOT" ] \
+    || fail "bare-name (command -v) 'miuops version' reported '$got2', expected '$ROOT'"
+
+echo "ALL SCRIPT_DIR RESOLUTION CHECKS PASSED"


### PR DESCRIPTION
## Problem

Invoking miuops through a symlink (e.g. `ln -s .../miuops /usr/local/bin/miuops`) resolved `SCRIPT_DIR` to the symlink's own directory, so the tool looked for its assets (playbook, roles, requirements.yml, ansible.cfg) there and died -- e.g. `requirements file '/usr/local/bin/requirements.yml' does not exist`. `dirname "$0"` does not follow symlinks.

## Fix

Follow the symlink chain from `BASH_SOURCE[0]` before taking `dirname` -- portable, no `readlink -f` (which macOS lacks). Logical `cd` (not `cd -P`) keeps `SCRIPT_DIR` in the same form as `FLEET_DIR`, so the host_vars shadow guard (which compares the two by string) does not spuriously fire on a symlinked path such as macOS `/tmp` -> `/private/tmp`. The `MIUOPS_TEST_SCRIPT_DIR` test override is unchanged.

Adds a `miuops version` subcommand: prints the version (`git describe`) plus the resolved tool/fleet directories -- a diagnostic for exactly this "where are my assets coming from" class of problem, and the observable the regression test asserts.

## Test

`tests/script_dir_resolution_test.sh` (wired into CI -- shellcheck + run): a symlinked `miuops version` must report the real tool dir. RED before (reports the symlink's dir), GREEN after.
