### PR TITLE
feat(cli): add `miuops backup-setup` to onboard a server's backup identity

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -33,9 +33,13 @@ jobs:
             tests/config_secret_split_test.sh \
             tests/secrets_docs_lint_test.sh \
             tests/backup_lifecycle_net.sh \
-            tests/backup_bucket_resolve_test.sh
+            tests/backup_bucket_resolve_test.sh \
+            tests/backup_setup_cmd_test.sh \
+            tests/backup_setup_script_test.sh
           bash tests/cli_test.sh
           bash tests/backup_bucket_resolve_test.sh
+          bash tests/backup_setup_cmd_test.sh
+          bash tests/backup_setup_script_test.sh
           bash tests/script_dir_resolution_test.sh
           bash tests/discover_changed_servers_test.sh
           bash tests/deploy_workflow_lint_test.sh

--- a/miuops
+++ b/miuops
@@ -944,6 +944,31 @@ cmd_version() {
     printf 'miuops %s\ntool dir:  %s\nfleet dir: %s\n' "$v" "$SCRIPT_DIR" "$FLEET_DIR"
 }
 
+# Set up a server's host-side backup identity. The bucket name is CONFIG with one
+# versioned home, so the CLI resolves it (host_vars -> fleet group_vars) and hands it
+# to the setup script as MIUOPS_BUCKET -- the operator never re-types a project/bucket
+# (the divergent-bucket footgun). Fails closed when no bucket is configured: the first
+# server must set backup_s3_bucket in group_vars/all.yml first.
+cmd_backup_setup() {
+    local host="" bucket
+    local pass_through=()
+    while [[ $# -gt 0 ]]; do
+        case "$1" in
+            --server)   [[ $# -ge 2 ]] || die "backup-setup: --server requires a value"; host="$2"; shift 2 ;;
+            --server=*)  host="${1#*=}"; shift ;;
+            *)           pass_through+=("$1"); shift ;;   # --region / --yes forwarded as-is
+        esac
+    done
+    [[ -n "$host" ]] || die "backup-setup: --server <name> is required"
+    bucket="$(resolve_backup_bucket "$host")"
+    [[ -n "$bucket" ]] || die "backup-setup: no backup_s3_bucket configured in ${FLEET_DIR}/group_vars/all.yml (or host_vars/${host}.yml). Set the fleet bucket there once -- the first server creates it; see docs/SECRETS.md."
+    if [[ ${#pass_through[@]} -gt 0 ]]; then
+        MIUOPS_BUCKET="$bucket" "${SCRIPT_DIR}/scripts/setup-s3-backup.sh" --server "$host" "${pass_through[@]}"
+    else
+        MIUOPS_BUCKET="$bucket" "${SCRIPT_DIR}/scripts/setup-s3-backup.sh" --server "$host"
+    fi
+}
+
 # ── Main ───────────────────────────────────────────────────────────
 if [[ "${1:-}" != "--source-only" ]]; then
     case "${1:-}" in
@@ -951,6 +976,7 @@ if [[ "${1:-}" != "--source-only" ]]; then
         apply)         shift; cmd_apply "$@" ;;
         add-domain)    shift; cmd_add_domain "$@" ;;
         remove-domain) shift; cmd_remove_domain "$@" ;;
+        backup-setup)  shift; cmd_backup_setup "$@" ;;
         version|--version|-v) cmd_version ;;
         *)             usage ;;
     esac

--- a/scripts/setup-s3-backup.sh
+++ b/scripts/setup-s3-backup.sh
@@ -161,13 +161,24 @@ echo "        S3 Backup Bucket Setup                "
 echo "=============================================="
 echo ""
 
