### PR TITLE
feat(backup): write a server's backup key into the fleet on backup-setup, plaintext-safe

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -33,6 +33,8 @@ jobs:
             tests/config_secret_split_test.sh \
             tests/secrets_docs_lint_test.sh \
             tests/backup_lifecycle_net.sh \
+            tests/backup_secret_write_test.sh \
+            tests/backup_setup_write_test.sh \
             tests/backup_bucket_resolve_test.sh \
             tests/backup_setup_cmd_test.sh \
             tests/backup_setup_script_test.sh
@@ -65,6 +67,8 @@ jobs:
           command -v age-keygen >/dev/null 2>&1 || sudo apt-get install -y age >/dev/null
           bash tests/sops_test.sh
           bash tests/backup_lifecycle_net.sh
+          bash tests/backup_secret_write_test.sh
+          bash tests/backup_setup_write_test.sh
 
       - name: Install Ansible
         run: pip install ansible

--- a/miuops
+++ b/miuops
@@ -962,10 +962,12 @@ cmd_backup_setup() {
     [[ -n "$host" ]] || die "backup-setup: --server <name> is required"
     bucket="$(resolve_backup_bucket "$host")"
     [[ -n "$bucket" ]] || die "backup-setup: no backup_s3_bucket configured in ${FLEET_DIR}/group_vars/all.yml (or host_vars/${host}.yml). Set the fleet bucket there once -- the first server creates it; see docs/SECRETS.md."
+    # MIUOPS_FLEET_ROOT lets the script write the new credential into the fleet
+    # (fleet/secrets/<host>.vars.json, SOPS-encrypted) instead of printing it.
     if [[ ${#pass_through[@]} -gt 0 ]]; then
-        MIUOPS_BUCKET="$bucket" "${SCRIPT_DIR}/scripts/setup-s3-backup.sh" --server "$host" "${pass_through[@]}"
+        MIUOPS_BUCKET="$bucket" MIUOPS_FLEET_ROOT="$FLEET_ROOT" "${SCRIPT_DIR}/scripts/setup-s3-backup.sh" --server "$host" "${pass_through[@]}"
     else
-        MIUOPS_BUCKET="$bucket" "${SCRIPT_DIR}/scripts/setup-s3-backup.sh" --server "$host"
+        MIUOPS_BUCKET="$bucket" MIUOPS_FLEET_ROOT="$FLEET_ROOT" "${SCRIPT_DIR}/scripts/setup-s3-backup.sh" --server "$host"
     fi
 }
 

--- a/scripts/setup-s3-backup.sh
+++ b/scripts/setup-s3-backup.sh
@@ -63,6 +63,46 @@ gen_iam_policy() {
 EOF
 }
 
+# Write a server's new AWS backup credentials into <fleet_root>/<rel> (a
+# fleet/secrets/<server>.vars.json), SOPS-encrypted, with two guarantees:
+#   * no plaintext on disk -- the creds go stdin->sops, and a merge decrypts the
+#     existing object only into memory/a pipe, so an interrupted write can never
+#     strand a cleartext key in the fleet repo;
+#   * merge, never clobber -- if the file already holds OTHER keys (e.g. a deployed
+#     token), they are preserved; only the two backup-cred keys are (over)written.
+#   $1 = fleet repo root (holds .sops.yaml)   $2 = repo-relative target path
+#   $3 = access key id   $4 = secret access key
+# The fresh path needs no age identity (encryption uses only the .sops.yaml
+# recipient); the merge path decrypts the existing file (age identity / YubiKey).
+write_backup_secret() {
+    local root="$1" rel="$2" akid="$3" secret="$4" creds tmp existing
+    # printf is a builtin, so the secret never lands in any process's argv (no `ps`
+    # leak). The values go in unescaped: an AWS key id/secret is base64-ish
+    # ([A-Za-z0-9/+]=) with no '"' or '\', so the JSON stays well-formed -- and if one
+    # ever did contain those, sops would reject the malformed JSON and the write fails
+    # closed (no partial/garbage file), rather than letting a value break out.
+    creds="$(printf '{"backup_aws_access_key_id":"%s","backup_aws_secret_access_key":"%s"}' "$akid" "$secret")"
+    # Temp ends in .tmp and lives in fleet/secrets/ -- so even an orphan left by a
+    # mid-write SIGKILL is ciphertext AND already gitignored (fleet/secrets/* + the
+    # *.tmp glob), never a plaintext leak and never accidentally committable. On a
+    # handled error it is removed explicitly below.
+    tmp="${root}/${rel}.$$.tmp"
+    if [ -f "${root}/${rel}" ]; then
+        existing="$( cd "$root" && sops --decrypt --output-type json "$rel" )" \
+            || { echo "Error: cannot decrypt existing ${rel} to merge (is the age identity / YubiKey available?)." >&2; return 1; }
+        ( cd "$root" && printf '%s\n%s' "$existing" "$creds" \
+            | jq -s '.[0] * .[1]' \
+            | sops --encrypt --input-type json --output-type json --filename-override "$rel" /dev/stdin ) > "$tmp" \
+            || { rm -f "$tmp"; echo "Error: failed to write merged ${rel}." >&2; return 1; }
+    else
+        ( cd "$root" && printf '%s' "$creds" \
+            | sops --encrypt --input-type json --output-type json --filename-override "$rel" /dev/stdin ) > "$tmp" \
+            || { rm -f "$tmp"; echo "Error: failed to encrypt ${rel}." >&2; return 1; }
+    fi
+    chmod 600 "$tmp" 2>/dev/null || true
+    mv "$tmp" "${root}/${rel}"
+}
+
 # When sourced as a library (by the iam-policy check), define the functions above and
 # stop here -- do NOT run the interactive provisioning flow or touch AWS.
 if [ -n "${MIUOPS_S3_SETUP_LIB:-}" ]; then
@@ -411,6 +451,40 @@ echo ""
 echo "--- Creating access key ---"
 
 EXISTING_KEYS=$(aws iam list-access-keys --user-name "$IAM_USER" --query 'AccessKeyMetadata[].AccessKeyId' --output text)
+
+# Invoked by `miuops backup-setup` (MIUOPS_FLEET_ROOT set): write the credential into the
+# fleet SOPS-encrypted instead of printing it, with re-run semantics. AWS never returns an
+# existing key's secret, so we only mint+write when the user has NO key; an existing key
+# with a vars.json is a no-op; an existing key with NO vars.json must be rotated.
+if [[ -n "${MIUOPS_FLEET_ROOT:-}" ]]; then
+    command -v sops >/dev/null 2>&1 \
+        || { echo "Error: sops is required to write the encrypted credential (brew install sops)." >&2; exit 1; }
+    secret_rel="fleet/secrets/${SERVER}.vars.json"
+    if [[ -n "$EXISTING_KEYS" ]]; then
+        if [[ -f "${MIUOPS_FLEET_ROOT}/${secret_rel}" ]]; then
+            echo "Already set up: ${IAM_USER} has an access key and ${secret_rel} exists — nothing to do."
+            echo "To replace the key, run:  miuops backup-rotate --server ${SERVER}"
+            exit 0
+        fi
+        echo "Error: ${IAM_USER} already has an access key, but ${secret_rel} is missing." >&2
+        echo "AWS does not return an existing key's secret, so it cannot be written now." >&2
+        echo "Run:  miuops backup-rotate --server ${SERVER}   (mints a fresh key and writes it)" >&2
+        exit 1
+    fi
+    new_key_json=$(aws iam create-access-key --user-name "$IAM_USER")
+    new_akid=$(echo "$new_key_json" | jq -r '.AccessKey.AccessKeyId')
+    new_secret=$(echo "$new_key_json" | jq -r '.AccessKey.SecretAccessKey')
+    if ! write_backup_secret "$MIUOPS_FLEET_ROOT" "$secret_rel" "$new_akid" "$new_secret"; then
+        echo "Error: created IAM key ${new_akid} but failed to write it encrypted to ${secret_rel}." >&2
+        exit 1
+    fi
+    unset new_secret new_key_json
+    echo ""
+    echo "Wrote ${secret_rel} (SOPS-encrypted; access key ${new_akid})."
+    echo "Set backup_enabled + backup_volumes in host_vars/${SERVER}.yml (bucket + region come from"
+    echo "group_vars), commit the fleet repo, then:  miuops apply ${SERVER}"
+    exit 0
+fi
 
 if [[ -n "$EXISTING_KEYS" ]]; then
     echo "IAM user already has access key(s): $EXISTING_KEYS"

--- a/tests/backup_secret_write_test.sh
+++ b/tests/backup_secret_write_test.sh
@@ -1,0 +1,75 @@
+#!/usr/bin/env bash
+#
+# write_backup_secret — write a server's new AWS backup creds into
+# fleet/secrets/<server>.vars.json, SOPS-encrypted, with two guarantees:
+#   * no plaintext on disk: the creds go STDIN -> sops (and a merge decrypts only
+#     to a pipe), so an interrupted write can never strand a cleartext key;
+#   * merge, never clobber: if the file already holds OTHER vars (e.g. a deployed
+#     token), they are preserved; only the two backup-cred keys are (over)written.
+#
+# Real sops round-trip with a throwaway age key (no operator key / YubiKey for the
+# fresh path; the merge path decrypts with the throwaway key here). Each assertion
+# checks a concrete property; the secret is a distinctive literal so a leak scan is
+# meaningful.
+
+set -uo pipefail
+
+ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+fail() { echo "FAIL: $1" >&2; exit 1; }
+command -v sops       >/dev/null 2>&1 || fail "sops not installed"
+command -v age-keygen >/dev/null 2>&1 || fail "age-keygen not installed"
+command -v jq         >/dev/null 2>&1 || fail "jq not installed"
+
+# Source the setup script as a library: it must define write_backup_secret and
+# return WITHOUT running the interactive provisioning flow.
+# shellcheck source=/dev/null
+MIUOPS_S3_SETUP_LIB=1 . "$ROOT/scripts/setup-s3-backup.sh"
+declare -F write_backup_secret >/dev/null 2>&1 || fail "write_backup_secret not defined in library mode"
+
+TMP="$(mktemp -d)"; trap 'rm -rf "$TMP"' EXIT
+export SOPS_AGE_KEY_FILE="$TMP/keys.txt"
+age-keygen -o "$SOPS_AGE_KEY_FILE" 2>/dev/null
+RECIPIENT="$(age-keygen -y "$SOPS_AGE_KEY_FILE")"
+mkdir -p "$TMP/fleet/secrets"
+cat > "$TMP/.sops.yaml" <<EOF
+creation_rules:
+  - path_regex: ^fleet/secrets/.*\.(json|env)\$
+    age: ${RECIPIENT}
+EOF
+
+REL="fleet/secrets/web1.vars.json"
+TGT="$TMP/$REL"
+SECRET='AKIAsecret-Value-rb7/qZ+first'
+leaks() { grep -rlF "$1" "$TMP" 2>/dev/null; }
+
+# ── 1. FRESH write (no existing file): ciphertext, round-trips, no plaintext ──
+write_backup_secret "$TMP" "$REL" "AKIAFIRSTID000000001" "$SECRET" >/dev/null \
+  || fail "fresh write returned non-zero"
+grep -q 'ENC\[' "$TGT" || fail "fresh: file is not ciphertext"
+if grep -qF "$SECRET" "$TGT"; then fail "fresh: raw secret leaked into ciphertext file"; fi
+got="$( cd "$TMP" && sops -d --output-type json "$REL" | jq -r '.backup_aws_secret_access_key' )"
+[ "$got" = "$SECRET" ] || fail "fresh: round-trip mismatch (got '${got}')"
+[ -z "$(leaks "$SECRET")" ] || fail "fresh: a plaintext copy of the secret exists on disk: $(leaks "$SECRET")"
+echo "ok  - fresh write: ciphertext + exact round-trip + no plaintext on disk"
+
+# ── 2. MERGE: an UNRELATED key already in the file must survive; creds update ──
+# Seed the file with an unrelated deployed var + stale backup creds, encrypted.
+printf '{"grafana_cloud_token":"glc_KEEP_ME","backup_aws_access_key_id":"OLDID","backup_aws_secret_access_key":"OLDSECRET"}' \
+  | ( cd "$TMP" && sops --encrypt --input-type json --output-type json --filename-override "$REL" /dev/stdin ) > "$TMP/seed" \
+  && mv "$TMP/seed" "$TGT"
+NEW='AKIAsecret-Value-9mX/Lp+second'
+write_backup_secret "$TMP" "$REL" "AKIASECONDID00000002" "$NEW" >/dev/null \
+  || fail "merge write returned non-zero"
+dec="$( cd "$TMP" && sops -d --output-type json "$REL" )"
+[ "$(printf '%s' "$dec" | jq -r '.grafana_cloud_token')" = "glc_KEEP_ME" ] \
+  || fail "merge CLOBBERED the unrelated key grafana_cloud_token"
+[ "$(printf '%s' "$dec" | jq -r '.backup_aws_access_key_id')" = "AKIASECONDID00000002" ] \
+  || fail "merge did not update backup_aws_access_key_id"
+[ "$(printf '%s' "$dec" | jq -r '.backup_aws_secret_access_key')" = "$NEW" ] \
+  || fail "merge did not update backup_aws_secret_access_key"
+grep -q 'ENC\[' "$TGT" || fail "merge: file is not ciphertext"
+[ -z "$(leaks "$NEW")" ] || fail "merge: a plaintext copy of the new secret exists on disk"
+echo "ok  - merge write: preserves unrelated keys + updates creds + no plaintext"
+
+echo "BACKUP SECRET WRITE: PASS"
+exit 0

--- a/tests/backup_setup_write_test.sh
+++ b/tests/backup_setup_write_test.sh
@@ -1,0 +1,87 @@
+#!/usr/bin/env bash
+#
+# CLI-mode (MIUOPS_FLEET_ROOT set) credential write + re-run semantics of
+# setup-s3-backup.sh -- the integration of write_backup_secret into the real
+# provisioning flow, behind a recording fake `aws` + a throwaway sops env:
+#   * no key            -> mint a key and WRITE fleet/secrets/<s>.vars.json
+#     (SOPS-encrypted), and NEVER print the secret;
+#   * key + vars.json   -> no-op ("already set up");
+#   * key, no vars.json -> refuse ("run backup-rotate") and write nothing, because
+#     AWS does not return an existing key's secret.
+#
+# Real sops (throwaway age key); aws faked. Each case has a concrete assertion.
+
+set -uo pipefail
+
+ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+SCRIPT="$ROOT/scripts/setup-s3-backup.sh"
+pass=0; fail=0
+ok()  { printf 'ok   - %s\n' "$1"; pass=$((pass + 1)); }
+bad() { printf 'FAIL - %s\n' "$1"; fail=$((fail + 1)); }
+command -v sops       >/dev/null 2>&1 || { echo "sops not installed" >&2; exit 1; }
+command -v age-keygen >/dev/null 2>&1 || { echo "age-keygen not installed" >&2; exit 1; }
+
+# $1 = has_key (0/1)  $2 = seed an existing vars.json (0/1). Echoes "<fleet_root> <rc>".
+run() {
+  local has_key="$1" seed="$2" root bin recip rc
+  root="$(mktemp -d)"; bin="$(mktemp -d)"
+  export SOPS_AGE_KEY_FILE="$root/keys.txt"
+  age-keygen -o "$SOPS_AGE_KEY_FILE" 2>/dev/null
+  recip="$(age-keygen -y "$SOPS_AGE_KEY_FILE")"
+  mkdir -p "$root/fleet/secrets"
+  cat > "$root/.sops.yaml" <<EOF
+creation_rules:
+  - path_regex: ^fleet/secrets/.*\.(json|env)\$
+    age: ${recip}
+EOF
+  if [ "$seed" = 1 ]; then
+    printf '{"backup_aws_access_key_id":"OLD","backup_aws_secret_access_key":"OLDSEC"}' \
+      | ( cd "$root" && sops --encrypt --input-type json --output-type json \
+            --filename-override fleet/secrets/web1.vars.json /dev/stdin ) > "$root/fleet/secrets/web1.vars.json"
+  fi
+  cat > "$bin/aws" <<REC
+#!/usr/bin/env bash
+case "\$1 \$2" in
+  "sts get-caller-identity") echo '{"Arn":"arn:aws:iam::1:user/t"}' ;;
+  "s3api head-bucket")       exit 0 ;;
+  "iam get-user")            exit 1 ;;
+  "iam list-access-keys")    $( [ "$has_key" = 1 ] && printf 'echo AKIAOLD' || printf 'echo ""' ) ;;
+  "iam create-access-key")   echo '{"AccessKey":{"AccessKeyId":"AKIANEWID","SecretAccessKey":"AKIAnewSecret/xyz"}}' ;;
+  *)                         : ;;
+esac
+exit 0
+REC
+  chmod +x "$bin/aws"
+  rc=0
+  ( PATH="$bin:$PATH" MIUOPS_BUCKET=wwang-fleet-backup MIUOPS_FLEET_ROOT="$root" \
+      bash "$SCRIPT" --server web1 --region us-west-2 --yes </dev/null > "$root/out" 2>&1 ) || rc=$?
+  rm -rf "$bin"
+  printf '%s %s' "$root" "$rc"
+}
+
+# ── 1. no key -> mint + write encrypted; secret never printed ─────────────────
+read -r root rc <<< "$(run 0 0)"
+vj="$root/fleet/secrets/web1.vars.json"
+{ [ -f "$vj" ] && grep -q 'ENC\[' "$vj"; } \
+  && ok "no key: wrote an encrypted vars.json" || bad "no key: vars.json missing or not ciphertext"
+{ [ "$rc" = 0 ]; } && ok "no key: exit 0" || bad "no key: exit $rc"
+got="$( cd "$root" && SOPS_AGE_KEY_FILE="$root/keys.txt" sops -d --output-type json fleet/secrets/web1.vars.json 2>/dev/null | jq -r '.backup_aws_secret_access_key' )"
+[ "$got" = "AKIAnewSecret/xyz" ] && ok "no key: round-trips to the freshly-minted secret" || bad "no key: round-trip mismatch (got '${got}')"
+if grep -q 'AKIAnewSecret' "$root/out"; then bad "no key: the secret was PRINTED to stdout (leak)"; else ok "no key: secret not printed"; fi
+rm -rf "$root"
+
+# ── 2. key + vars.json already there -> no-op ─────────────────────────────────
+read -r root rc <<< "$(run 1 1)"
+{ [ "$rc" = 0 ] && grep -qi 'already set up' "$root/out"; } \
+  && ok "key + vars.json: clean no-op (already set up)" || bad "key + vars.json: not a clean no-op (rc=$rc)"
+rm -rf "$root"
+
+# ── 3. key but NO vars.json -> refuse, write nothing, point to backup-rotate ──
+read -r root rc <<< "$(run 1 0)"
+{ [ "$rc" != 0 ] && grep -qi 'backup-rotate' "$root/out" && [ ! -f "$root/fleet/secrets/web1.vars.json" ]; } \
+  && ok "key, no vars.json: refuses + points to backup-rotate + writes nothing" \
+  || bad "key, no vars.json: did not refuse cleanly (rc=$rc)"
+rm -rf "$root"
+
+echo "== ${pass} passed, ${fail} failed =="
+[ "$fail" -eq 0 ]


