### PR TITLE
feat(cli): guard fleet group_vars + ship the group_vars/all layer

### DIFF
--- a/README.md
+++ b/README.md
@@ -87,8 +87,11 @@ All commands accept `--dry-run` (preview) and `--no-apply` (change config/DNS bu
 
 Your fleet repo describes the whole fleet: each server is one line in
 `fleet/inventory.ini` plus one `fleet/host_vars/<name>.yml` (its `domains` +
-`tunnel_id`). The CLI reads `fleet/` from the current directory, so run it from your
-fleet repo — servers coexist and you converge any subset:
+`tunnel_id`). Config shared by the whole fleet (e.g. the Grafana Cloud endpoints)
+goes in `fleet/group_vars/all.yml` instead of being repeated per server — see
+[`group_vars/all.yml.example`](group_vars/all.yml.example). The CLI reads `fleet/`
+from the current directory, so run it from your fleet repo — servers coexist and you
+converge any subset:
 
 ```bash
 miuops apply server-a          # one server

--- a/group_vars/all.yml.example
+++ b/group_vars/all.yml.example
@@ -1,0 +1,21 @@
+# Fleet-wide config — group_vars/all.yml
+#
+# Values here apply to EVERY server in this fleet. This file belongs in YOUR FLEET
+# repo (next to inventory.ini and host_vars/), copied from this example — NOT in the
+# miuops tool checkout: Ansible loads tool-adjacent group_vars at higher precedence
+# than the fleet's, so `miuops apply` refuses to converge if it finds group_vars in
+# the tool dir (the same fail-closed guard as host_vars).
+#
+# Per-server values go in host_vars/<server>.yml; values shared by the whole fleet
+# go here. (group_vars/all.yml itself is gitignored in this repo so a local copy in
+# the tool checkout is never committed; commit it in your fleet repo instead.)
+
+# --- Grafana Cloud observability (shared by the whole fleet) -------------------
+# The push endpoints + user IDs are identical across servers, so they belong here
+# rather than duplicated in every host_vars file. The token is a secret — keep it
+# out of git (export GRAFANA_CLOUD_TOKEN, or the SOPS-encrypted fleet secret).
+# observability_enabled: true
+# grafana_cloud_prometheus_url:  "https://prometheus-prod-XX.grafana.net/api/prom/push"
+# grafana_cloud_prometheus_user: "1234567"
+# grafana_cloud_loki_url:        "https://logs-prod-XX.grafana.net/loki/api/v1/push"
+# grafana_cloud_loki_user:       "1234567"

--- a/miuops
+++ b/miuops
@@ -346,16 +346,33 @@ run_apply() {
     if $NO_APPLY; then info "--no-apply: skipping converge"; return 0; fi
     [[ -f "${FLEET_DIR}/inventory.ini" ]] \
         || die "No fleet inventory at ${FLEET_DIR}/inventory.ini — run from your fleet repo root, or set MIUOPS_FLEET_DIR"
-    # Ansible loads host_vars/ adjacent to the PLAYBOOK (SCRIPT_DIR) as well as the
-    # inventory (FLEET_DIR), and playbook-adjacent OUTRANKS inventory-adjacent. So real
-    # host_vars left in the tool checkout would silently shadow the fleet's — fail closed
-    # rather than converge a host with the wrong (tool-checkout) vars.
+    # Ansible loads host_vars/ AND group_vars/ adjacent to the PLAYBOOK (SCRIPT_DIR) as
+    # well as the inventory (FLEET_DIR), and playbook-adjacent OUTRANKS inventory-adjacent.
+    # So real host_vars/group_vars left in the tool checkout would silently shadow the
+    # fleet's — fail closed rather than converge with the wrong (tool-checkout) vars.
+    # Match any form Ansible actually loads — <name>[.yml|.yaml|.json], an extension-less
+    # file, or a <name>/ directory — not just *.yml. Skip the shipped *.example templates
+    # and editor/backup files (*.bak, *.swp, ...) that Ansible does not load.
     if [[ "${SCRIPT_DIR}" != "${FLEET_DIR}" ]]; then
-        local _shadow="" _hv
-        for _hv in "${SCRIPT_DIR}"/host_vars/*.yml; do [[ -e "$_hv" ]] && { _shadow="$_hv"; break; }; done
-        [[ -z "$_shadow" ]] \
-            || die "Tool checkout has host_vars (${_shadow}) that Ansible would load OVER the fleet's.
-  Move host_vars/ into ${FLEET_DIR}/ (the fleet repo), then retry."
+        local _vdir _entry _base _shadow _lc
+        for _vdir in host_vars group_vars; do
+            _shadow=""
+            for _entry in "${SCRIPT_DIR}/${_vdir}"/*; do
+                [[ -e "$_entry" ]] || continue
+                _base="${_entry##*/}"
+                [[ "$_base" == *.example ]] && continue
+                # Lowercase for the extension test: Ansible also loads all.YML / all.Yaml
+                # (case-insensitively), and a case-sensitive control node would otherwise
+                # let an uppercase-extension shadow slip past a case-sensitive match.
+                _lc="$(printf '%s' "$_base" | tr '[:upper:]' '[:lower:]')"
+                if [[ -d "$_entry" || "$_lc" == *.yml || "$_lc" == *.yaml || "$_lc" == *.json || "$_base" != *.* ]]; then
+                    _shadow="$_entry"; break
+                fi
+            done
+            [[ -z "$_shadow" ]] \
+                || die "Tool checkout has ${_vdir} (${_shadow}) that Ansible would load OVER the fleet's.
+  Move ${_vdir}/ into ${FLEET_DIR}/ (the fleet repo), then retry."
+        done
     fi
     # Tool's ansible.cfg + the fleet inventory, both by absolute path so `cd my-fleet &&
     # miuops apply` from outside the tool checkout still resolves cfg, inventory + host_vars.

