### PR TITLE
feat: observability on by default, activating when configured

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -28,13 +28,15 @@ jobs:
             tests/ssh_deploy_key_validation_test.sh tests/deploy_server_skip_test.sh \
             scripts/test/iam-policy-check.sh scripts/setup-s3-backup.sh \
             tests/sops_test.sh tests/setup_s3_backup_noninteractive_test.sh \
-            tests/backup_role_lint_test.sh tests/script_dir_resolution_test.sh
+            tests/backup_role_lint_test.sh tests/script_dir_resolution_test.sh \
+            tests/observability_role_lint_test.sh
           bash tests/cli_test.sh
           bash tests/script_dir_resolution_test.sh
           bash tests/discover_changed_servers_test.sh
           bash tests/deploy_workflow_lint_test.sh
           bash tests/deploy_server_skip_test.sh
           bash tests/backup_role_lint_test.sh
+          bash tests/observability_role_lint_test.sh
           bash tests/ssh_deploy_key_validation_test.sh
           bash scripts/test/iam-policy-check.sh
           bash tests/setup_s3_backup_noninteractive_test.sh

--- a/README.md
+++ b/README.md
@@ -110,7 +110,7 @@ Day-to-day domain/converge commands are in [Daily Operations](docs/DAILY_OPS.md)
 | Cloudflare Tunnel | `cloudflared` | Zero exposed ports; wildcard + root DNS records; systemd service. |
 | SSH hardening | `ssh` | Key-only login (`PasswordAuthentication no`). |
 | Metadata block | `metadata-block` | Blocks containers from reaching the cloud metadata endpoint (`169.254.0.0/16`). |
-| Observability | `observability` | Grafana Alloy host binary shipping metrics + logs to Grafana Cloud (opt-in, off by default). |
+| Observability | `observability` | Grafana Alloy host binary shipping metrics + logs to Grafana Cloud (on by default; activates once the Grafana Cloud connection is configured). |
 | Volume backup | `backup` | Host `systemd` timer that tars Docker volumes to S3 — no container, no `docker.sock`. |
 | Security upgrades | `unattended-upgrades` | Automatic unattended security patches, no auto-reboot. |
 

--- a/docs/OBSERVABILITY.md
+++ b/docs/OBSERVABILITY.md
@@ -1,12 +1,14 @@
 # Observability — Grafana Alloy → Grafana Cloud
 
-Optional, opt-in per host. Each enabled server runs **Grafana Alloy** as a host systemd
-service that ships **metrics + logs** to **Grafana Cloud**. It is egress-only (no inbound
-port; the agent pushes out), so it fits the tunnel-only model.
+On by default. Each server runs **Grafana Alloy** as a host systemd service that ships
+**metrics + logs** to **Grafana Cloud**. It is egress-only (no inbound port; the agent
+pushes out), so it fits the tunnel-only model.
 
 **Collected:** host metrics (CPU/mem/disk/net), per-container metrics (cAdvisor),
 cloudflared metrics (`127.0.0.1:2000`), and all Docker container logs (apps + Traefik).
-Disabled by default — a host without `observability_enabled: true` is untouched.
+On by default — it activates once the connection (below) is configured; an
+enabled-but-unconfigured host skips with a warning, so a fleet that hasn't set up Grafana
+Cloud still converges. Opt a host out with `observability_enabled: false`.
 
 ## 1. Get the connection details from Grafana Cloud
 
@@ -35,12 +37,13 @@ posture as `CF_API_TOKEN`). The URLs + instance IDs are not secret; if you tire 
 exporting them you may instead set the matching `grafana_cloud_*` vars in gitignored
 config (they override the env-lookup defaults) — but keep the token env-only.
 
-## 3. Enable a host
+## 3. On by default — opt out per host
 
-Set this in that host's gitignored `host_vars/<host>.yml`:
+Observability is **on by default** and activates once the connection above is set. To
+turn it off for a specific host, set in that host's gitignored `host_vars/<host>.yml`:
 
 ```yaml
-observability_enabled: true
+observability_enabled: false
 ```
 
 ## 4. Deploy
@@ -57,9 +60,10 @@ Grafana Cloud **Docker / Linux Node** integrations for ready-made dashboards.
 ## Notes
 
 - The token is rendered into `/etc/alloy/config.alloy` on the server at mode `0600`.
