### PR TITLE
fix(deploy): skip a stack-less server before checking SSH secrets

### DIFF
--- a/.github/scripts/deploy-server.sh
+++ b/.github/scripts/deploy-server.sh
@@ -36,6 +36,15 @@ NAME_RE='^[A-Za-z0-9][A-Za-z0-9._-]*$'
 SERVER="${SERVER:?SERVER is required}"
 [[ "$SERVER" =~ $NAME_RE ]] || err "Refusing to deploy: invalid server name '${SERVER}'"
 
+# A server with no stack directory is a clean skip (exit 0) -- check this BEFORE
+# the SSH secrets, so a server removed from the fleet (or one whose Environment
+# has no secrets) is a no-op, not a "No SSH_HOST" failure. discover lists every
+# changed server including deletions, so a removed stack dir would otherwise red
+# the run with a misleading secrets error.
+STACKS_DIR="${STACKS_DIR:-fleet/stacks}"; STACKS_DIR="${STACKS_DIR%/}"
+src="${GITHUB_WORKSPACE:-.}/${STACKS_DIR}/${SERVER}"
+[ -d "$src" ] || { note "No stacks for '${SERVER}' (${STACKS_DIR}/${SERVER} absent) — nothing to deploy."; exit 0; }
+
 # Fail fast on missing secrets BEFORE any network action, naming the server. A
 # typo'd Environment resolves to empty secrets (no cross-server fallback exists),
 # so this fails CLOSED — it can never reuse another server's key.
@@ -44,13 +53,7 @@ SERVER="${SERVER:?SERVER is required}"
 [ -n "${SSH_PRIVATE_KEY:-}" ] || err "No SSH_PRIVATE_KEY for environment '${SERVER}'."
 SSH_PORT="${SSH_PORT:-22}"
 [[ "$SSH_PORT" =~ ^[0-9]+$ ]] || err "Invalid SSH_PORT '${SSH_PORT}' for '${SERVER}' (must be numeric)."
-STACKS_DIR="${STACKS_DIR:-fleet/stacks}"; STACKS_DIR="${STACKS_DIR%/}"
 REMOTE_STACKS_DIR="${REMOTE_STACKS_DIR:-/opt/stacks}"; REMOTE_STACKS_DIR="${REMOTE_STACKS_DIR%/}"
-
-src="${GITHUB_WORKSPACE:-.}/${STACKS_DIR}/${SERVER}"
-# A server with no stack directory (e.g. just removed from the fleet) is a clean
-# skip, never a blind rsync of a nonexistent source.
-[ -d "$src" ] || { note "No stacks for '${SERVER}' (${STACKS_DIR}/${SERVER} absent) — nothing to deploy."; exit 0; }
 
 # Per-run private key + known_hosts in a 0700 temp dir; gone on exit.
 sshdir="$(mktemp -d)"; chmod 700 "$sshdir"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -25,13 +25,14 @@ jobs:
           command -v shellcheck >/dev/null 2>&1 || { sudo apt-get update -qq && sudo apt-get install -y shellcheck >/dev/null; }
           shellcheck -S error miuops tests/stack_policy_check_test.sh \
             .github/scripts/discover-changed-servers.sh .github/scripts/deploy-server.sh \
-            tests/ssh_deploy_key_validation_test.sh \
+            tests/ssh_deploy_key_validation_test.sh tests/deploy_server_skip_test.sh \
             scripts/test/iam-policy-check.sh scripts/setup-s3-backup.sh \
             tests/sops_test.sh tests/setup_s3_backup_noninteractive_test.sh \
             tests/backup_role_lint_test.sh
           bash tests/cli_test.sh
           bash tests/discover_changed_servers_test.sh
           bash tests/deploy_workflow_lint_test.sh
+          bash tests/deploy_server_skip_test.sh
           bash tests/backup_role_lint_test.sh
           bash tests/ssh_deploy_key_validation_test.sh
           bash scripts/test/iam-policy-check.sh

--- a/tests/deploy_server_skip_test.sh
+++ b/tests/deploy_server_skip_test.sh
@@ -1,0 +1,31 @@
+#!/usr/bin/env bash
+# A server with no stack directory must be a clean skip (exit 0), even when its
+# GitHub Environment has no SSH secrets -- e.g. a stack removed from the fleet, or
+# the template's example server that has no Environment. The SSH-secret check must
+# STILL fire when the server DOES have stacks. Regression: deploy-server.sh checked
+# the SSH secrets BEFORE the no-stacks skip, so a removed / Environment-less server
+# reddened the Deploy run with "No SSH_HOST".
+set -euo pipefail
+ROOT="$(cd "$(dirname "$0")/.." && pwd)"
+DS="$ROOT/.github/scripts/deploy-server.sh"
+fail() { echo "FAIL: $1"; exit 1; }
+
+ws="$(mktemp -d)"; trap 'rm -rf "$ws"' EXIT
+mkdir -p "$ws/fleet/stacks/has-stacks/app"   # a server WITH a stack dir
+# (intentionally NO dir for server "no-stacks")
+
+# Case 1: no stack dir + no SSH secrets -> clean skip (exit 0), notes "No stacks".
+rc=0
+out="$(SERVER=no-stacks GITHUB_WORKSPACE="$ws" SSH_HOST='' SSH_USER='' SSH_PRIVATE_KEY='' \
+       bash "$DS" 2>&1)" || rc=$?
+[ "$rc" -eq 0 ] || fail "no-stacks + no-SSH must exit 0 (clean skip), got rc=$rc: $out"
+printf '%s' "$out" | grep -q 'No stacks' || fail "no-stacks skip must note 'No stacks', got: $out"
+
+# Case 2 (positive control): stacks present + no SSH secrets -> MUST still err.
+rc=0
+out="$(SERVER=has-stacks GITHUB_WORKSPACE="$ws" SSH_HOST='' SSH_USER='' SSH_PRIVATE_KEY='' \
+       bash "$DS" 2>&1)" || rc=$?
+[ "$rc" -ne 0 ] || fail "stacks present + no-SSH must FAIL the SSH check, but exited 0: $out"
+printf '%s' "$out" | grep -q 'No SSH_HOST' || fail "stacks + no-SSH must err 'No SSH_HOST', got: $out"
+
+echo "ALL DEPLOY-SERVER SKIP CHECKS PASSED"


### PR DESCRIPTION
## Problem

The Deploy workflow's `discover` step lists every changed server, including one whose stack directory was just deleted from the fleet. `deploy-server.sh` checked the SSH secrets first, so such a server -- which has no GitHub Environment / secrets -- reddened the run with a misleading `No SSH_HOST` instead of a clean skip.

## Fix

Move the no-stacks check (`exit 0`) ahead of the SSH-secret checks. A server that *does* have stacks still requires its secrets -- the fail-closed check is unchanged, only reordered, and the no-stacks check is a local filesystem test (not a network action), so secrets are still verified before anything touches the network.

## Test

`tests/deploy_server_skip_test.sh` (wired into CI -- shellcheck + run):
- no stacks + no secrets -> `exit 0` (clean skip)
- stacks present + no secrets -> still errs `No SSH_HOST` (positive control)

RED before the reorder (the skip was unreachable behind the secret check).