-if [[ -z "$PROJECT_NAME" ]]; then
-    read -rp "Enter project name (used as bucket prefix, e.g. myproject): " PROJECT_NAME
-fi
-
-if [[ -z "$PROJECT_NAME" ]]; then
-    echo "Error: Project name cannot be empty."
-    exit 1
+# Bucket name: `miuops backup-setup` resolves the fleet bucket from versioned config and
+# passes it as MIUOPS_BUCKET, so the operator never re-types a project/bucket (the
+# divergent-bucket footgun). Standalone use still accepts --project (bucket = <project>-backup).
+if [[ -n "${MIUOPS_BUCKET:-}" ]]; then
+    BUCKET_NAME="$MIUOPS_BUCKET"
+else
+    if [[ -z "$PROJECT_NAME" ]]; then
+        read -rp "Enter project name (used as bucket prefix, e.g. myproject): " PROJECT_NAME
+    fi
+    if [[ -z "$PROJECT_NAME" ]]; then
+        echo "Error: Project name cannot be empty (or run 'miuops backup-setup', which resolves the fleet bucket from group_vars)."
+        exit 1
+    fi
+    if [[ ! "$PROJECT_NAME" =~ ^[a-z0-9][a-z0-9-]*$ ]]; then
+        echo "Error: invalid project name '${PROJECT_NAME}' — use lowercase letters, digits, hyphens (the S3 bucket charset)."
+        exit 1
+    fi
+    BUCKET_NAME="${PROJECT_NAME}-backup"
 fi
 
 if [[ -z "$SERVER" ]]; then
@@ -183,9 +194,11 @@ fi
 # Fail-closed: validate both identifiers BEFORE they are interpolated into the IAM
 # policy JSON, AWS CLI arguments, the S3 prefix, and the IAM user name. A crafted
 # value (quotes, spaces, '..', shell/JSON metachars) must be rejected here, never
-# relied on being blocked incidentally by AWS's own naming rules.
-if [[ ! "$PROJECT_NAME" =~ ^[a-z0-9][a-z0-9-]*$ ]]; then
-    echo "Error: invalid project name '${PROJECT_NAME}' — use lowercase letters, digits, hyphens (the S3 bucket charset)."
+# relied on being blocked incidentally by AWS's own naming rules. The bucket may come
+# from --project (constrained above) or MIUOPS_BUCKET (config) -- validate the final
+# name regardless of source.
+if [[ ! "$BUCKET_NAME" =~ ^[a-z0-9][a-z0-9.-]*$ ]]; then
+    echo "Error: invalid bucket name '${BUCKET_NAME}' — use lowercase letters, digits, dots, hyphens (the S3 bucket charset)."
     exit 1
 fi
 if [[ ! "$SERVER" =~ ^[A-Za-z0-9][A-Za-z0-9._-]*$ ]]; then
@@ -193,7 +206,6 @@ if [[ ! "$SERVER" =~ ^[A-Za-z0-9][A-Za-z0-9._-]*$ ]]; then
     exit 1
 fi
 
-BUCKET_NAME="${PROJECT_NAME}-backup"
 # Per-server IAM user: "<bucket>-<server>". Each server gets its own user + key
 # pair scoped to its own "<server>/" prefix only.
 IAM_USER="${BUCKET_NAME}-${SERVER}"
@@ -229,8 +241,20 @@ fi
 echo ""
 echo "--- Creating S3 bucket ---"
 
-if aws s3api head-bucket --bucket "$BUCKET_NAME" 2>/dev/null; then
+# head-bucket fails for BOTH "absent" (404) and "present-but-can't-stat" (403 / throttle
+# / network). Only a real 404 may take the create path; any other failure must NOT fall
+# through to create + reconfigure, or a transient blip could re-touch a shared bucket we
+# simply could not confirm. Capture rc + message and branch on a genuine 404.
+head_rc=0
+head_out="$(aws s3api head-bucket --bucket "$BUCKET_NAME" 2>&1)" || head_rc=$?
+if [[ $head_rc -eq 0 ]]; then
     echo "Bucket $BUCKET_NAME already exists, skipping creation."
+    bucket_preexisted=true
+elif ! printf '%s\n' "$head_out" | grep -qE '\(404\)|Not Found'; then
+    echo "Error: could not stat bucket '$BUCKET_NAME' (not a 404 / not confirmed absent):" >&2
+    printf '%s\n' "$head_out" >&2
+    echo "Refusing to create or reconfigure a bucket that cannot be confirmed absent — re-run when AWS is reachable." >&2
+    exit 1
 else
     if [[ "$AWS_REGION" == "us-east-1" ]]; then
         aws s3api create-bucket \
@@ -245,7 +269,17 @@ else
             --object-lock-enabled-for-bucket
     fi
     echo "Bucket created: $BUCKET_NAME"
+    bucket_preexisted=false
 fi
