### PR TITLE
feat(backup): keep WAL-G's stack .env key in sync on setup + rotate

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -34,6 +34,7 @@ jobs:
             tests/secrets_docs_lint_test.sh \
             tests/backup_lifecycle_net.sh \
             tests/backup_secret_write_test.sh \
+            tests/backup_env_sync_test.sh \
             tests/backup_setup_write_test.sh \
             tests/backup_bucket_resolve_test.sh \
             tests/backup_setup_cmd_test.sh \
@@ -72,6 +73,7 @@ jobs:
           bash tests/sops_test.sh
           bash tests/backup_lifecycle_net.sh
           bash tests/backup_secret_write_test.sh
+          bash tests/backup_env_sync_test.sh
           bash tests/backup_setup_write_test.sh
 
       - name: Install Ansible

--- a/docs/DISASTER_RECOVERY.md
+++ b/docs/DISASTER_RECOVERY.md
@@ -263,43 +263,30 @@ docker start CONTAINER [CONTAINER...]
 
 ## Scenario 4: Credential rotation
 
-If an AWS access key is compromised, rotate it immediately.
-
-### 1. Create a new access key
-
-```bash
-aws iam create-access-key --user-name PROJECT-backup
-```
-
-Save the new `AccessKeyId` and `SecretAccessKey`.
-
-### 2. Delete the old key
+If a server's AWS backup key is compromised (or on a routine schedule), rotate it
+with one command from your fleet repo:
 
 ```bash
-aws iam delete-access-key --user-name PROJECT-backup --access-key-id OLD_KEY_ID
+miuops backup-rotate --server <server>
 ```
 
-### 3. Update the server's `.env`
+`miuops backup-rotate` does the whole dance safely:
 
-Update `/opt/stacks/.env` on the server with the new credentials:
+1. mints a new access key for the server's scoped IAM user;
+2. writes it into `fleet/secrets/<server>.vars.json` (host volume backups) **and**,
+   if the server runs WAL-G, syncs it into `fleet/secrets/<server>.env` (the stack
+   env WAL-G reads) — both SOPS-encrypted, merged not clobbered;
+3. runs `miuops apply <server>` to push the new key to the host;
+4. and **only after that apply succeeds** deletes the old key.
 
-```
-AWS_ACCESS_KEY_ID=new_key_id
-AWS_SECRET_ACCESS_KEY=new_secret_key
-```
+Because both credential locations are updated and pushed *before* the old key is
+deleted, neither the host volume backup nor WAL-G is ever stranded on a dead key.
+If the apply fails it stops **before** the delete, so the server keeps a working key
+— re-run `miuops apply <server>`, then the old key can be removed. It refuses unless
+the IAM user has exactly one key, so a rotation is never ambiguous. Commit the
+updated `fleet/secrets/<server>.*` afterward.
 
