### PR TITLE
docs(backup): point the backup docs at the backup-setup / backup-rotate commands

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -38,12 +38,14 @@ jobs:
             tests/backup_bucket_resolve_test.sh \
             tests/backup_setup_cmd_test.sh \
             tests/backup_setup_script_test.sh \
-            tests/backup_rotate_test.sh
+            tests/backup_rotate_test.sh \
+            tests/backup_docs_lint_test.sh
           bash tests/cli_test.sh
           bash tests/backup_bucket_resolve_test.sh
           bash tests/backup_setup_cmd_test.sh
           bash tests/backup_setup_script_test.sh
           bash tests/backup_rotate_test.sh
+          bash tests/backup_docs_lint_test.sh
           bash tests/script_dir_resolution_test.sh
           bash tests/discover_changed_servers_test.sh
           bash tests/deploy_workflow_lint_test.sh

--- a/README.md
+++ b/README.md
@@ -149,7 +149,8 @@ ansible-playbook playbook.yml --tags docker
 
 ## Backup Setup
 
-- `scripts/setup-s3-backup.sh --server <server>` — Create the shared S3 bucket (Object Lock + lifecycle) and a per-server, prefix-scoped IAM user for backups
+- `miuops backup-setup --server <server>` — mint this server's prefix-scoped IAM user and write its key into the fleet (SOPS-encrypted; merged, never clobbered); creates the shared bucket (Object Lock + lifecycle) on the first server. The bucket name is resolved once from `fleet/group_vars/all.yml`, never re-typed. (`scripts/setup-s3-backup.sh` is the underlying script.)
+- `miuops backup-rotate --server <server>` — rotate a server's key safely: create the new key, write + apply it, and delete the old one only after the new one is live
 - `images/postgres-walg/` — Custom PostgreSQL 17 + WAL-G image for continuous WAL archiving to S3
 
 One shared `{project}-backup` bucket holds every server's backups under a per-server prefix (`<server>/…`); each server gets its own IAM user scoped to only its prefix (no Delete, no cross-prefix access), so a compromised server's key can touch only its own backups. Within a server's prefix the host-side `backup` role stores volume tarballs under `<server>/vol/` and WAL-G stores database backups under `<server>/db/`. The volume backup is a host `systemd` timer — no container, no `docker.sock` mount; see [roles/backup/README.md](roles/backup/README.md). Object Lock (Governance, 30 days) prevents deletion; S3 lifecycle transitions to Glacier at 30 days and expires at 90 days.

--- a/docs/INSTALLATION.md
+++ b/docs/INSTALLATION.md
@@ -128,34 +128,36 @@ ansible-playbook playbook.yml
 
 ## Step 3: Set up backups
 
+Name the shared bucket once in `fleet/group_vars/all.yml` (config — the whole fleet shares
+one bucket), then mint each server's own backup identity with a single command from your
+fleet repo:
+
 ```bash
-./scripts/setup-s3-backup.sh
+# one-time, fleet-wide (config, not a secret):
+#   fleet/group_vars/all.yml:  backup_s3_bucket: <your-fleet>-backup
+
+miuops backup-setup --server <server>      # needs your AWS admin creds in the environment
 ```
 
-The script prompts for a project name and AWS region (default: `us-west-2`), then creates:
-- S3 bucket `{project}-backup` with Object Lock (Governance, 30 days)
-- Lifecycle rules: transition to Glacier at 30 days, expire at 90 days
-- IAM user with PutObject/GetObject/ListBucket only (no Delete)
-- Access key credentials
+`miuops backup-setup` resolves the bucket from versioned config (never re-typed), creates it
+on the first server (Object Lock Governance 30 days; Glacier at 30 days, expire at 90 days),
+and mints an IAM user scoped to **only** this server's `<server>/` prefix (PutObject/GetObject/
+ListBucket — no Delete, no cross-prefix). It then writes the new access key straight into
+`fleet/secrets/<server>.vars.json`, **SOPS-encrypted** — the secret never hits disk in
+plaintext, and an existing file is merged, not clobbered. There is nothing to copy or paste.
 
-One bucket serves the whole fleet; each server backs up under its own
-`<server>/` prefix (`<server>/db/…` for WAL-G, `<server>/vol/…` for volume
-tarballs), with a per-server prefix-scoped IAM user so a compromised server can
-touch only its own backups.
+One bucket serves the whole fleet; each server backs up under its own `<server>/` prefix
+(`<server>/db/…` for WAL-G, `<server>/vol/…` for volume tarballs), so a compromised server
+can touch only its own backups.
 
