### PR TITLE
feat(cli): decrypt SOPS-in-fleet deployed secrets into the converge

### DIFF
--- a/miuops
+++ b/miuops
@@ -68,6 +68,7 @@ dry()  { echo -e "  ${YELLOW}[dry-run]${NC} $1"; }
 
 DRY_RUN=false
 NO_APPLY=false
+APPLY_TAGS=""
 
 # ── Validation ──────────────────────────────────────────────────────
 # Use [[ =~ ]] (whole-string anchored) rather than `grep` (line-oriented), so a
@@ -379,6 +380,7 @@ run_apply() {
     export ANSIBLE_CONFIG="${SCRIPT_DIR}/ansible.cfg"
     local cmd=(ansible-playbook -i "${FLEET_DIR}/inventory.ini" "${SCRIPT_DIR}/playbook.yml")
     [[ -n "$host" ]] && cmd+=(--limit "$host")
+    [[ -n "${APPLY_TAGS:-}" ]] && cmd+=(--tags "${APPLY_TAGS}")
 
     # If a host is targeted and its tunnel credential is committed encrypted under
     # fleet/secrets/, decrypt it LOCALLY to a private temp file and hand Ansible the
@@ -395,6 +397,23 @@ run_apply() {
             cmd+=(-e "cloudflared_credentials_src=${_cred_tmp}")
         fi
     fi
+
+    # Deployed secrets (SOPS-in-fleet): decrypt the fleet-wide secrets (all.vars.json --
+    # the Grafana token) and, when a host is targeted, that host's secrets
+    # (<host>.vars.json -- the AWS backup creds) to private temp files, each handed to
+    # Ansible as extra-vars. Like the tunnel cred above, the plaintext lives only on this
+    # control node, is shredded on return, and extra-vars OUTRANK the roles' defaults --
+    # so at converge the operator supplies ONLY the age key, never a per-apply
+    # GRAFANA_CLOUD_TOKEN / AWS_*. (Per-host secrets need a targeted host, mirroring the
+    # tunnel cred; a whole-fleet apply carries only the fleet-wide all.vars.json.)
+    local _sf _stmp
+    for _sf in "${SECRETS_DIR}/all.vars.json" "${host:+${SECRETS_DIR}/${host}.vars.json}"; do
+        [[ -n "$_sf" && -f "$_sf" ]] || continue
+        require_sops
+        _stmp="$(sops_decrypt_to_tmp "$_sf")"
+        _SOPS_TMPS+=("$_stmp")   # shredded by the global EXIT/INT/TERM trap
+        cmd+=(-e "@${_stmp}")
+    done
 
     if $DRY_RUN; then
         dry "Would install Ansible Galaxy requirements"
@@ -414,6 +433,8 @@ cmd_apply() {
         case "$1" in
             --dry-run)  DRY_RUN=true; shift ;;
             --no-apply) NO_APPLY=true; shift ;;
+            --tags)     [[ $# -ge 2 ]] || die "--tags requires an argument"; APPLY_TAGS="$2"; shift 2 ;;
+            --tags=*)   APPLY_TAGS="${1#*=}"; shift ;;
             -*) die "Unknown flag: $1" ;;
             *)  host="$1"; shift ;;
         esac

--- a/tests/sops_test.sh
+++ b/tests/sops_test.sh
@@ -159,6 +159,34 @@ echo "ok: env provisioning targets /opt/stacks/.env at mode 0600"
 grep -q 'cloudflared_credentials_src=' "$ROOT/miuops" \
     || fail "CLI must pass -e cloudflared_credentials_src=<decrypted temp> to the playbook"
 
