### PR TITLE
docs(backup): show the single-source backup config in the fleet template

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -40,13 +40,15 @@ jobs:
             tests/backup_setup_cmd_test.sh \
             tests/backup_setup_script_test.sh \
             tests/backup_rotate_test.sh \
-            tests/backup_docs_lint_test.sh
+            tests/backup_docs_lint_test.sh \
+            tests/backup_config_template_test.sh
           bash tests/cli_test.sh
           bash tests/backup_bucket_resolve_test.sh
           bash tests/backup_setup_cmd_test.sh
           bash tests/backup_setup_script_test.sh
           bash tests/backup_rotate_test.sh
           bash tests/backup_docs_lint_test.sh
+          bash tests/backup_config_template_test.sh
           bash tests/script_dir_resolution_test.sh
           bash tests/discover_changed_servers_test.sh
           bash tests/deploy_workflow_lint_test.sh

--- a/group_vars/all.yml.example
+++ b/group_vars/all.yml.example
@@ -23,3 +23,15 @@
 #
 # The TOKEN is a SECRET — it does NOT go here. It bridges via the environment
 # (export GRAFANA_CLOUD_TOKEN) until the SOPS-encrypted fleet secret supplies it.
+
+# --- Backup destination (shared by the whole fleet) ---------------------------
+# One S3 bucket for the whole fleet; each server backs up under its own <server>/
+# prefix with its own scoped IAM key. The bucket name, client-side encryption mode,
+# and age recipients are CONFIG, identical across servers, so they live here once
+# (single source of truth) — `miuops backup-setup` reads the bucket from here and never
+# asks you to re-type it. The per-server AWS key is a SECRET that `miuops backup-setup`
+# writes into fleet/secrets/<server>.vars.json (SOPS); it is NOT set here. Uncomment:
+# backup_s3_bucket: "your-fleet-backup"
+# backup_encryption: age          # none | age (client-side encryption before upload)
+# backup_age_recipients:
+#   - "age1..."                   # or ssh-ed25519 / age1yubikey1... (decrypt-side key)

--- a/host_vars/server1.yml.example
+++ b/host_vars/server1.yml.example
@@ -7,3 +7,13 @@ tunnel_id: ""   # this server's Cloudflare tunnel UUID (miuops fills this in)
 # Optional firewall posture override for this server (defaults are generic-safe):
 # firewall_management_networks_v4: ["203.0.113.0/24"]
 # firewall_ssh_ratelimit_enabled: false
+
+# Backups — PER-SERVER only: the on/off switch and this server's volume list. The
+# shared bucket + encryption + age recipients are fleet-wide and live ONCE in
+# group_vars/all.yml (not here). Run `miuops backup-setup --server <name>` to mint
+# this server's key. Uncomment to enable:
+# backup_enabled: true
+# backup_volumes:
+#   - name: myapp_data           # docker volume name
+#     stop: [myapp-1]            # containers to stop for an at-rest snapshot ([] = hot copy)
+# backup_aws_region: us-west-2   # only if this server's bucket isn't in us-west-2

--- a/roles/backup/README.md
+++ b/roles/backup/README.md
@@ -39,18 +39,23 @@ the writer first.
    `AWS_*` export. (A bare `export AWS_ACCESS_KEY_ID/...SECRET...` still works as a
    fallback for a whole-fleet apply or a host without a `.vars.json`.)
 
-## Configuration (host_vars schema)
+## Configuration
+
+Fleet-wide values — `backup_s3_bucket`, `backup_encryption`, `backup_age_recipients` —
+are identical across servers and live **once** in `group_vars/all.yml`. Per-server
+values (`backup_enabled`, `backup_volumes`, `backup_aws_region`, …) live in
+`host_vars/<host>.yml`.
 
 | Variable | Default | Description |
 |---|---|---|
-| `backup_enabled` | `false` | Master switch. Role is a no-op when false. |
-| `backup_volumes` | `[]` | List of `{ name, stop }` items (below). |
-| `backup_s3_bucket` | `""` | Destination bucket name (no `s3://`). One bucket for the whole fleet. Required. |
+| `backup_enabled` | `false` | Master switch. Role is a no-op when false. **Per-server** (host_vars). |
+| `backup_volumes` | `[]` | List of `{ name, stop }` items (below). **Per-server** (host_vars). |
+| `backup_s3_bucket` | `""` | Destination bucket name (no `s3://`). One bucket for the whole fleet — **fleet-wide, set in group_vars** (single source). Required. |
 | `backup_s3_prefix` | `"{{ inventory_hostname }}/vol"` | Key prefix, rooted at this server's name. Objects land under `<server>/vol/<volume>/`. Must start with `<inventory_hostname>/` (the role asserts it). |
 | `backup_schedule` | `"*-*-* 02:00:00"` | systemd `OnCalendar` expression. |
 | `backup_randomized_delay_sec` | `"45m"` | `RandomizedDelaySec` to smear the start. |