-- If `observability_enabled` is true but any required value is unset, the play
-  **fails fast and prints the exact env var names** to export — so a forgotten or
-  misspelled variable is caught with a clear hint, not a half-started agent.
+- On by default but unconfigured (no Grafana endpoint) → the role **skips with a
+  warning**, so the converge still succeeds. A **partial** config (endpoint set but
+  another value missing) **fails fast** with the missing names — a half-configured agent
+  is never shipped.
 - **Docker 29+ (overlayfs):** Docker 29 made `overlayfs` the default storage driver,
   which dropped the on-disk layer layout the old cAdvisor read. cAdvisor v0.54+
   (bundled in Alloy >= 1.14) instead resolves each container's read-write layer

--- a/miuops
+++ b/miuops
@@ -467,6 +467,23 @@ EOF
 # server need not be keyed by its IP.
 up_resolve_handle() { printf '%s' "${1:-$2}"; }
 
+# True iff the Grafana Cloud push endpoint is configured for this host ($1 = handle) --
+# in the fleet-wide group_vars/all.yml (its blessed home) or the host's host_vars. The
+# anchored match rejects a commented-out stub, so the operator who left one still gets
+# the nudge. `up` uses this because observability is on by default.
+obs_configured() {
+    grep -qsE "^[[:space:]]*grafana_cloud_prometheus_url[[:space:]]*:[[:space:]]*[\"']?[^[:space:]\"'#]" \
+        "${FLEET_DIR}/group_vars/all.yml" "${FLEET_DIR}/host_vars/${1}.yml"
+}
+
+# True iff observability is explicitly disabled for this host ($1 = handle) -- in its
+# host_vars or the fleet group_vars -- matching a YAML false (false/no/off, any case,
+# optionally quoted), tolerant of whitespace around the colon.
+obs_opted_out() {
+    grep -qsiE '^[[:space:]]*observability_enabled[[:space:]]*:[[:space:]]*"?(false|no|off)"?[[:space:]]*($|#)' \
+        "${FLEET_DIR}/host_vars/${1}.yml" "${FLEET_DIR}/group_vars/all.yml"
+}
+
 cmd_up() {
     # Parse flags and positional args in any order
     local positional=() name_flag=""
@@ -758,6 +775,14 @@ ${existing}
             info "Domain: *.${domain} -> Cloudflare Tunnel -> Traefik"
         done
         echo ""
+        # Observability is on by default; nudge if this fleet hasn't configured its
+        # Grafana endpoints and the host hasn't opted out -- otherwise it only surfaces
+        # as a graceful skip at converge.
+        if ! obs_configured "$handle" && ! obs_opted_out "$handle"; then
+            warn "Observability runs by default, but the Grafana Cloud endpoints aren't set in
+  ${FLEET_DIR}/group_vars/all.yml — set them there (+ export GRAFANA_CLOUD_TOKEN), or set
+  observability_enabled: false in host_vars to opt out. See docs/OBSERVABILITY.md."
+        fi
         info "Next: create your private fleet repo from miuops-fleet-template"
     fi
 }

--- a/roles/observability/defaults/main.yml
+++ b/roles/observability/defaults/main.yml
@@ -1,7 +1,13 @@
 ---
-# Grafana Alloy agent shipping metrics + logs to Grafana Cloud. Opt-in per host:
-# set `observability_enabled: true` in that host's host_vars.
-observability_enabled: false
+# Grafana Alloy agent shipping metrics + logs to Grafana Cloud. ON by default so a
+# server is never silently unmonitored. It ACTIVATES only once the Grafana Cloud push
+# endpoint is configured; enabled-but-unconfigured skips with a warning rather than
+# failing the converge (so a default-on fleet that hasn't set up Grafana still
+# converges). Set `observability_enabled: false` in a host's host_vars to opt out.
+observability_enabled: true
+# Derived gate: the role's tasks + its config assert run only when ACTIVE. A partial
+# config (endpoint set but token/other endpoints missing) still fails that assert.
+observability_active: "{{ observability_enabled | bool and (grafana_cloud_prometheus_url | length > 0) }}"
 
 # Pin the Alloy apt package version (supply chain). List available versions with
 # `apt-cache madison alloy` (Grafana apt repo). Must be >= 1.14: that release bundles the

--- a/roles/observability/tasks/main.yml
+++ b/roles/observability/tasks/main.yml
@@ -2,7 +2,22 @@
 # Grafana Alloy -> Grafana Cloud, run as a host systemd service.
 # No-op unless observability_enabled.
 