-Route the output by nature — see [Secret Model](SECRETS.md):
+Then set the **config** (not secret) in `fleet/host_vars/<server>.yml` — `backup_enabled: true`,
+`backup_volumes`, and `backup_aws_region` if it isn't `us-west-2` (the bucket comes from
+group_vars) — commit the fleet repo, and `miuops apply <server>`. (WAL-G database backups read
+the same credentials from the stack's app `.env` in Step 4.)
 
-- **Config** (not secret) → versioned in `fleet/host_vars/<server>.yml`: `backup_enabled: true`,
-  `backup_s3_bucket`, `backup_aws_region`, and `backup_volumes`.
-- **The AWS credentials** (secret) → SOPS-encrypted in `fleet/secrets/<server>.vars.json`:
-
-  ```bash
-  printf '{ "backup_aws_access_key_id": "AKIA...", "backup_aws_secret_access_key": "..." }\n' \
-      > fleet/secrets/<server>.vars.json
-  sops --encrypt --in-place fleet/secrets/<server>.vars.json
-  ```
-
-  (WAL-G database backups read the same credentials from the stack's app `.env` in Step 4.)
+To replace a key later, `miuops backup-rotate --server <server>` mints a new key, applies it,
+and deletes the old one only after the new one is live — so a rotation never leaves the server
+without a working key.
 
 ## Step 3b: Deployed secrets + observability
 

--- a/roles/backup/README.md
+++ b/roles/backup/README.md
@@ -24,22 +24,20 @@ the writer first.
 
 ## Quick start
 
-1. Create the shared S3 bucket + this server's scoped IAM user (Object Lock +
-   lifecycle): `scripts/setup-s3-backup.sh --server <server>` (one bucket is
-   shared by the whole fleet and with WAL-G; each server gets its own prefix +
-   IAM user — see the repo README and the **Fleet isolation** section below).
-2. Export the AWS **credentials** (the two secrets) in the shell you run miuOps from:
-
-   ```bash
-   export AWS_ACCESS_KEY_ID=AKIA...
-   export AWS_SECRET_ACCESS_KEY=...
-   ```
-
-   The region is **config, not a secret** — set `backup_aws_region` in host_vars
-   (step 3; it defaults to `us-west-2`), not via the environment.
-
-3. Configure the host in `host_vars/<host>.yml` (see schema below).
-4. Apply: `./miuops apply <host>` (or `ansible-playbook playbook.yml --tags backup --limit <host>`).
+1. From your fleet repo, mint this server's backup identity and write its key
+   into the fleet (encrypted): `miuops backup-setup --server <server>`. One
+   bucket is shared by the whole fleet (and with WAL-G); each server gets its own
+   prefix + scoped IAM user — see the repo README and the **Fleet isolation**
+   section below. The command writes `fleet/secrets/<server>.vars.json` for you
+   (SOPS-encrypted, merged not clobbered) — there is no key to copy or export. To
+   replace a key later: `miuops backup-rotate --server <server>`.
+2. Configure the host in `host_vars/<host>.yml` (see schema below) and set
+   `backup_enabled: true`. The region is **config, not a secret** — set
+   `backup_aws_region` there (defaults to `us-west-2`).
+3. Apply: `miuops apply <host>`. The CLI decrypts `<host>.vars.json` and hands the
+   AWS credentials to Ansible as extra-vars, so you unlock only your age key — no
+   `AWS_*` export. (A bare `export AWS_ACCESS_KEY_ID/...SECRET...` still works as a
+   fallback for a whole-fleet apply or a host without a `.vars.json`.)
 
 ## Configuration (host_vars schema)
 
@@ -53,8 +51,8 @@ the writer first.
 | `backup_randomized_delay_sec` | `"45m"` | `RandomizedDelaySec` to smear the start. |
 | `backup_encryption` | `"none"` | `none` \| `age`. |
 | `backup_age_recipients` | `[]` | age recipients (`age1...`, `ssh-ed25519`/`ssh-rsa`, or `age1yubikey1...`). |
-| `backup_aws_access_key_id` | env `AWS_ACCESS_KEY_ID` | AWS key. Keep env-only. |
-| `backup_aws_secret_access_key` | env `AWS_SECRET_ACCESS_KEY` | AWS secret. Keep env-only. |
+| `backup_aws_access_key_id` | from `<host>.vars.json` | AWS key. Written by `miuops backup-setup`; falls back to env `AWS_ACCESS_KEY_ID`. |
+| `backup_aws_secret_access_key` | from `<host>.vars.json` | AWS secret. Written by `miuops backup-setup`; falls back to env `AWS_SECRET_ACCESS_KEY`. |
 | `backup_aws_region` | `us-west-2` | AWS region. **Config** — set in host_vars (not env). |
 | `backup_s3_endpoint_url` | `""` | Optional S3-compatible endpoint override. |
 
@@ -106,10 +104,11 @@ backup_volumes:
     stop: []
 ```
 
-AWS credentials are **not** in host_vars — export them as environment variables
-(above) so they stay out of the repo. They are rendered on the host into
-`/etc/miuops-backup/backup.env` (mode `0600`, root) and sourced by the script,
-so they never appear in `ps` / the process table.
+AWS credentials are **not** in host_vars — `miuops backup-setup` writes them
+SOPS-encrypted to `fleet/secrets/<host>.vars.json`, which `miuops apply` decrypts
+and hands to this role (a bare `AWS_*` environment export is the fallback). Either
+way they are rendered on the host into `/etc/miuops-backup/backup.env` (mode `0600`,
+root) and sourced by the script, so they never appear in `ps` / the process table.
 
 When `backup_age_recipients` includes a YubiKey identity (`age1yubikey1...`), the
 role installs **age-plugin-yubikey** on the host automatically (pinned `.deb` +

--- a/roles/backup/defaults/main.yml
+++ b/roles/backup/defaults/main.yml
@@ -71,10 +71,11 @@ backup_age_plugin_yubikey_deb_revision: "1"
 backup_age_plugin_yubikey_deb_sha256: "bf7a02418de04b3d3df9791e185d493eb344829bca4009247a41bc4d7630b47f"
 
 # --- AWS credentials --------------------------------------------------------
-# config/secret split. The ACCESS KEY + SECRET are SECRETS: they bridge via the
-# environment for now (export AWS_ACCESS_KEY_ID / AWS_SECRET_ACCESS_KEY before
-# `./miuops apply`); the SOPS-in-fleet migration decrypts them at converge and supplies
-# them as extra-vars. They render into /etc/miuops-backup/backup.env (0600, root); the
+# config/secret split. The ACCESS KEY + SECRET are SECRETS: `miuops backup-setup`
+# writes them SOPS-encrypted to fleet/secrets/<host>.vars.json, and `miuops apply`
+# decrypts them at converge and supplies them as extra-vars (which outrank these
+# env-lookup defaults -- the bare AWS_ACCESS_KEY_ID / AWS_SECRET_ACCESS_KEY export is
+# the fallback). They render into /etc/miuops-backup/backup.env (0600, root); the
 # script sources that file, so credentials never appear in argv / `ps` output.
 backup_aws_access_key_id: "{{ lookup('env', 'AWS_ACCESS_KEY_ID') | default('', true) }}"
 backup_aws_secret_access_key: "{{ lookup('env', 'AWS_SECRET_ACCESS_KEY') | default('', true) }}"

--- a/roles/backup/tasks/main.yml
+++ b/roles/backup/tasks/main.yml
@@ -14,9 +14,10 @@
       - backup_aws_region | length > 0
     fail_msg: >-
       backup_enabled is true but the destination/credentials are incomplete.
-      Set backup_s3_bucket + backup_aws_region in host_vars (region is config, not
-      secret; it defaults to us-west-2). Export the secret AWS credentials before
-      running (see roles/backup/README.md): AWS_ACCESS_KEY_ID, AWS_SECRET_ACCESS_KEY.
+      Set backup_s3_bucket (here or in group_vars) + backup_aws_region in
+      host_vars (region is config, not secret; default us-west-2), then run
+      'miuops backup-setup --server <host>' to mint and write the AWS creds
+      into the encrypted <host>.vars.json (see roles/backup/README.md).
     quiet: true
   when: backup_enabled | bool
   tags: ['backup']

--- a/tests/backup_docs_lint_test.sh
+++ b/tests/backup_docs_lint_test.sh
@@ -1,0 +1,58 @@
+#!/usr/bin/env bash
+#
+# The operator-facing backup docs describe the `miuops backup-setup` /
+# `miuops backup-rotate` command family -- the single-source-of-truth credential
+# lifecycle -- and NOT the superseded manual flow (run the raw setup script, then
+# export/paste the AWS creds by hand). This is a drift guard: it fails if a doc
+# still teaches the old flow or forgets to mention the new commands.
+#
+# Pure text lint (no aws/sops); each assertion has a positive and a negative form
+# so it can actually fail.
+
+set -uo pipefail
+
+ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+pass=0; fail=0
+ok()  { printf 'ok   - %s\n' "$1"; pass=$((pass + 1)); }
+bad() { printf 'FAIL - %s\n' "$1"; fail=$((fail + 1)); }
+
+# ── POSITIVE: the new command family is the documented entry point ────────────
+for d in docs/INSTALLATION.md README.md roles/backup/README.md; do
+  if grep -qF 'miuops backup-setup' "$ROOT/$d"; then
+    ok "$d documents 'miuops backup-setup'"
+  else
+    bad "$d does not mention 'miuops backup-setup'"
+  fi
+done
+
+# (exclude the gitignored *.local.* planning docs -- only a shipped operator doc counts)
+if grep -rlF 'miuops backup-rotate' "$ROOT/docs" "$ROOT/roles/backup/README.md" "$ROOT/README.md" 2>/dev/null | grep -qv '\.local\.'; then
+  ok "rotation is documented via 'miuops backup-rotate'"
+else
+  bad "no operator doc mentions 'miuops backup-rotate'"
+fi
+
+# ── NEGATIVE (drift sentinels): the superseded instructions are gone ──────────
+if grep -qF 'Keep env-only' "$ROOT/roles/backup/README.md"; then
+  bad "roles/backup/README.md still calls the creds 'env-only' (superseded by the encrypted vars.json the command writes)"
+else
+  ok "roles/backup/README.md dropped the stale 'env-only' creds note"
+fi
+
+# INSTALLATION's backup step must be the command, not a bare raw-script invocation.
+if grep -qE '^\./scripts/setup-s3-backup\.sh[[:space:]]*$' "$ROOT/docs/INSTALLATION.md"; then
+  bad "docs/INSTALLATION.md still shows the bare './scripts/setup-s3-backup.sh' as the setup step"
+else
+  ok "docs/INSTALLATION.md setup step is the command, not the raw script"
+fi
+
+# The role README's creds prose must not teach env-export as THE mechanism (it's a
+# fallback) -- this sentinel guards the prose block, not just the var table.
+if grep -qiF 'export them as environment variables' "$ROOT/roles/backup/README.md"; then
+  bad "roles/backup/README.md still teaches env-export as the primary creds path (it's a fallback)"
+else
+  ok "roles/backup/README.md does not teach env-export as the primary creds path"
+fi
+
+echo "== ${pass} passed, ${fail} failed =="
+[ "$fail" -eq 0 ]


### PR DESCRIPTION
## What

The operator-facing backup docs walked through the old manual flow — run `setup-s3-backup.sh` directly, then export/paste the AWS credentials by hand. Point them at the command family that now owns the credential lifecycle:

- **INSTALLATION Step 3**: `miuops backup-setup --server <h>` resolves the bucket from `group_vars`, mints the scoped IAM user, and writes the key SOPS-encrypted into `fleet/secrets/<h>.vars.json` (merged, no copy/paste); `miuops backup-rotate` for rotation.
- **README** + **roles/backup/README**: the commands are the entry point; the per-server creds come from `<host>.vars.json` (env stays a documented fallback). Also fixed an internal contradiction where a lower prose block still taught env-export as the primary path.
- The backup role's missing-creds **assert message** points at `miuops backup-setup`.

## Test

`tests/backup_docs_lint_test.sh` — a drift guard asserting the operator docs name the commands and have dropped the superseded "env-only / raw-script / export-as-primary" instructions (positive + negative sentinels, each proven to fail on regression). `shellcheck` + `ansible --syntax-check` clean; CI wired.

> Stacked on #98. `docs/DISASTER_RECOVERY.md` Scenario 4 (manual rotation) is deferred to the follow-up that also makes `backup-rotate` cover WAL-G's stack `.env`.