+# ── 4b. U6 deployed-secret loop: run_apply decrypts fleet/secrets/{all,<host>}.vars.json
+# into Ansible extra-vars (-e @<decrypted-tmp>), so the Grafana token + AWS creds reach
+# the converge with ONLY the age key -- no per-apply env. Plus --tags passthrough (which
+# the U6 e2e uses to converge obs+backup in isolation). ───────────────────────────────
+printf '[bare_metal]\nu6host ansible_host=192.0.2.9\n' > "$TMP/fleet/inventory.ini"
+printf '{ "grafana_cloud_token": "glc_U6TESTtoken" }\n' > "$TMP/fleet/secrets/all.vars.json"
+printf '{ "backup_aws_access_key_id": "AKIAU6TEST", "backup_aws_secret_access_key": "x" }\n' > "$TMP/fleet/secrets/u6host.vars.json"
+( cd "$TMP" && sops -e -i fleet/secrets/all.vars.json && sops -e -i fleet/secrets/u6host.vars.json ) \
+    || fail "could not SOPS-encrypt the U6 deployed secrets"
+# Dry-run run_apply in a SUBSHELL (its EXIT/INT/TERM trap stays isolated from this
+# test's) and confirm the cmd carries one `-e @` per present vars.json. The cloudflared
+# cred uses `-e cloudflared_credentials_src=` (no `@`) + u6host has no tunnel, so the
+# `-e @` count is purely the U6 deployed secrets.
+# shellcheck disable=SC1090
+u6out="$( source "$ROOT/miuops" --source-only; DRY_RUN=true APPLY_TAGS="" run_apply u6host 2>&1 )" \
+    || fail "run_apply dry-run failed with SOPS deployed secrets present"
+u6n="$(printf '%s' "$u6out" | grep -o -- '-e @' | wc -l | tr -d ' ' || true)"   # count OCCURRENCES (both -e @ sit on one line, so grep -c would undercount to 1); trailing || true so the disabled-loop case (0 matches -> grep exits 1 under pipefail) doesn't abort before the fail msg below
+[ "${u6n:-0}" -ge 2 ] \
+    || fail "run_apply must pass each fleet/secrets/*.vars.json as -e @<tmp> (got ${u6n} '-e @', expected >=2): $u6out"
+echo "ok: U6 loop decrypts all.vars.json + <host>.vars.json into -e @ extra-vars"
+# --tags passthrough: `apply <host> --tags X` parses through to the converge cmd
+# (the U6 e2e uses this to converge obs+backup in isolation).
+# shellcheck disable=SC1090
+u6tags="$( source "$ROOT/miuops" --source-only; cmd_apply u6host --tags observability,backup --dry-run 2>&1 )"
+printf '%s' "$u6tags" | grep -q -- '--tags observability,backup' \
+    || fail "apply must parse --tags through to the converge (got: $u6tags)"
+echo "ok: apply --tags passthrough reaches the converge cmd"
+
 # ── 5. cloudflared role consumes a local decrypted source, legacy fallback ───
 ROLE="$ROOT/roles/cloudflared/tasks/main.yml"
 DEFAULTS="$ROOT/roles/cloudflared/defaults/main.yml"


### PR DESCRIPTION
## What

The Grafana token and the per-server AWS backup creds were the last per-apply env — the operator had to `export GRAFANA_CLOUD_TOKEN` / `AWS_*` on every converge. Route them by nature like the tunnel credential: SOPS-encrypted in the fleet, decrypted at converge with only the age key.

`run_apply` now decrypts `fleet/secrets/all.vars.json` (the fleet-wide token) and, for a targeted host, `fleet/secrets/<host>.vars.json` (its AWS creds) to private `0600` temp files (shredded on exit), each passed as Ansible extra-vars (`-e @<tmp>`). Extra-vars outrank the role defaults, so at converge the operator unlocks **only the age key** — no per-apply env. Mirrors the existing `cloudflared_credentials_src` path; a whole-fleet apply carries only the fleet-wide `all.vars.json` (per-host secrets need a targeted host).

Also adds `apply --tags <names>` for a targeted converge.

## Test

`tests/sops_test.sh` (in CI): `run_apply` decrypts each present `*.vars.json` into a distinct `-e @<tmp>`, and `apply --tags` reaches the cmd — RED before (0 `-e @`), GREEN after. Verified end-to-end on a fresh test VPS: the SOPS token + AWS key, supplied with **only the age key** (no per-apply env), decrypt at converge and render into `/etc/alloy/config.alloy` + `/etc/miuops-backup/backup.env` at `0600` root; the same converge fails closed (the observability assert) when the decrypt loop is off.

---
> Depends on #89 (config/secret split) — merge that first; this PR then retargets to `main`.