-The `.env` lives on the server (not a GitHub secret) — edit it over SSH
-(`ssh <user>@<server>`), then redeploy.
-
-### 4. Redeploy
-
-Push to `main` (or re-run the deploy workflow) so containers pick up the new credentials:
-
-```bash
-git commit --allow-empty -m "Rotate AWS credentials" && git push
-```
-
-### 5. Verify
+### Verify
 
 ```bash
 # Check that backups still work

--- a/miuops
+++ b/miuops
@@ -1036,6 +1036,13 @@ cmd_backup_rotate() {
         unset new_secret new_json
         die "backup-rotate: created key ${new_akid} but failed to write it. The old key ${old_key} is still active; resolve the new key manually."
     fi
+    # The same key also feeds WAL-G via the stack env -- sync it BEFORE apply (so apply
+    # pushes both) and BEFORE the delete, or WAL-G would be stranded on the deleted key.
+    # No-op when the server has no fleet/secrets/<host>.env carrying AWS creds.
+    if ! sync_backup_env "$FLEET_ROOT" "fleet/secrets/${host}.env" "$new_akid" "$new_secret"; then
+        unset new_secret new_json
+        die "backup-rotate: wrote the new key to vars.json but failed to sync it into fleet/secrets/${host}.env. The old key ${old_key} is still active; resolve manually before deleting it."
+    fi
     unset new_secret new_json
     # 3. push the new key to the host
     info "Applying ${host} to push the new key..."

--- a/scripts/setup-s3-backup.sh
+++ b/scripts/setup-s3-backup.sh
@@ -103,6 +103,34 @@ write_backup_secret() {
     mv "$tmp" "${root}/${rel}"
 }
 
+# The same per-server key is also consumed by WAL-G via the stack env at
+# <fleet_root>/<rel> (fleet/secrets/<server>.env). Keep its AWS_ACCESS_KEY_ID /
+# AWS_SECRET_ACCESS_KEY in sync with a freshly minted/rotated key so a rotation
+# never leaves WAL-G on a deleted key. No-op when the env is absent or carries no
+# AWS_ACCESS_KEY_ID (not a backup-bearing stack env) -- it never INJECTS creds.
+#   $1 = fleet repo root   $2 = repo-relative .env path   $3 = akid   $4 = secret
+sync_backup_env() {
+    local root="$1" rel="$2" akid="$3" secret="$4" existing tmp
+    [ -f "${root}/${rel}" ] || return 0
+    existing="$( cd "$root" && sops --decrypt --output-type dotenv "$rel" )" \
+        || { echo "Error: cannot decrypt ${rel} to sync the backup key (age identity / YubiKey available?)." >&2; return 1; }
+    printf '%s\n' "$existing" | grep -q '^AWS_ACCESS_KEY_ID=' || return 0
+    tmp="${root}/${rel}.$$.tmp"
+    # awk -v assigns the values literally; an AWS key id/secret is base64-ish
+    # ([A-Za-z0-9/+]=) with no backslash, so there is nothing for awk to re-escape.
+    if ! ( cd "$root" && printf '%s\n' "$existing" \
+            | awk -v akid="$akid" -v secret="$secret" '
+                /^AWS_ACCESS_KEY_ID=/     { print "AWS_ACCESS_KEY_ID=" akid; s1=1; next }
+                /^AWS_SECRET_ACCESS_KEY=/ { print "AWS_SECRET_ACCESS_KEY=" secret; s2=1; next }
+                { print }
+                END { if (!s1) print "AWS_ACCESS_KEY_ID=" akid; if (!s2) print "AWS_SECRET_ACCESS_KEY=" secret }' \
+            | sops --encrypt --input-type dotenv --output-type dotenv --filename-override "$rel" /dev/stdin ) > "$tmp"; then
+        rm -f "$tmp"; echo "Error: failed to write synced ${rel}." >&2; return 1
+    fi
+    chmod 600 "$tmp" 2>/dev/null || true
+    mv "$tmp" "${root}/${rel}"
+}
+
 # When sourced as a library (by the iam-policy check), define the functions above and
 # stop here -- do NOT run the interactive provisioning flow or touch AWS.
 if [ -n "${MIUOPS_S3_SETUP_LIB:-}" ]; then
@@ -476,6 +504,12 @@ if [[ -n "${MIUOPS_FLEET_ROOT:-}" ]]; then
     new_secret=$(echo "$new_key_json" | jq -r '.AccessKey.SecretAccessKey')
     if ! write_backup_secret "$MIUOPS_FLEET_ROOT" "$secret_rel" "$new_akid" "$new_secret"; then
         echo "Error: created IAM key ${new_akid} but failed to write it encrypted to ${secret_rel}." >&2
+        exit 1
+    fi
+    # If this server runs WAL-G, the same key lives in its stack env too -- keep it in
+    # sync (no-op when there is no fleet/secrets/<server>.env carrying AWS creds).
+    if ! sync_backup_env "$MIUOPS_FLEET_ROOT" "fleet/secrets/${SERVER}.env" "$new_akid" "$new_secret"; then
+        echo "Error: wrote ${secret_rel} but failed to sync the key into fleet/secrets/${SERVER}.env." >&2
         exit 1
     fi
     unset new_secret new_key_json

--- a/tests/backup_docs_lint_test.sh
+++ b/tests/backup_docs_lint_test.sh
@@ -54,5 +54,18 @@ else
   ok "roles/backup/README.md does not teach env-export as the primary creds path"
 fi
 
+# DISASTER_RECOVERY's key-rotation scenario must use the command, not the old manual
+# aws-iam create/delete + hand-edit-the-.env dance.
+if grep -qF 'miuops backup-rotate' "$ROOT/docs/DISASTER_RECOVERY.md"; then
+  ok "DISASTER_RECOVERY rotation uses 'miuops backup-rotate'"
+else
+  bad "DISASTER_RECOVERY does not use 'miuops backup-rotate' for key rotation"
+fi
+if grep -qF 'aws iam create-access-key' "$ROOT/docs/DISASTER_RECOVERY.md"; then
+  bad "DISASTER_RECOVERY still documents the manual 'aws iam create-access-key' rotation steps"
+else
+  ok "DISASTER_RECOVERY dropped the manual aws-iam rotation steps"
+fi
+
 echo "== ${pass} passed, ${fail} failed =="
 [ "$fail" -eq 0 ]

--- a/tests/backup_env_sync_test.sh
+++ b/tests/backup_env_sync_test.sh
@@ -1,0 +1,73 @@
+#!/usr/bin/env bash
+#
+# sync_backup_env — keep a WAL-G server's stack .env (fleet/secrets/<host>.env)
+# AWS backup credentials in sync with a freshly minted/rotated key, so that
+# rotating the key never strands WAL-G on a deleted key. Guarantees:
+#   * updates AWS_ACCESS_KEY_ID + AWS_SECRET_ACCESS_KEY in place and preserves
+#     EVERY other line (WALG_S3_PREFIX, DATABASE_URL, …);
+#   * stdin -> sops (dotenv): the new secret never lands on disk in plaintext;
+#   * no-op when the .env is absent OR carries no AWS_ACCESS_KEY_ID (i.e. not a
+#     backup-bearing stack env) -- it never INJECTS AWS creds into an unrelated env.
+#
+# Real sops dotenv round-trip with a throwaway age key.
+
+set -uo pipefail
+
+ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+fail() { echo "FAIL: $1" >&2; exit 1; }
+command -v sops       >/dev/null 2>&1 || fail "sops not installed"
+command -v age-keygen >/dev/null 2>&1 || fail "age-keygen not installed"
+
+# shellcheck source=/dev/null
+MIUOPS_S3_SETUP_LIB=1 . "$ROOT/scripts/setup-s3-backup.sh"
+declare -F sync_backup_env >/dev/null 2>&1 || fail "sync_backup_env not defined in library mode"
+
+TMP="$(mktemp -d)"; trap 'rm -rf "$TMP"' EXIT
+export SOPS_AGE_KEY_FILE="$TMP/keys.txt"
+age-keygen -o "$SOPS_AGE_KEY_FILE" 2>/dev/null
+RECIPIENT="$(age-keygen -y "$SOPS_AGE_KEY_FILE")"
+mkdir -p "$TMP/fleet/secrets"
+cat > "$TMP/.sops.yaml" <<EOF
+creation_rules:
+  - path_regex: ^fleet/secrets/.*\.env\$
+    age: ${RECIPIENT}
+EOF
+
+REL="fleet/secrets/web1.env"
+TGT="$TMP/$REL"
+NEW_ID="AKIAROTATEDID0000001"
+NEW_SECRET="rotated-Secret/9mX+Lp"
+seal_env() {  # stdin (plaintext dotenv) -> encrypted $TGT
+  ( cd "$TMP" && sops --encrypt --input-type dotenv --output-type dotenv --filename-override "$REL" /dev/stdin ) > "$TGT"
+}
+leaks() { grep -rlF "$1" "$TMP" 2>/dev/null | grep -v keys.txt; }
+
+# ── 1. .env with AWS creds + unrelated keys -> updates creds, preserves the rest ──
+printf 'WALG_S3_PREFIX=s3://b/web1/db\nAWS_ACCESS_KEY_ID=OLDID\nAWS_SECRET_ACCESS_KEY=OLDSECRET\nDATABASE_URL=postgres://x/y\n' | seal_env
+sync_backup_env "$TMP" "$REL" "$NEW_ID" "$NEW_SECRET" >/dev/null || fail "sync returned non-zero on a backup .env"
+grep -q 'ENC\[' "$TGT" || fail "result is not ciphertext"
+if grep -qF "$NEW_SECRET" "$TGT"; then fail "new secret leaked in ciphertext"; fi
+dec="$( cd "$TMP" && sops -d --output-type dotenv "$REL" )"
+grep -qx "AWS_ACCESS_KEY_ID=${NEW_ID}" <<<"$dec"        || fail "AWS_ACCESS_KEY_ID not updated"
+grep -qx "AWS_SECRET_ACCESS_KEY=${NEW_SECRET}" <<<"$dec" || fail "AWS_SECRET_ACCESS_KEY not updated"
+grep -qx 'WALG_S3_PREFIX=s3://b/web1/db' <<<"$dec"      || fail "CLOBBERED WALG_S3_PREFIX"
+grep -qx 'DATABASE_URL=postgres://x/y' <<<"$dec"        || fail "CLOBBERED DATABASE_URL"
+[ -z "$(leaks "$NEW_SECRET")" ] || fail "plaintext copy of the new secret on disk: $(leaks "$NEW_SECRET")"
+echo "ok  - backup .env: updates AWS creds, preserves other keys, no plaintext"
+
+# ── 2. .env WITHOUT AWS creds -> left untouched (never injects creds) ─────────
+printf 'WALG_S3_PREFIX=s3://b/web1/db\nDATABASE_URL=postgres://x/y\n' | seal_env
+before="$( cd "$TMP" && sops -d --output-type dotenv "$REL" )"
+sync_backup_env "$TMP" "$REL" "$NEW_ID" "$NEW_SECRET" >/dev/null || fail "sync returned non-zero on a non-backup .env"
+after="$( cd "$TMP" && sops -d --output-type dotenv "$REL" )"
+[ "$before" = "$after" ] || fail "a non-backup .env was modified (creds injected)"
+if grep -qF "$NEW_ID" <<<"$after"; then fail "injected AWS_ACCESS_KEY_ID into a .env that had none"; fi
+echo "ok  - non-backup .env: left untouched (no creds injected)"
+
+# ── 3. no .env at all -> no-op, success ──────────────────────────────────────
+rm -f "$TGT"
+sync_backup_env "$TMP" "$REL" "$NEW_ID" "$NEW_SECRET" >/dev/null || fail "sync should be a no-op (0) when the .env is absent"
+[ -f "$TGT" ] || echo "ok  - absent .env: no-op, no file created"
+
+echo "BACKUP ENV SYNC: PASS"
+exit 0

--- a/tests/backup_rotate_test.sh
+++ b/tests/backup_rotate_test.sh
@@ -52,6 +52,7 @@ REC
       . "'"$ROOT"'/miuops" --source-only 2>/dev/null
       require_sops()        { :; }   # the sops binary is a converge dep, not needed to unit-test the rotation flow (CI lint stage has no sops)
       write_backup_secret() { echo "WRITE $2" >> "'"$log"'"; return 0; }
+      sync_backup_env()     { echo "ENVSYNC $2" >> "'"$log"'"; return 0; }
       run_apply()           { echo "APPLY $*" >> "'"$log"'"; return '"$apply_rc"'; }
       cmd_backup_rotate --server web1 --yes
     ' >/dev/null 2>>"$log" ) || rc=$?
@@ -59,13 +60,20 @@ REC
   printf '%s %s' "$log" "$rc"
 }
 
-seq_of() { grep -oE 'CREATE|WRITE|APPLY|DELETE' "$1" | tr '\n' ' '; }
+seq_of() { grep -oE 'CREATE|WRITE|ENVSYNC|APPLY|DELETE' "$1" | tr '\n' ' '; }
+pos_of() { grep -n "$2" "$1" | head -1 | cut -d: -f1; }
 
 # 1. exactly 1 key + apply OK -> full sequence, old key deleted, exit 0
 read -r log rc <<< "$(run_rotate 1 0)"
-[ "$(seq_of "$log")" = "CREATE WRITE APPLY DELETE " ] \
-  && ok "happy path: create -> write -> apply -> delete, in order" \
+[ "$(seq_of "$log")" = "CREATE WRITE ENVSYNC APPLY DELETE " ] \
+  && ok "happy path: create -> write -> sync-env -> apply -> delete, in order" \
   || bad "happy path wrong sequence: '$(seq_of "$log")'"
+# WAL-G safety: the stack .env is synced BEFORE the old key is deleted (else WAL-G
+# would be stranded on a deleted key). Require both present + ENVSYNC earlier.
+env_at="$(pos_of "$log" ENVSYNC)"; del_at="$(pos_of "$log" DELETE)"
+{ [ -n "$env_at" ] && [ -n "$del_at" ] && [ "$env_at" -lt "$del_at" ]; } \
+  && ok "WAL-G .env synced before the old key is deleted" \
+  || bad "old key deleted before (or without) the .env sync"
 grep -q 'DELETE .*AKIAOLD1' "$log" && ok "deletes the OLD key (AKIAOLD1)" || bad "did not delete the old key"
 { [ "$rc" = 0 ]; } && ok "happy path exit 0" || bad "happy path exit $rc"
 rm -rf "$(dirname "$log")"
@@ -95,7 +103,7 @@ rm -rf "$(dirname "$log")"
 #    WITHOUT erroring (so set -e does NOT catch it) -> the guard must abort BEFORE
 #    write/apply/delete, so the old key is never touched (safety invariant stays total).
 read -r log rc <<< "$(run_rotate 1 0 '{"AccessKey":{}}')"
-{ [ "$rc" != 0 ] && grep -q 'CREATE' "$log" && ! grep -qE 'WRITE|APPLY|DELETE' "$log"; } \
+{ [ "$rc" != 0 ] && grep -q 'CREATE' "$log" && ! grep -qE 'WRITE|ENVSYNC|APPLY|DELETE' "$log"; } \
   && ok "malformed create response: aborts before write/apply/delete (old key untouched)" \
   || bad "malformed create: did not abort cleanly (rc=$rc seq='$(seq_of "$log")')"
 rm -rf "$(dirname "$log")"


### PR DESCRIPTION
## What

The per-server backup IAM key has **two** consumers: the host volume-backup role (`fleet/secrets/<host>.vars.json`) and WAL-G, which reads the same key from the server's stack env (`fleet/secrets/<host>.env`). `backup-rotate` updated only the vars.json, so on a WAL-G server it would delete the old key while WAL-G's `.env` still held it — stranding WAL-G on a dead key.

`sync_backup_env` updates `AWS_ACCESS_KEY_ID` / `AWS_SECRET_ACCESS_KEY` in an existing encrypted dotenv (**stdin → sops**, no plaintext on disk), preserving every other line, and is a **no-op** when the server has no `.env` carrying AWS creds (never injects creds into an unrelated env). `backup-setup` and `backup-rotate` both call it; rotate syncs the `.env` **before** the apply (so apply pushes both) and **before** the delete — so neither consumer is ever stranded on a deleted key.

`docs/DISASTER_RECOVERY.md` Scenario 4 now documents the single safe `miuops backup-rotate` (both cred locations + safe ordering) instead of the manual `aws iam create/delete` + hand-edit-the-`.env` dance.

## Test

- `tests/backup_env_sync_test.sh` — real sops dotenv round-trip: updates the creds + preserves other keys with no plaintext on disk (merge mutation-proven); leaves a non-backup `.env` untouched; no-op when absent.
- `tests/backup_rotate_test.sh` — sync wired in the right order (`create → write → sync-env → apply → delete`), with an explicit assertion + mutation proof that the `.env` is synced **before** the old key is deleted.
- `tests/backup_docs_lint_test.sh` — DR uses `backup-rotate`; the manual aws-iam steps are gone.
- Adversarial probes (prefix-collision `AWS_ACCESS_KEY_IDX`, secret with `=`/`+`/`/`/`&`, inject-guard) all pass.

`shellcheck -S error` + `bash -n` + `ansible --syntax-check` clean; CI wired.

> Stacked on #99.