+
+# Bucket-level config (encryption / public-access / Object Lock / lifecycle) is applied
+# ONCE, when the bucket is first created. Adding a SERVER to an existing fleet bucket must
+# NOT re-touch the shared bucket -- a server onboard mints only its own IAM identity (below).
+if [[ "$bucket_preexisted" == true ]]; then
+    echo ""
+    echo "Reusing the existing fleet bucket — not re-applying bucket-level config"
+    echo "(encryption / public-access / Object Lock / lifecycle stay as first set)."
+else
 
 # -- Default encryption -------------------------------------------------------
 
@@ -343,6 +377,7 @@ aws s3api put-bucket-lifecycle-configuration \
     }'
 
 echo "Lifecycle rules configured."
+fi
 
 # -- Create IAM user ----------------------------------------------------------
 

--- a/tests/backup_setup_cmd_test.sh
+++ b/tests/backup_setup_cmd_test.sh
@@ -1,0 +1,68 @@
+#!/usr/bin/env bash
+#
+# `miuops backup-setup --server <h>` subcommand.
+#
+# The CLI owns fleet context, so it resolves the backup bucket from versioned
+# config and hands it to the setup script as MIUOPS_BUCKET -- the script
+# never re-prompts for a project / re-derives the bucket. The bucket is thus
+# typed ONCE (in group_vars), killing the divergent-bucket footgun at the source.
+#
+# Verified WITHOUT real AWS by pointing MIUOPS_TEST_SCRIPT_DIR at a throwaway tool
+# dir whose scripts/setup-s3-backup.sh is a recorder that captures MIUOPS_BUCKET
+# and argv, then exits 0. Each assertion has a clear pass/fail.
+
+set -uo pipefail
+
+ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+pass=0; fail=0
+ok()  { printf 'ok   - %s\n' "$1"; pass=$((pass + 1)); }
+bad() { printf 'FAIL - %s\n' "$1"; fail=$((fail + 1)); }
+
+# Build a throwaway tool dir (fake scripts/setup-s3-backup.sh recorder) + fleet dir.
+# Prints "the env line | the argv line" the recorder captured, or the CLI's stderr.
+run_backup_setup() {
+  local gv="$1"; shift              # group_vars/all.yml content ('' = none)
+  local tool fleet rec
+  tool="$(mktemp -d)"; fleet="$(mktemp -d)"; rec="$tool/rec"
+  mkdir -p "$tool/scripts" "$fleet/fleet/group_vars"
+  [ -n "$gv" ] && printf '%s\n' "$gv" > "$fleet/fleet/group_vars/all.yml"
+  cat > "$tool/scripts/setup-s3-backup.sh" <<REC
+#!/usr/bin/env bash
+{ echo "BUCKET=\${MIUOPS_BUCKET:-<unset>}"; echo "ARGV=\$*"; } > "$rec"
+exit 0
+REC
+  chmod +x "$tool/scripts/setup-s3-backup.sh"
+  # The CLI must invoke the script under SCRIPT_DIR (overridden here for test).
+  ( MIUOPS_TEST_SCRIPT_DIR="$tool" MIUOPS_FLEET_DIR="$fleet/fleet" \
+      bash "$ROOT/miuops" backup-setup "$@" >/dev/null 2>"$tool/err" ) || true
+  if [ -f "$rec" ]; then cat "$rec"; else printf 'NO_SCRIPT_CALL\n'; cat "$tool/err"; fi
+  rm -rf "$tool" "$fleet"
+}
+
+# 1. resolves the fleet bucket from group_vars and passes it as MIUOPS_BUCKET
+out="$(run_backup_setup 'backup_s3_bucket: wwang-fleet-backup' --server web1)"
+printf '%s' "$out" | grep -q 'BUCKET=wwang-fleet-backup' \
+  && ok "passes the resolved bucket as MIUOPS_BUCKET" \
+  || bad "did not pass resolved bucket: $out"
+
+# 2. forwards --server to the setup script
+printf '%s' "$out" | grep -q -- '--server web1' \
+  && ok "forwards --server to the setup script" \
+  || bad "did not forward --server: $out"
+
+# 3. NEGATIVE: no bucket in group_vars (first server / unconfigured) -> the CLI
+#    must FAIL CLOSED with guidance, and must NOT invoke the setup script blind.
+out="$(run_backup_setup '' --server web1)"
+printf '%s' "$out" | grep -q 'NO_SCRIPT_CALL' \
+  && ok "no fleet bucket -> does not invoke the setup script (fail-closed)" \
+  || bad "ran setup with no bucket configured: $out"
+
+# 4. --server with no value -> a clean die (not a raw bash unbound-variable crash),
+#    and the setup script is never invoked.
+out="$(run_backup_setup 'backup_s3_bucket: wwang-fleet-backup' --server)"
+{ printf '%s' "$out" | grep -q 'NO_SCRIPT_CALL' && printf '%s' "$out" | grep -qi 'requires a value'; } \
+  && ok "--server with no value fails closed with a clear message" \
+  || bad "--server with no value did not fail cleanly: $out"
+
+echo "== ${pass} passed, ${fail} failed =="
+[ "$fail" -eq 0 ]