### PR DESCRIPTION
## What

`miuops backup-setup` now writes the new AWS backup credential straight into `fleet/secrets/<server>.vars.json`, SOPS-encrypted, instead of printing it for the operator to copy-paste.

- **`write_backup_secret`** (sourceable): the creds go **stdin → sops** (no plaintext on disk), and an existing file is decrypted only into memory and **jq-merged** so other keys (e.g. a deployed token) survive — never a bare overwrite. The creds JSON is built with the `printf` builtin, so the secret never lands in any process's argv.
- The script writes only when invoked by the CLI (`MIUOPS_FLEET_ROOT`, passed by `cmd_backup_setup`); standalone use still prints. AWS never returns an existing key's secret, so the re-run is principled: **no key →** mint + write; **key + a vars.json →** no-op ("already set up"); **key but no vars.json →** refuse and point at `backup-rotate` (the secret is unrecoverable).

## Test

- `tests/backup_secret_write_test.sh` — unit-tests `write_backup_secret` with a real sops round-trip (throwaway age key): a fresh write is ciphertext that round-trips to the exact secret with no plaintext copy on disk; a merge preserves an unrelated key (mutation-proven).
- `tests/backup_setup_write_test.sh` — runs the real script (fake `aws` + throwaway sops) through the three re-run paths; the no-key path asserts the secret is written encrypted and never printed. The CLI-mode gate is mutation-proven.

`shellcheck -S error` + `bash -n` clean; standalone + IAM-policy paths unregressed; CI wired.

> Stacked on #96.