-- name: Ensure Grafana Cloud connection is configured
+- name: Note that observability is on by default but unconfigured (skipping)
+  # Default-on, but gracefully skip when no Grafana Cloud endpoint is set -- a fleet
+  # that hasn't configured observability still converges, just without monitoring. The
+  # `up` command nudges about this too; here it surfaces at converge as well.
+  ansible.builtin.debug:
+    msg: >-
+      Observability is on by default but unconfigured (grafana_cloud_prometheus_url is
+      empty) -- skipping this role. Set the Grafana Cloud endpoints (group_vars/all.yml)
+      and the token, or set observability_enabled: false in host_vars to opt out.
+      See docs/OBSERVABILITY.md.
+  when: observability_enabled | bool and not (observability_active | bool)
+  tags: ['observability']
+
+- name: Ensure the Grafana Cloud connection is complete
+  # Reached only when ACTIVE (the endpoint is set) -- so an empty value here means a
+  # PARTIAL config, which must fail loud rather than ship a half-configured agent.
   ansible.builtin.assert:
     that:
       - grafana_cloud_prometheus_url | length > 0
@@ -11,12 +26,12 @@
       - grafana_cloud_loki_user | length > 0
       - grafana_cloud_token | length > 0
     fail_msg: >-
-      observability_enabled is true but one or more Grafana Cloud values are unset.
-      Export these environment variables before running (see docs/OBSERVABILITY.md):
-      GRAFANA_CLOUD_PROM_URL, GRAFANA_CLOUD_PROM_USER, GRAFANA_CLOUD_LOKI_URL,
-      GRAFANA_CLOUD_LOKI_USER, GRAFANA_CLOUD_TOKEN.
+      Observability is partially configured: the Grafana Cloud endpoint is set but one
+      or more of the others are empty. Set ALL of them (see docs/OBSERVABILITY.md) --
+      grafana_cloud_prometheus_url, grafana_cloud_prometheus_user, grafana_cloud_loki_url,
+      grafana_cloud_loki_user, and the token grafana_cloud_token.
     quiet: true
-  when: observability_enabled | bool
+  when: observability_active | bool
   tags: ['observability']
 
 # ---- Install Alloy from Grafana's apt repository -------------------------------------
@@ -27,7 +42,7 @@
     name: python3-debian
     state: present
     update_cache: true
-  when: observability_enabled | bool
+  when: observability_active | bool
   tags: ['observability']
 
 - name: Create apt keyrings directory
@@ -35,7 +50,7 @@
     path: /etc/apt/keyrings
     state: directory
     mode: '0755'
-  when: observability_enabled | bool
+  when: observability_active | bool
   tags: ['observability']
 
 - name: Add Grafana apt signing key
@@ -43,7 +58,7 @@
     url: https://apt.grafana.com/gpg-full.key
     dest: /etc/apt/keyrings/grafana.asc
     mode: '0644'
-  when: observability_enabled | bool
+  when: observability_active | bool
   tags: ['observability']
 
 - name: Add Grafana apt repository
@@ -55,7 +70,7 @@
     components: main
     signed_by: /etc/apt/keyrings/grafana.asc
     state: present
-  when: observability_enabled | bool
+  when: observability_active | bool
   tags: ['observability']
 
 - name: Install Alloy (pinned)
@@ -63,7 +78,7 @@
     name: "alloy={{ observability_alloy_version }}"
     state: present
     update_cache: true
-  when: observability_enabled | bool
+  when: observability_active | bool
   tags: ['observability']
 
 # ---- Run Alloy as root ----------------------------------------------------------------
@@ -75,7 +90,7 @@
     path: /etc/systemd/system/alloy.service.d
     state: directory
     mode: '0755'
-  when: observability_enabled | bool
+  when: observability_active | bool
   tags: ['observability']
 
 - name: Run Alloy as root, constrained by a systemd sandbox
@@ -100,7 +115,7 @@
       SystemCallFilter=@system-service
       SystemCallErrorNumber=EPERM
     mode: '0644'
-  when: observability_enabled | bool
+  when: observability_active | bool
   notify: Restart Alloy
   tags: ['observability']
 
@@ -109,7 +124,7 @@
     path: /etc/default/alloy
     regexp: '^CUSTOM_ARGS='
     line: 'CUSTOM_ARGS="--server.http.listen-addr=127.0.0.1:12345"'
-  when: observability_enabled | bool
+  when: observability_active | bool
   notify: Restart Alloy
   tags: ['observability']
 
