### PR TITLE
chore(tests): drop internal planning-unit numbers from test comments + output

### DIFF
--- a/tests/backup_lifecycle_net.sh
+++ b/tests/backup_lifecycle_net.sh
@@ -2,7 +2,7 @@
 #
 # Verification-net foundation for the backup-credential lifecycle program
 # (miuops backup-setup / backup-rotate). It locks the ONE mechanism the safe
-# secret-write unit (U3) is built on, with a POSITIVE control AND a NEGATIVE
+# secret-write unit is built on, with a POSITIVE control AND a NEGATIVE
 # fixture so a green run is meaningful:
 #
 #   stdin->sops write is plaintext-safe. A per-server backup credential
@@ -11,7 +11,7 @@
 #     * round-trip back to the EXACT secret, and
 #     * leave NO plaintext copy of the secret anywhere on disk.
 #   This is the construction `miuops backup-{setup,rotate}` MUST use so an
-#   interrupted write can never strand a cleartext key in the fleet repo (F3),
+#   interrupted write can never strand a cleartext key in the fleet repo,
 #   replacing the legacy "write plaintext file, then sops -e -i" pattern.
 #
 # The NEGATIVE fixture (a deliberately-leaked plaintext file) proves the
@@ -79,7 +79,7 @@ leak_scan() { grep -rlF "$SECRET" "$1" 2>/dev/null; }
 if [ -n "$(leak_scan "$TMP")" ]; then
   fail "a plaintext copy of the secret exists on disk: $(leak_scan "$TMP")"
 fi
-echo "ok  - stdin->sops write is plaintext-safe and round-trips (F3 mechanism)"
+echo "ok  - stdin->sops write is plaintext-safe and round-trips"
 
 # ── NEGATIVE fixture: a deliberately-leaked plaintext file MUST be caught by
 #    the same scan -- proving the leak check has teeth (not theater). ─────────

--- a/tests/cli_test.sh
+++ b/tests/cli_test.sh
@@ -68,7 +68,7 @@ got="$( export CF_API_TOKEN=x; curl() { printf '{"result":[{"id":"ZONEID123"}],"
 # word -- the per-host invariant is covered by write_host_vars landing in host_vars. ---
 grep -qF 'write_host_vars "$handle"' "$ROOT/miuops" || fail "up does not call write_host_vars with the resolved handle"
 
-# --- U8: up --name decouples the fleet handle (inventory key / host_vars / tunnel /
+# --- up --name decouples the fleet handle (inventory key / host_vars / tunnel /
 # domain owner) from the SSH target, so a server need not be keyed by its IP. ---
 [ "$(up_resolve_handle myname 198.51.100.7)" = "myname" ]      || fail "up_resolve_handle must prefer --name"
 [ "$(up_resolve_handle '' 198.51.100.7)" = "198.51.100.7" ]    || fail "up_resolve_handle must default to the ssh host"
@@ -232,7 +232,7 @@ write_host_vars notunnel "" a.example b.example
 out="$(cd "$ROOT" && MIUOPS_TEST_SCRIPT_DIR="$TMP/tool" ./miuops remove-domain notunnel a.example 2>&1 || true)"
 echo "$out" | grep -qi 'no tunnel_id' || fail "remove-domain must require a non-empty tunnel_id"
 
-# --- U4: observability on by default + graceful skip + an `up` nudge ---
+# --- observability on by default + graceful skip + an `up` nudge ---
 # default-on: the obs role is enabled unless a host opts out (no more silently-off).
 grep -qE '^observability_enabled:[[:space:]]+true' "$ROOT/roles/observability/defaults/main.yml" \
     || fail "observability_enabled must default to true (obs on by default)"

--- a/tests/observability_role_lint_test.sh
+++ b/tests/observability_role_lint_test.sh
@@ -6,7 +6,7 @@
 # assert.
 #
 # This is a TRIPWIRE pinning that contract so a future edit can't (a) flip the default
-# back to off [the silently-unmonitored regression U4 exists to kill], (b) re-gate the
+# back to off [the silently-unmonitored regression this guards against], (b) re-gate the
 # role on the RAW observability_enabled so default-on hard-fails every unconfigured
 # adopter, or (c) drop the unconfigured-skip warning.
 set -euo pipefail