--- a/tests/cli_test.sh
+++ b/tests/cli_test.sh
@@ -59,8 +59,10 @@ grep -q -- '- ""' "$TMP/fleet/host_vars/solo.yml" && fail "empty domain entry wr
 got="$( export CF_API_TOKEN=x; curl() { printf '{"result":[{"id":"ZONEID123"}],"success":true}\n200\n'; }; cf_zone_id example.com )"
 [ "$got" = "ZONEID123" ] || fail "cf_zone_id did not parse zone id (got: '$got')"
 
-# --- Task 7: cmd_up uses host_vars, never group_vars ---
-grep -q 'group_vars' "$ROOT/miuops" && fail "miuops still references group_vars"
+# --- Task 7: cmd_up writes per-host config to host_vars (verified above it lands under
+# FLEET_DIR/host_vars, never SCRIPT_DIR), never group_vars. group_vars is now a fleet-WIDE
+# config layer with its own read-only shadow guard (below), so we no longer forbid the
+# word -- the per-host invariant is covered by write_host_vars landing in host_vars. ---
 grep -q 'write_host_vars "\$ssh_host"' "$ROOT/miuops" || fail "up does not call write_host_vars"
 
 # --- Task 8: apply targets --limit; --no-apply skips converge ---
@@ -82,10 +84,50 @@ out="$(cd "$ROOT" && ./miuops apply server-a 2>&1 || true)"
 echo "$out" | grep -qiE 'would load over|shadow|tool checkout has host_vars' \
     || fail "apply must refuse when tool-checkout host_vars could shadow the fleet"
 rm -rf "$TMP/tool/host_vars"
+# the same guard covers the non-.yml forms Ansible loads (.yaml here)
+mkdir -p "$TMP/tool/host_vars"; : > "$TMP/tool/host_vars/server-a.yaml"
+out="$(cd "$ROOT" && ./miuops apply server-a 2>&1 || true)"
+echo "$out" | grep -qiE 'tool checkout has host_vars' || fail "host_vars guard missed the .yaml form"
+rm -rf "$TMP/tool/host_vars"
 # positive control: with NO shadowing host_vars, the guard does not fire and apply proceeds
 out="$(cd "$ROOT" && ./miuops apply --dry-run server-a 2>&1 || true)"
 echo "$out" | grep -qiE 'would load over|tool checkout has host_vars' && fail "shadow guard false-fired without tool host_vars"
 echo "$out" | grep -q -- "--limit server-a" || fail "apply --dry-run should proceed when no shadow"