@@ -121,7 +136,7 @@
     group: root
     mode: '0600'
   no_log: true
-  when: observability_enabled | bool
+  when: observability_active | bool
   notify: Restart Alloy
   tags: ['observability']
 
@@ -134,7 +149,7 @@
     owner: root
     group: root
     mode: '0770'
-  when: observability_enabled | bool
+  when: observability_active | bool
   tags: ['observability']
 
 - name: Enable + start Alloy
@@ -143,5 +158,5 @@
     enabled: true
     state: started
     daemon_reload: true
-  when: observability_enabled | bool
+  when: observability_active | bool
   tags: ['observability']

--- a/tests/cli_test.sh
+++ b/tests/cli_test.sh
@@ -232,4 +232,53 @@ write_host_vars notunnel "" a.example b.example
 out="$(cd "$ROOT" && MIUOPS_TEST_SCRIPT_DIR="$TMP/tool" ./miuops remove-domain notunnel a.example 2>&1 || true)"
 echo "$out" | grep -qi 'no tunnel_id' || fail "remove-domain must require a non-empty tunnel_id"
 
+# --- U4: observability on by default + graceful skip + an `up` nudge ---
+# default-on: the obs role is enabled unless a host opts out (no more silently-off).
+grep -qE '^observability_enabled:[[:space:]]+true' "$ROOT/roles/observability/defaults/main.yml" \
+    || fail "observability_enabled must default to true (obs on by default)"
+
+# obs_configured <handle>: true iff the Grafana push endpoint is set for this host --
+# in group_vars/all.yml (its blessed home) OR the host's host_vars. A COMMENTED key
+# must NOT count (the operator who left a stub is exactly who the nudge is for).
+mkdir -p "$TMP/fleet/group_vars" "$TMP/fleet/host_vars"
+: > "$TMP/fleet/group_vars/all.yml"
+obs_configured srv && fail "obs_configured must be false when nothing sets the endpoint"
+echo '# grafana_cloud_prometheus_url: "https://x"' > "$TMP/fleet/group_vars/all.yml"
+obs_configured srv && fail "obs_configured must be false for a COMMENTED endpoint (#2)"
+printf 'grafana_cloud_prometheus_url: ""\n' > "$TMP/fleet/group_vars/all.yml"
+obs_configured srv && fail "obs_configured must be false for an EMPTY-valued stub"
+echo 'grafana_cloud_prometheus_url: "https://x/api/prom/push"' > "$TMP/fleet/group_vars/all.yml"
+obs_configured srv || fail "obs_configured must be true when group_vars/all sets the endpoint"
+: > "$TMP/fleet/group_vars/all.yml"
+echo 'grafana_cloud_prometheus_url: "https://x"' > "$TMP/fleet/host_vars/srv.yml"
+obs_configured srv || fail "obs_configured must be true when the host's host_vars sets the endpoint (#3)"
+rm -f "$TMP/fleet/host_vars/srv.yml"
+
+# obs_opted_out <handle>: true iff observability_enabled is a YAML false, in host_vars
+# OR group_vars, tolerant of spacing/quoting/case (#4).
+: > "$TMP/fleet/group_vars/all.yml"
+obs_opted_out srv && fail "obs_opted_out must be false when nothing disables obs"
+for spelling in 'observability_enabled: false' 'observability_enabled : false' \
+                'observability_enabled: "false"' 'observability_enabled: False' \
+                'observability_enabled: no'; do
+    printf '%s\n' "$spelling" > "$TMP/fleet/host_vars/srv.yml"
+    obs_opted_out srv || fail "obs_opted_out must catch host_vars opt-out spelling: [$spelling]"
+done
+rm -f "$TMP/fleet/host_vars/srv.yml"
+# A non-false value must NOT count as opt-out (the false|no|off alternation must not
+# prefix-match nope/offline/true -- else obs would silently never run).
+for nonfalse in 'observability_enabled: true' 'observability_enabled: nope' \
+                'observability_enabled: offline' 'observability_enabled: notyet'; do
+    printf '%s\n' "$nonfalse" > "$TMP/fleet/host_vars/srv.yml"
+    obs_opted_out srv && fail "obs_opted_out must NOT fire on a non-false value: [$nonfalse]"
+done
+rm -f "$TMP/fleet/host_vars/srv.yml"
+printf 'observability_enabled: false\n' > "$TMP/fleet/group_vars/all.yml"
+obs_opted_out srv || fail "obs_opted_out must catch a group_vars opt-out (#4)"
+rm -rf "$TMP/fleet/group_vars" "$TMP/fleet/host_vars"
+
+# `up` nudges via obs_configured + the robust obs_opted_out.
+grep -qF 'obs_configured' "$ROOT/miuops" || fail "up must use obs_configured to nudge"
+grep -qF 'obs_opted_out'  "$ROOT/miuops" || fail "up must use obs_opted_out (robust opt-out check)"
+
 echo "ALL CLI HELPER TESTS PASSED"

