### PR TITLE
docs: secret model (SECRETS.md) + Cloudflare token guidance

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -30,7 +30,8 @@ jobs:
             tests/sops_test.sh tests/setup_s3_backup_noninteractive_test.sh \
             tests/backup_role_lint_test.sh tests/script_dir_resolution_test.sh \
             tests/observability_role_lint_test.sh \
-            tests/config_secret_split_test.sh
+            tests/config_secret_split_test.sh \
+            tests/secrets_docs_lint_test.sh
           bash tests/cli_test.sh
           bash tests/script_dir_resolution_test.sh
           bash tests/discover_changed_servers_test.sh
@@ -39,6 +40,7 @@ jobs:
           bash tests/backup_role_lint_test.sh
           bash tests/observability_role_lint_test.sh
           bash tests/config_secret_split_test.sh
+          bash tests/secrets_docs_lint_test.sh
           bash tests/ssh_deploy_key_validation_test.sh
           bash scripts/test/iam-policy-check.sh
           bash tests/setup_s3_backup_noninteractive_test.sh

--- a/README.md
+++ b/README.md
@@ -168,6 +168,7 @@ One shared `{project}-backup` bucket holds every server's backups under a per-se
 
 - [Architecture](docs/ARCHITECTURE.md) — Design decisions, network model, and system diagram
 - [Installation Guide](docs/INSTALLATION.md) — Full end-to-end setup walkthrough
+- [Secret Model](docs/SECRETS.md) — Where each secret lives: config in versioned vars, deployed secrets SOPS-encrypted in the fleet, the Cloudflare token operator-local
 - [Scaling & Advanced](docs/SCALING.md) — Optional patterns (env grouping, SOPS, YubiKey)
 - [Repository Structure](docs/STRUCTURE.md) — Directory layout and role descriptions
 - [Disaster Recovery](docs/DISASTER_RECOVERY.md) — Backup restore procedures for all failure scenarios