--- a/tests/sops_test.sh
+++ b/tests/sops_test.sh
@@ -159,28 +159,28 @@ echo "ok: env provisioning targets /opt/stacks/.env at mode 0600"
 grep -q 'cloudflared_credentials_src=' "$ROOT/miuops" \
     || fail "CLI must pass -e cloudflared_credentials_src=<decrypted temp> to the playbook"
 
-# ── 4b. U6 deployed-secret loop: run_apply decrypts fleet/secrets/{all,<host>}.vars.json
+# ── 4b. deployed-secret loop: run_apply decrypts fleet/secrets/{all,<host>}.vars.json
 # into Ansible extra-vars (-e @<decrypted-tmp>), so the Grafana token + AWS creds reach
 # the converge with ONLY the age key -- no per-apply env. Plus --tags passthrough (which
-# the U6 e2e uses to converge obs+backup in isolation). ───────────────────────────────
+# the deployed-secret e2e uses to converge obs+backup in isolation). ───────────────────────────────
 printf '[bare_metal]\nu6host ansible_host=192.0.2.9\n' > "$TMP/fleet/inventory.ini"
 printf '{ "grafana_cloud_token": "glc_U6TESTtoken" }\n' > "$TMP/fleet/secrets/all.vars.json"
 printf '{ "backup_aws_access_key_id": "AKIAU6TEST", "backup_aws_secret_access_key": "x" }\n' > "$TMP/fleet/secrets/u6host.vars.json"
 ( cd "$TMP" && sops -e -i fleet/secrets/all.vars.json && sops -e -i fleet/secrets/u6host.vars.json ) \
-    || fail "could not SOPS-encrypt the U6 deployed secrets"
+    || fail "could not SOPS-encrypt the deployed secrets"
 # Dry-run run_apply in a SUBSHELL (its EXIT/INT/TERM trap stays isolated from this
 # test's) and confirm the cmd carries one `-e @` per present vars.json. The cloudflared
 # cred uses `-e cloudflared_credentials_src=` (no `@`) + u6host has no tunnel, so the
-# `-e @` count is purely the U6 deployed secrets.
+# `-e @` count is purely the deployed secrets.
 # shellcheck disable=SC1090
 u6out="$( source "$ROOT/miuops" --source-only; DRY_RUN=true APPLY_TAGS="" run_apply u6host 2>&1 )" \
     || fail "run_apply dry-run failed with SOPS deployed secrets present"
 u6n="$(printf '%s' "$u6out" | grep -o -- '-e @' | wc -l | tr -d ' ' || true)"   # count OCCURRENCES (both -e @ sit on one line, so grep -c would undercount to 1); trailing || true so the disabled-loop case (0 matches -> grep exits 1 under pipefail) doesn't abort before the fail msg below
 [ "${u6n:-0}" -ge 2 ] \
     || fail "run_apply must pass each fleet/secrets/*.vars.json as -e @<tmp> (got ${u6n} '-e @', expected >=2): $u6out"
-echo "ok: U6 loop decrypts all.vars.json + <host>.vars.json into -e @ extra-vars"
+echo "ok: deployed-secret loop decrypts all.vars.json + <host>.vars.json into -e @ extra-vars"
 # --tags passthrough: `apply <host> --tags X` parses through to the converge cmd
-# (the U6 e2e uses this to converge obs+backup in isolation).
+# (the deployed-secret e2e uses this to converge obs+backup in isolation).
 # shellcheck disable=SC1090
 u6tags="$( source "$ROOT/miuops" --source-only; cmd_apply u6host --tags observability,backup --dry-run 2>&1 )"
 printf '%s' "$u6tags" | grep -q -- '--tags observability,backup' \


### PR DESCRIPTION
Several committed test files carried internal planning-unit labels (in comments, and one in an echoed pass line) that mean nothing to a reader of the public repo. Replace them with descriptive wording.

- `tests/backup_lifecycle_net.sh`, `tests/cli_test.sh`, `tests/sops_test.sh`, `tests/observability_role_lint_test.sh`

Comments + output strings only — **no assertion or logic changes**. All four tests still pass; shellcheck clean.

Standalone (off `main`), independent of the backup PR stack.