--- a/tests/observability_role_lint_test.sh
+++ b/tests/observability_role_lint_test.sh
@@ -1,0 +1,37 @@
+#!/usr/bin/env bash
+# The observability role is ON by default (observability_enabled: true) but must
+# ACTIVATE gracefully: enabled-but-unconfigured SKIPS with a warning, never a converge
+# failure -- so a default-on fleet that hasn't set up Grafana Cloud still converges. A
+# PARTIAL config (the endpoint set but token/other endpoints missing) still fails the
+# assert.
+#
+# This is a TRIPWIRE pinning that contract so a future edit can't (a) flip the default
+# back to off [the silently-unmonitored regression U4 exists to kill], (b) re-gate the
+# role on the RAW observability_enabled so default-on hard-fails every unconfigured
+# adopter, or (c) drop the unconfigured-skip warning.
+set -euo pipefail
+ROOT="$(cd "$(dirname "$0")/.." && pwd)"
+D="$ROOT/roles/observability/defaults/main.yml"
+T="$ROOT/roles/observability/tasks/main.yml"
+fail() { echo "FAIL: $1"; exit 1; }
+
+# (a) on by default
+grep -qE '^observability_enabled:[[:space:]]+true' "$D" \
+    || fail "observability_enabled must default to true (on by default)"
+
+# the activation gate: enabled AND the push endpoint configured
+grep -qE '^observability_active:.*observability_enabled.*grafana_cloud_prometheus_url' "$D" \
+    || fail "observability_active must derive from observability_enabled AND grafana_cloud_prometheus_url"
+
+# (b) tasks gate on observability_ACTIVE, and NO task gates on the raw enabled flag
+# (raw-enabled gating would hard-fail unconfigured adopters at the assert).
+grep -qF 'observability_active | bool' "$T" \
+    || fail "tasks must gate on observability_active (graceful skip when unconfigured)"
+grep -qE 'when:[[:space:]]*observability_enabled[[:space:]]*\|[[:space:]]*bool[[:space:]]*$' "$T" \
+    && fail "no task may gate on the RAW observability_enabled (hard-fails unconfigured adopters) -- use observability_active"
+
+# (c) the enabled-but-unconfigured WARNING task exists (gated on enabled AND not active)
+grep -qF 'not (observability_active | bool)' "$T" \
+    || fail "an enabled-but-unconfigured WARNING task must exist (gated on enabled AND not active)"
+
+echo "ALL OBSERVABILITY ROLE LINT CHECKS PASSED"


### PR DESCRIPTION
## What

Observability was opt-in (`observability_enabled: false`), so a server could run silently unmonitored — the operator simply forgets to enable it.

**Default it ON, but activate gracefully.** The role runs only when the Grafana Cloud endpoint is configured (`observability_active` = enabled AND the endpoint set):
- **Unconfigured** (enabled, no endpoint) → the role **skips with a warning**, so a fleet that hasn't set up Grafana Cloud still converges (and an existing deployment isn't broken on upgrade).
- **Configured** → runs.
- **Partial** (endpoint set, another value missing) → the assert **fails loud** — a half-configured agent is never shipped.

`up` nudges at bootstrap when a fleet hasn't configured observability and the host hasn't opted out. `obs_configured` / `obs_opted_out` check `group_vars/all.yml` and the host's `host_vars`, with anchored matches (a commented or empty stub doesn't count) and tolerant opt-out spellings (false/no/off, any case, quoted).

## Test

`tests/observability_role_lint_test.sh` (default-on + active-gating + warn-task tripwire) and `cli_test` (obs_configured/obs_opted_out incl. commented/empty stub + opt-out-spelling cases) — RED before, GREEN after, both mutation-proven. Net-0 (the render net) stays green. With graceful activation the converge is green whether or not Grafana is configured.

Docs: `OBSERVABILITY.md` + `README` reflect on-by-default + graceful activation.