--- a/docs/SECRETS.md
+++ b/docs/SECRETS.md
@@ -1,0 +1,102 @@
+# Secret model — where each secret lives
+
+miuops routes every converge datum to a home matched to its nature, so an `apply`
+needs only your age identity unlocked — no secrets typed on the command line. Three
+classes:
+
+## 1. Config (NOT secret) → versioned vars
+
+Non-secret settings that vary per fleet or host: the Grafana Cloud push **endpoints +
+user IDs**, the backup **S3 bucket + region**. These are versioned in your fleet repo —
+fleet-wide in `fleet/group_vars/all.yml`, per-host in `fleet/host_vars/<host>.yml` — and
+are safe to commit. See [OBSERVABILITY.md](OBSERVABILITY.md) and
+[../roles/backup/README.md](../roles/backup/README.md).
+
+## 2. Deployed secrets → SOPS-encrypted in the fleet
+
+Secrets the **server** needs at converge. They are SOPS-encrypted under `fleet/secrets/`
+(safe to commit as ciphertext) and decrypted **at converge, on your machine, with your
+age key** — never typed as per-apply env, never plaintext in git. The mechanics (age
+key, `.sops.yaml`, round-trip + tamper checks) are in [SOPS_SECRETS.md](SOPS_SECRETS.md).
+
+| Secret | File | Supplies |
+|---|---|---|
+| Grafana Cloud token | `fleet/secrets/all.vars.json` (fleet-wide) | `grafana_cloud_token` |
+| AWS backup creds | `fleet/secrets/<host>.vars.json` (per-host) | `backup_aws_access_key_id`, `backup_aws_secret_access_key` |
+| Tunnel credential | `fleet/secrets/<tunnel_id>.json` | the `cloudflared` role |
+| App env | `fleet/secrets/<server>.env` | `/opt/stacks/.env` |
+
+Create the **deployed-vars** secrets (the `*.vars.json`) — JSON objects of Ansible vars,
+encrypted to your age recipient:
+
+```bash
+# fleet-wide Grafana Cloud token
+printf '{ "grafana_cloud_token": "glc_..." }\n' > fleet/secrets/all.vars.json
+sops --encrypt --in-place fleet/secrets/all.vars.json
+
+# per-server AWS backup credentials (one file per server)
+printf '{ "backup_aws_access_key_id": "AKIA...", "backup_aws_secret_access_key": "..." }\n' \
+    > fleet/secrets/web1.vars.json
+sops --encrypt --in-place fleet/secrets/web1.vars.json
+```
+
+> The `printf` writes the token in **plaintext** to disk (and into your shell history)
+> until `sops --encrypt` rewrites it in place. Confirm it encrypted before you commit —
+> `git grep -L sops -- 'fleet/secrets/*'` must print nothing — and never `git add` the
+> plaintext. To keep plaintext off disk and history entirely, edit the encrypted file
+> directly: `sops fleet/secrets/all.vars.json` opens a decrypted buffer that re-encrypts
+> on save. See [SOPS_SECRETS.md](SOPS_SECRETS.md#never-commit-plaintext).
+
+At converge miuops decrypts these to private `0600` temp files and passes each to Ansible
+as `-e @<file>` extra-vars, which **outrank** the roles' defaults — so the token + creds
+render into the on-host config (`/etc/alloy/config.alloy`, `/etc/miuops-backup/backup.env`)
+with **no** `export GRAFANA_CLOUD_TOKEN` / `AWS_*`.
+
+> **Per-host secrets need a targeted apply.** `miuops apply <host>` loads `all.vars.json`
+> **and** that host's `<host>.vars.json`. A whole-fleet `miuops apply` (no host) loads only
+> the fleet-wide `all.vars.json`. So converge a backup-enabled host with
+> `miuops apply <host>` to supply its AWS creds. Whenever a host's `<host>.vars.json` is
+> not loaded — no host targeted, *or* the file doesn't exist yet — the backup role falls
+> back to `AWS_*` from your shell. Once your creds are SOPS'd,
+> `unset AWS_ACCESS_KEY_ID AWS_SECRET_ACCESS_KEY` so a stale value can never silently win.
+
+## 3. The operator token (Cloudflare) → operator-local, NOT in the fleet
+
+`CF_API_TOKEN` is the one secret that does **not** go in the fleet. `miuops up` /
+`add-domain` / `remove-domain` use it to create the tunnel and DNS via the Cloudflare API.
+It is **high blast radius** (it can edit your DNS), so it stays operator-local — never
+committed, never on a server, and not needed by `apply` at all.
+
+Keep it in an operator secret store and inject it only for the one command:
+
+```bash
+# 1Password CLI
+CF_API_TOKEN=$(op read "op://Private/Cloudflare-miuops/token") miuops up root@<ip> example.com
+# pass
+CF_API_TOKEN=$(pass cloudflare/miuops) miuops up root@<ip> example.com
+# macOS keychain
+CF_API_TOKEN=$(security find-generic-password -s cloudflare-miuops -w) miuops up root@<ip> example.com
+```
+
+**Scope the token to the minimum.** Create it at
+[Cloudflare → API Tokens](https://dash.cloudflare.com/profile/api-tokens) with the
+prebuilt **"Edit zone DNS"** template — it grants `Zone:DNS:Edit` plus the `Zone:Read`
+the zone lookup needs — **restricted to the specific zone(s) you serve**, not *all* zones.
+
+The token is **DNS-only**: it needs no tunnel or account permission. `miuops up` creates
+the tunnel through the `cloudflared` binary, which authenticates with the
+`cloudflared login` browser cert (`~/.cloudflared/cert.pem`) — never with `CF_API_TOKEN`.
+So do **not** add `Account → Cloudflare Tunnel` to this token; keep it scoped to DNS on
+your zones.
+
+Set a TTL and, if you can, an IP allowlist. A scoped, expiring token limits the damage if
+it leaks — and because it never enters the fleet or a server, a compromised server can't
+reach it.
+
+## The end state at `apply`
+
+Config is versioned; deployed secrets are SOPS-in-fleet. So a converge needs only your
+**age identity** unlocked — a YubiKey touch, or the key file SOPS resolves (see
+[SOPS_SECRETS.md](SOPS_SECRETS.md#where-the-key-is-resolved)). No `GRAFANA_CLOUD_TOKEN` /
+`AWS_*` typed per apply. The sole operator-local secret is `CF_API_TOKEN`, and only for
+`up` / `add-domain` / `remove-domain`.

--- a/docs/SOPS_SECRETS.md
+++ b/docs/SOPS_SECRETS.md
@@ -1,7 +1,8 @@
 # Secrets with SOPS + age
 
-miuops encrypts the secrets your fleet needs — the Cloudflare Tunnel credential
-and each server's application `.env` — with [SOPS](https://github.com/getsops/sops)
+miuops encrypts the secrets your fleet needs — the Cloudflare Tunnel credential,
+each server's application `.env`, and the deployed vars (the Grafana Cloud token and a
+server's AWS backup creds) — with [SOPS](https://github.com/getsops/sops)
 and [age](https://github.com/FiloSottile/age). The ciphertext is safe to commit
 to your fleet repo under `fleet/secrets/`; the matching age **private key** lives
 only on your machine (or a YubiKey) and **never** enters CI.
@@ -136,6 +137,23 @@ matches.
 
   SOPS encrypts only the **values** in a `.env`, so a `git diff` still shows which
   keys changed without leaking their values.
+
+- **Deployed vars** (`fleet/secrets/all.vars.json`, `fleet/secrets/<host>.vars.json`) —
+  JSON objects of Ansible vars: the Grafana Cloud token (fleet-wide) and a server's AWS
+  backup credentials (per-host). At converge miuops decrypts each present file to a
+  `0600` temp and passes it to Ansible as `-e @<temp>` extra-vars, which **outrank** the
+  role defaults — so the secret renders into the on-host config with no per-apply env.
+  `<host>.vars.json` loads only for a targeted `apply <host>`. Encrypt one with:
+
+  ```bash
+  printf '{ "grafana_cloud_token": "glc_..." }\n' > fleet/secrets/all.vars.json
+  sops --encrypt --in-place fleet/secrets/all.vars.json
+  ```
+
+  As with every example here, the file is plaintext until `sops` rewrites it — confirm it
+  encrypted before committing (see [Never commit plaintext](#never-commit-plaintext)). See
+  [SECRETS.md](SECRETS.md) for the full secret model (config vs deployed secret vs the
+  operator-local Cloudflare token).
 
 ## Verify it works — round-trip and tamper
 

--- a/tests/secrets_docs_lint_test.sh
+++ b/tests/secrets_docs_lint_test.sh
@@ -1,0 +1,44 @@
+#!/usr/bin/env bash
+# docs/SECRETS.md is the operator-facing secret model. Pin it to reality so it can't
+# drift from the code: the deployed-secret FILES it documents must be the ones the CLI
+# decrypts, the VARS it names must be the ones the roles read, and the Cloudflare token
+# must stay documented as operator-local (never in the fleet).
+#
+# A TRIPWIRE, not a proof: it catches the realistic drift -- a renamed secret file, a
+# renamed var, or the doc silently dropping the operator-local stance.
+set -euo pipefail
+ROOT="$(cd "$(dirname "$0")/.." && pwd)"
+DOC="$ROOT/docs/SECRETS.md"
+CLI="$ROOT/miuops"
+fail() { echo "FAIL: $1"; exit 1; }
+
+[ -f "$DOC" ] || fail "docs/SECRETS.md is missing (the secret-model doc)"
+
+# All three classes have a section.
+grep -qiE '^##.*config'          "$DOC" || fail "SECRETS.md must have a config-class section"
+grep -qiE '^##.*deployed secret' "$DOC" || fail "SECRETS.md must have a deployed-secret section"
+grep -qiE '^##.*operator token'  "$DOC" || fail "SECRETS.md must have an operator-token section"
+
+# The deployed-secret FILES the doc names are the ones run_apply actually decrypts.
+grep -qF 'all.vars.json'    "$DOC" || fail "SECRETS.md must document fleet/secrets/all.vars.json"
+grep -qF '<host>.vars.json' "$DOC" || fail "SECRETS.md must document fleet/secrets/<host>.vars.json"
+grep -qF 'all.vars.json'    "$CLI" || fail "doc names all.vars.json but the CLI does not read it"
+grep -qF '${host}.vars.json' "$CLI" || fail "doc names <host>.vars.json but the CLI does not read \${host}.vars.json"
+
+# The VARS the doc names are the ones the roles read (no phantom var in the doc).
+grep -qF 'grafana_cloud_token' "$DOC" \
+    && grep -qrF 'grafana_cloud_token' "$ROOT/roles/observability" \
+    || fail "grafana_cloud_token must appear in BOTH SECRETS.md and the observability role"
+grep -qF 'backup_aws_access_key_id' "$DOC" \
+    && grep -qrF 'backup_aws_access_key_id' "$ROOT/roles/backup" \
+    || fail "backup_aws_access_key_id must appear in BOTH SECRETS.md and the backup role"
+
+# The Cloudflare token is documented as operator-local, NOT in the fleet.
+grep -qF 'CF_API_TOKEN'   "$DOC" || fail "SECRETS.md must name CF_API_TOKEN"
+grep -qiF 'operator-local' "$DOC" || fail "SECRETS.md must state CF_API_TOKEN stays operator-local (not in the fleet)"
+# The CF token is DNS-only -- the tunnel is created via the cloudflared binary, not this
+# API token. Pin the correct scope so the doc can't regress to granting tunnel perms.
+grep -qiE 'edit zone dns|zone:read' "$DOC" \
+    || fail "SECRETS.md must scope CF_API_TOKEN to DNS (the 'Edit zone DNS' template / Zone:Read); it needs NO tunnel perms (tunnel = cloudflared, not the token)"
+
+echo "ALL SECRETS DOCS LINT CHECKS PASSED"


### PR DESCRIPTION
## What

Documents where each secret lives now that config is versioned and the deployed secrets are SOPS-in-fleet:

- **`docs/SECRETS.md`** (new): the secret taxonomy — config in versioned vars; deployed secrets (the Grafana token in `all.vars.json`, AWS creds in `<host>.vars.json`) SOPS-encrypted in the fleet, decrypted at converge with only the age key; the Cloudflare token operator-local (DNS-scoped, kept in an operator store), never in the fleet. Notes the per-host-secret / targeted-apply rule and the encrypt-before-commit guard.
- **`docs/SOPS_SECRETS.md`**: adds the deployed vars (`*.vars.json`) to "what miuops encrypts".
- **README**: links the secret model.

## Test

`tests/secrets_docs_lint_test.sh` (in CI): a tripwire pinning `SECRETS.md` to the code — the secret files it names are the ones `run_apply` decrypts, the vars it names are read by the roles, and the Cloudflare token stays documented DNS-scoped + operator-local. RED before (no `SECRETS.md`), GREEN after.

---
> Depends on #91 (deployed-secret decrypt loop) — merge that first; this PR then retargets to `main`.