--- a/tests/backup_setup_script_test.sh
+++ b/tests/backup_setup_script_test.sh
@@ -1,0 +1,91 @@
+#!/usr/bin/env bash
+#
+# setup-s3-backup.sh consumes MIUOPS_BUCKET + skips shared-bucket
+# config on reuse.
+#
+#   * MIUOPS_BUCKET set  -> the script uses that bucket and NEVER prompts for a
+#     project (the CLI already resolved the fleet bucket from versioned config).
+#   * bucket already exists (head-bucket succeeds) -> the script does NOT re-apply
+#     the shared bucket-level config (create-bucket / encryption / public-access /
+#     object-lock / lifecycle); it ONLY mints this server's IAM identity. Adding a
+#     server can therefore never re-touch the shared fleet bucket.
+#   * bucket does NOT exist (first server) -> the config IS applied (positive
+#     control: the skip is conditional, not a blanket removal).
+#
+# Real script logic runs; only the `aws` boundary is faked by a PATH-shimmed
+# recorder that logs every call and returns canned responses (no real AWS, no jq
+# mocking). Each assertion has its mirror in the other branch so it can FAIL.
+
+set -uo pipefail
+
+ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+SCRIPT="$ROOT/scripts/setup-s3-backup.sh"
+pass=0; fail=0
+ok()  { printf 'ok   - %s\n' "$1"; pass=$((pass + 1)); }
+bad() { printf 'FAIL - %s\n' "$1"; fail=$((fail + 1)); }
+
+# Run the real setup script with a recording fake `aws`. $1 = head-bucket mode:
+#   exists -> bucket already there (rc 0); absent -> a real 404; error -> a NON-404
+#   failure (403 / throttle). Echoes "<call-log-path> <script-exit-code>".
+run_setup() {
+  local mode="$1" bin log rc
+  bin="$(mktemp -d)"; log="$bin/aws.log"
+  cat > "$bin/aws" <<REC
+#!/usr/bin/env bash
+echo "\$*" >> "$log"
+case "\$1 \$2" in
+  "sts get-caller-identity")  echo '{"Arn":"arn:aws:iam::123456789012:user/tester"}' ;;
+  "s3api head-bucket")
+    case "$mode" in
+      exists) exit 0 ;;
+      absent) echo "An error occurred (404) when calling the HeadBucket operation: Not Found" >&2; exit 254 ;;
+      error)  echo "An error occurred (403) when calling the HeadBucket operation: Forbidden" >&2; exit 254 ;;
+    esac ;;
+  "iam get-user")             exit 1 ;;   # NoSuchEntity -> script creates the user
+  "iam list-access-keys")     echo "" ;;  # no existing key -> script creates one
+  "iam create-access-key")    echo '{"AccessKey":{"AccessKeyId":"AKIAFAKE000000000000","SecretAccessKey":"fakeSecretValue/abc"}}' ;;
+  *)                          : ;;        # create-user/put-user-policy/create-bucket/put-* -> log + succeed
+esac
+exit 0
+REC
+  chmod +x "$bin/aws"
+  rc=0
+  ( PATH="$bin:$PATH" MIUOPS_BUCKET="wwang-fleet-backup" \
+      bash "$SCRIPT" --server web1 --region us-west-2 --yes </dev/null >/dev/null 2>&1 ) || rc=$?
+  printf '%s %s' "$log" "$rc"
+}
+
+called()     { grep -q -- "$2" "$1"; }
+
+# ── A. reuse path: bucket EXISTS -> only IAM, never re-touch the shared bucket ──
+read -r log rc <<< "$(run_setup exists)"
+called "$log" 'head-bucket --bucket wwang-fleet-backup' \
+  && ok "uses MIUOPS_BUCKET (no project prompt; head-bucket on the resolved bucket)" \
+  || bad "did not use MIUOPS_BUCKET / never reached head-bucket"
+
+for op in create-bucket put-bucket-encryption put-object-lock-configuration put-bucket-lifecycle-configuration put-public-access-block; do
+  if called "$log" "$op"; then bad "reuse re-touched the shared bucket: $op was called"; else ok "reuse skips shared-bucket op: $op"; fi
+done
+
+for op in 'iam put-user-policy' 'iam create-access-key'; do
+  called "$log" "$op" && ok "reuse still mints IAM: $op" || bad "IAM not minted: $op missing"
+done
+
+# ── B. positive control: bucket does NOT exist (a real 404) -> config IS applied ─
+read -r log rc <<< "$(run_setup absent)"
+called "$log" 'create-bucket --bucket wwang-fleet-backup' \
+  && ok "absent (404) bucket is created" || bad "absent bucket not created"
+called "$log" 'put-bucket-encryption' \
+  && ok "fresh bucket gets its config (skip is conditional, not blanket)" \
+  || bad "fresh bucket did not get encryption config"
+
+# ── C. a NON-404 head-bucket failure (transient/403) must fail closed: NEVER ──
+#       create or re-touch a bucket it cannot confirm absent, never mint IAM blind. ─
+read -r log rc <<< "$(run_setup error)"
+{ [ "$rc" -ne 0 ] && ok "non-404 head-bucket error fails closed (rc=$rc)"; } || bad "non-404 error did not fail closed (rc=$rc)"
+for op in create-bucket put-bucket-encryption put-object-lock-configuration put-bucket-lifecycle-configuration 'iam create-user' 'iam create-access-key'; do
+  if called "$log" "$op"; then bad "non-404 error still ran '$op' (touched/minted on an unconfirmed bucket)"; else ok "non-404 error skips '$op'"; fi
+done
+
+echo "== ${pass} passed, ${fail} failed =="
+[ "$fail" -eq 0 ]