-| `backup_encryption` | `"none"` | `none` \| `age`. |
-| `backup_age_recipients` | `[]` | age recipients (`age1...`, `ssh-ed25519`/`ssh-rsa`, or `age1yubikey1...`). |
+| `backup_encryption` | `"none"` | `none` \| `age`. **Fleet-wide** (group_vars). |
+| `backup_age_recipients` | `[]` | age recipients (`age1...`, `ssh-ed25519`/`ssh-rsa`, or `age1yubikey1...`). **Fleet-wide** (group_vars). |
 | `backup_aws_access_key_id` | from `<host>.vars.json` | AWS key. Written by `miuops backup-setup`; falls back to env `AWS_ACCESS_KEY_ID`. |
 | `backup_aws_secret_access_key` | from `<host>.vars.json` | AWS secret. Written by `miuops backup-setup`; falls back to env `AWS_SECRET_ACCESS_KEY`. |
 | `backup_aws_region` | `us-west-2` | AWS region. **Config** — set in host_vars (not env). |
@@ -84,19 +89,21 @@ until the next manual intervention.
 ### Example
 
 ```yaml
-# host_vars/<host>.yml
-backup_enabled: true
+# group_vars/all.yml — fleet-wide (one bucket + shared encryption/recipients)
 backup_s3_bucket: "myfleet-backup"      # one bucket for the whole fleet
-backup_aws_region: "us-west-2"          # config (not a secret); defaults to us-west-2
-# backup_s3_prefix defaults to "{{ inventory_hostname }}/vol" — leave it unset
-# unless you have a reason to change the trailing segment (keep the
-# "<server>/" root or the role's assert fails).
-backup_schedule: "*-*-* 02:00:00"
 backup_encryption: "age"
 backup_age_recipients:
   - "age1ql3z7hjy54pw3hyww5ayyfg7zqgvc7w3j2elw8zmrj2kg5sfn9aqmcac8p"
   # or an SSH public key:
   # - "ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAA..."
+
+# host_vars/<host>.yml — per server
+backup_enabled: true
+backup_aws_region: "us-west-2"          # config (not a secret); defaults to us-west-2
+# backup_s3_prefix defaults to "{{ inventory_hostname }}/vol" — leave it unset
+# unless you have a reason to change the trailing segment (keep the
+# "<server>/" root or the role's assert fails).
+backup_schedule: "*-*-* 02:00:00"
 backup_volumes:
   - name: app_uploads        # stateful: stop the writer for an at-rest copy
     stop: [app]

--- a/tests/backup_config_template_test.sh
+++ b/tests/backup_config_template_test.sh
@@ -1,0 +1,45 @@
+#!/usr/bin/env bash
+#
+# The adopter template teaches the single-source-of-truth backup pattern: the shared
+# bucket (+ client-side encryption mode + age recipients) lives ONCE in
+# group_vars/all.yml.example, and is NOT duplicated into host_vars/server1.yml.example
+# (which carries only the per-server switch + volume list). A future template edit
+# that re-scatters the shared bucket into host_vars trips this lint.
+set -uo pipefail
+ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+GV="$ROOT/group_vars/all.yml.example"
+HV="$ROOT/host_vars/server1.yml.example"
+pass=0; fail=0
+ok()  { printf 'ok   - %s\n' "$1"; pass=$((pass + 1)); }
+bad() { printf 'FAIL - %s\n' "$1"; fail=$((fail + 1)); }
+
+# Shared backup config -> group_vars example (single source).
+for k in backup_s3_bucket backup_encryption backup_age_recipients; do
+  grep -qE "^[# ]*${k}:" "$GV" && ok "group_vars example shows fleet-wide '${k}'" \
+    || bad "group_vars/all.yml.example is missing fleet-wide '${k}'"
+done
+
+# Per-server backup config -> host_vars example (the switch + volumes).
+for k in backup_enabled backup_volumes; do
+  grep -qE "^[# ]*${k}:" "$HV" && ok "host_vars example shows per-server '${k}'" \
+    || bad "host_vars/server1.yml.example is missing per-server '${k}'"
+done
+
+# The shared bucket must NOT be duplicated into the host_vars example (the anti-pattern
+# this consolidation removes). An ACTIVE (uncommented) line is the failure.
+if grep -qE '^[[:space:]]*backup_s3_bucket:' "$HV"; then
+  bad "host_vars/server1.yml.example duplicates the fleet-wide backup_s3_bucket (belongs in group_vars)"
+else
+  ok "host_vars example does not duplicate the fleet-wide bucket"
+fi
+
+# The role's own README must teach the SAME split (bucket under group_vars, fleet-wide),
+# not the old bucket-in-host_vars schema/example.
+if grep -qF 'group_vars/all.yml — fleet-wide' "$ROOT/roles/backup/README.md"; then
+  ok "roles/backup/README.md shows the bucket under group_vars (fleet-wide)"
+else
+  bad "roles/backup/README.md does not show the bucket as fleet-wide/group_vars (teaches the anti-pattern)"
+fi
+
+echo "== ${pass} passed, ${fail} failed =="
+[ "$fail" -eq 0 ]

--- a/tests/config_secret_split_test.sh
+++ b/tests/config_secret_split_test.sh
@@ -1,17 +1,17 @@
 #!/usr/bin/env bash
-# The config/secret split (the conflation this removes): in the observability + backup
-# role defaults, CONFIG is versioned and SECRETS bridge via env until SOPS-in-fleet.
+# The config/secret split: in the observability + backup role defaults, CONFIG is
+# versioned and SECRETS come from the SOPS-encrypted fleet (env is only a fallback).
 #
 #   CONFIG  (observability endpoints + user IDs, the backup region) -> role default
 #           carries NO lookup('env'): it comes only from group_vars/all (endpoints)
 #           or host_vars (region), and the role's `| length > 0` assert makes a
 #           missing one fail LOUD, not silently ship an empty config.
-#   SECRET  (the Grafana token, the AWS access key + secret) -> role default KEEPS
-#           lookup('env') as the interim bridge until U6 supplies it via SOPS
-#           `--extra-vars`.
+#   SECRET  (the Grafana token, the AWS access key + secret) -> supplied at converge
+#           from the SOPS-encrypted fleet (decrypted to --extra-vars, which outrank
+#           defaults); the role default KEEPS a lookup('env') as the FALLBACK.
 #
 # This is a TRIPWIRE: it pins the split so a future edit can't silently re-mix a config
-# value back onto env (re-introducing the conflation) or strip a secret's env bridge.
+# value back onto env (re-introducing the conflation) or strip a secret's env fallback.
 set -euo pipefail
 ROOT="$(cd "$(dirname "$0")/.." && pwd)"
 OBS="$ROOT/roles/observability/defaults/main.yml"
@@ -27,12 +27,12 @@ done
 grep -qE "^backup_aws_region:.*lookup\(['\"]env" "$BAK" \
     && fail "backup_aws_region is CONFIG -> must not lookup('env') (set it in host_vars)"
 
-# --- SECRETS keep the env bridge (until SOPS-in-fleet, U6) ---
+# --- SECRETS keep the env lookup as a FALLBACK (SOPS-in-fleet is the primary path) ---
 grep -qE "^grafana_cloud_token:.*lookup\(['\"]env" "$OBS" \
-    || fail "grafana_cloud_token is a SECRET -> keep the lookup('env') bridge (until SOPS)"
+    || fail "grafana_cloud_token is a SECRET -> keep the lookup('env') fallback"
 grep -qE "^backup_aws_access_key_id:.*lookup\(['\"]env" "$BAK" \
-    || fail "backup_aws_access_key_id is a SECRET -> keep the lookup('env') bridge"
+    || fail "backup_aws_access_key_id is a SECRET -> keep the lookup('env') fallback"
 grep -qE "^backup_aws_secret_access_key:.*lookup\(['\"]env" "$BAK" \
-    || fail "backup_aws_secret_access_key is a SECRET -> keep the lookup('env') bridge"
+    || fail "backup_aws_secret_access_key is a SECRET -> keep the lookup('env') fallback"
 
 echo "ALL CONFIG/SECRET SPLIT CHECKS PASSED"


### PR DESCRIPTION
## What

Teach adopters the single-source-of-truth backup config the fleet already uses.

- **`group_vars/all.yml.example`** now shows the fleet-wide backup config — `backup_s3_bucket` + `backup_encryption` + `backup_age_recipients` live **once** here; `miuops backup-setup` reads the bucket from here and never asks you to re-type it. The per-server AWS key is a secret written into `fleet/secrets/<server>.vars.json` (SOPS), not set here.
- **`host_vars/server1.yml.example`** shows only the per-server pieces — `backup_enabled`, `backup_volumes`, optional `backup_aws_region`. The bucket is **not** duplicated here.
- Refreshed `tests/config_secret_split_test.sh` comments: the SOPS-in-fleet path is shipped (secrets decrypt to `--extra-vars` at converge; the env lookup is now only a fallback), correcting the stale "interim bridge" framing. Assertions unchanged.

The matching consolidation in the live fleet repo (moving the three shared keys host_vars→group_vars) was verified effect-neutral: each host's effective backup config via `ansible-inventory --host` is byte-identical before and after.

## Test

`tests/backup_config_template_test.sh` asserts the shared keys are in the group_vars example, the per-server keys in the host_vars example, and the bucket is **not** duplicated into host_vars (positive + negative; fails on drift). `shellcheck` + YAML parse clean; CI wired.

> Stacked on #100.