+
+# --- tool-checkout group_vars must NOT silently shadow the fleet's either -- same
+# precedence issue as host_vars (playbook-adjacent SCRIPT_DIR outranks the fleet's), so a
+# fleet-wide group_vars/all left in the tool checkout would override the fleet's silently. ---
+mkdir -p "$TMP/tool/group_vars"; : > "$TMP/tool/group_vars/all.yml"
+out="$(cd "$ROOT" && ./miuops apply server-a 2>&1 || true)"
+echo "$out" | grep -qiE 'would load over|shadow|tool checkout has group_vars' \
+    || fail "apply must refuse when tool-checkout group_vars could shadow the fleet"
+rm -rf "$TMP/tool/group_vars"
+# positive control: with NO shadowing group_vars, the guard does not fire and apply proceeds
+out="$(cd "$ROOT" && ./miuops apply --dry-run server-a 2>&1 || true)"
+echo "$out" | grep -qiE 'tool checkout has group_vars' && fail "group_vars shadow guard false-fired without tool group_vars"
+echo "$out" | grep -q -- "--limit server-a" || fail "apply --dry-run should proceed when no group_vars shadow"
+
+# the guard must catch EVERY form Ansible loads (.yaml, extension-less, a directory),
+# not only *.yml -- a leftover all.yaml in the tool checkout would otherwise silently
+# override the fleet (one such file mis-converges every host).
+for form in yaml noext dir caps; do
+    rm -rf "$TMP/tool/group_vars"; mkdir -p "$TMP/tool/group_vars"
+    case "$form" in
+        yaml)  : > "$TMP/tool/group_vars/all.yaml" ;;
+        noext) : > "$TMP/tool/group_vars/all" ;;
+        dir)   mkdir -p "$TMP/tool/group_vars/all"; : > "$TMP/tool/group_vars/all/x.yml" ;;
+        caps)  : > "$TMP/tool/group_vars/all.YML" ;;   # Ansible loads it case-insensitively
+    esac
+    out="$(cd "$ROOT" && ./miuops apply server-a 2>&1 || true)"
+    echo "$out" | grep -qiE 'tool checkout has group_vars' || fail "group_vars guard missed the '$form' form (Ansible loads it)"
+done
+rm -rf "$TMP/tool/group_vars"
+# but it must NOT false-fire on the shipped template or an editor backup (Ansible loads neither)
+mkdir -p "$TMP/tool/group_vars"; : > "$TMP/tool/group_vars/all.yml.example"; : > "$TMP/tool/group_vars/all.yml.bak"
+out="$(cd "$ROOT" && ./miuops apply --dry-run server-a 2>&1 || true)"
+echo "$out" | grep -qiE 'tool checkout has group_vars' && fail "group_vars guard false-fired on .example/.bak"
+echo "$out" | grep -q -- "--limit server-a" || fail "apply should proceed with only .example/.bak in group_vars"
+rm -rf "$TMP/tool/group_vars"
 
 # --- Task 9: add-domain / remove-domain reject unknown hosts (offline) ---
 out="$(cd "$ROOT" && CF_API_TOKEN=x ./miuops add-domain nope new.example 2>&1 || true)"


### PR DESCRIPTION
## What

Establish the fleet-wide config layer (`group_vars/all.yml`) and harden the converge shadow guard that protects it. Config shared by the whole fleet -- e.g. the Grafana Cloud observability endpoints -- belongs in `fleet/group_vars/all.yml` rather than duplicated across every `host_vars/<server>.yml`.

## Changes

- **Shadow guard now covers group_vars, and is form-complete.** Ansible loads both `host_vars/` and `group_vars/` adjacent to the playbook (the tool checkout) at higher precedence than the fleet's, so either left in the tool checkout would silently override the fleet's. The guard fails closed for **every form Ansible actually loads** -- `<name>.yml` / `.yaml` / `.json` (case-insensitively), an extension-less file, or a `<name>/` directory -- not just `*.yml`. The shipped `*.example` templates and the editor/backup files Ansible ignores are skipped. (The enumeration was verified against ansible-core's var-file load set.)
- **`group_vars/all.yml.example`** + a README note documenting the convention: fleet-wide config goes here, per-server config in `host_vars/`; it lives in the fleet repo, not the tool checkout.
- **cli_test**: the group_vars shadow-guard regression (RED before / GREEN after) + a positive control + fixtures for the `.yaml` / extension-less / directory / uppercase-extension forms + a check that `.example` / `.bak` never false-fire.