### PR DESCRIPTION
## What

`miuops backup-setup --server <h>` onboards a server's host-side backup identity from the fleet repo, like `miuops apply`.

- It resolves the fleet backup bucket from versioned config (`host_vars` → `group_vars`) and hands it to the setup script as `MIUOPS_BUCKET`, forwarding `--region`/`--yes`. The operator never re-types a project/bucket, so a server can't be onboarded against a divergent bucket. Fails closed with guidance when no bucket is configured (the first server sets it in `group_vars/all.yml`).
- `setup-s3-backup.sh` honors `MIUOPS_BUCKET` (skipping its project prompt; standalone `--project` still works) and validates the final bucket name regardless of source.
- **Adding a server to an existing fleet bucket never re-touches the shared bucket.** Bucket-level config (encryption / public-access / Object Lock / lifecycle) runs only when the bucket is freshly created; reuse mints only that server's scoped IAM identity. `head-bucket` distinguishes a real 404 (create) from a transient/403 failure (refuse — don't create or reconfigure a bucket it can't confirm absent).

## Test

- `tests/backup_setup_cmd_test.sh` — points `MIUOPS_TEST_SCRIPT_DIR` at a recorder setup script; asserts the resolved bucket + `--server` reach it, that an unconfigured fleet fails closed, and that `--server` with no value dies cleanly.
- `tests/backup_setup_script_test.sh` — runs the real script against a PATH-shimmed recording fake `aws` (real `jq` + real script logic). Reuse asserts the five bucket-config ops are NOT called while IAM IS minted; the absent-404 path is the positive control (config IS applied); a non-404 `head-bucket` failure must fail closed without creating / re-touching / minting.

RED before / GREEN after; `setup_noninteractive` + `iam-policy-check` unregressed; `shellcheck -S error` + `bash -n` clean; CI wired.

> Stacked on #95 — review/merge that first.
