### PR TITLE
fix(cli): scope backup-rotate's converge to the backup role (fresh-VPS e2e)

### DIFF
--- a/docs/DISASTER_RECOVERY.md
+++ b/docs/DISASTER_RECOVERY.md
@@ -279,12 +279,17 @@ miuops backup-rotate --server <server>
 3. runs `miuops apply <server>` to push the new key to the host;
 4. and **only after that apply succeeds** deletes the old key.
 
-Because both credential locations are updated and pushed *before* the old key is
-deleted, neither the host volume backup nor WAL-G is ever stranded on a dead key.
+The host volume backup reloads `backup.env` on every (oneshot) run, so it uses the new
+key immediately. WAL-G/postgres is a long-running container that reads the key from
+`/opt/stacks/.env` **once at start** — so **if the server runs WAL-G, redeploy its stack
+after rotating** so the container reloads the new key (it is already in the fleet's
+`<server>.env` from step 2; the redeploy just restarts the container with it).
+`backup-rotate` prints this reminder when the server has a stack env.
+
 If the apply fails it stops **before** the delete, so the server keeps a working key
 — re-run `miuops apply <server>`, then the old key can be removed. It refuses unless
-the IAM user has exactly one key, so a rotation is never ambiguous. Commit the
-updated `fleet/secrets/<server>.*` afterward.
+the IAM user has exactly one key, so a rotation is never ambiguous. Commit the updated
+`fleet/secrets/<server>.*` afterward.
 
 ### Verify
 

--- a/miuops
+++ b/miuops
@@ -1036,16 +1036,22 @@ cmd_backup_rotate() {
         unset new_secret new_json
         die "backup-rotate: created key ${new_akid} but failed to write it. The old key ${old_key} is still active; resolve the new key manually."
     fi
-    # The same key also feeds WAL-G via the stack env -- sync it BEFORE apply (so apply
-    # pushes both) and BEFORE the delete, or WAL-G would be stranded on the deleted key.
-    # No-op when the server has no fleet/secrets/<host>.env carrying AWS creds.
+    # The same key also feeds WAL-G via the stack env -- sync it into the fleet's
+    # <host>.env BEFORE the delete so the fleet never points WAL-G at a deleted key. (The
+    # running stack picks up the new .env on its next `miuops up` / stack deploy, not via
+    # the backup-scoped apply below.) No-op when the host has no fleet/secrets/<host>.env.
     if ! sync_backup_env "$FLEET_ROOT" "fleet/secrets/${host}.env" "$new_akid" "$new_secret"; then
         unset new_secret new_json
         die "backup-rotate: wrote the new key to vars.json but failed to sync it into fleet/secrets/${host}.env. The old key ${old_key} is still active; resolve manually before deleting it."
     fi
     unset new_secret new_json
-    # 3. push the new key to the host
-    info "Applying ${host} to push the new key..."
+    # 3. push the new key to the host's backup role. Scope the converge to --tags backup:
+    # a rotation only needs backup.env re-rendered (the new creds are passed as extra-vars
+    # regardless of tags), and a full converge re-runs every role and, on a host whose
+    # other config is incomplete, can fail or block on an interactive prompt (e.g. the
+    # tunnel-id pause) -- which would hang an unattended rotation.
+    info "Applying ${host} (backup role) to push the new key..."
+    local APPLY_TAGS="backup"
     if ! run_apply "$host"; then
         die "backup-rotate: apply failed -- NOT deleting the old key ${old_key} (the host still has a working key, no gap). The new key is already written to the fleet; recover by re-running 'miuops apply ${host}' to push it, then deleting the OLD key ${old_key} in AWS yourself -- the user now has 2 keys, so backup-rotate will refuse until the old one is gone."
     fi
@@ -1053,6 +1059,13 @@ cmd_backup_rotate() {
     aws iam delete-access-key --user-name "$iam_user" --access-key-id "$old_key" \
         || die "backup-rotate: the new key is live, but deleting the old key ${old_key} failed -- delete it manually in AWS."
     info "Rotated ${iam_user}: new key ${new_akid} is live + written; old key ${old_key} deleted."
+    # The host volume-backup role reloads backup.env on every (oneshot) run, so it already
+    # uses the new key. A long-running stack container (e.g. WAL-G/postgres) reads the key
+    # from /opt/stacks/.env ONCE at start -- it keeps the old key until the stack is
+    # redeployed. The fleet's <host>.env is already in sync (above), so flag the redeploy.
+    if [[ -f "${FLEET_ROOT}/fleet/secrets/${host}.env" ]]; then
+        info "Note: ${host} has a stack env. If a long-running container reads the AWS key from it (e.g. WAL-G), redeploy that stack so it reloads the new key -- the rotated key is already in the fleet's ${host}.env."
+    fi
 }
 
 # ── Main ───────────────────────────────────────────────────────────

--- a/tests/backup_rotate_test.sh
+++ b/tests/backup_rotate_test.sh
@@ -26,11 +26,14 @@ run_rotate() {
   # NB: keep the brace-laden JSON OUT of ${3:-...} -- bash's brace matching inside the
   # parameter expansion mangles a provided $3 (appends stray braces), which silently
   # corrupted case 5's input.
-  local create_resp="${3:-}"
+  local create_resp="${3:-}" seed_env="${4:-0}"
   [ -n "$create_resp" ] || create_resp='{"AccessKey":{"AccessKeyId":"AKIANEW","SecretAccessKey":"new/sec+val"}}'
   fleet="$(mktemp -d)"; bin="$(mktemp -d)"; log="$fleet/log"; : > "$log"
-  mkdir -p "$fleet/fleet/group_vars"
+  mkdir -p "$fleet/fleet/group_vars" "$fleet/fleet/secrets"
   echo 'backup_s3_bucket: wwang-fleet-backup' > "$fleet/fleet/group_vars/all.yml"
+  # seed a stack env so the rotation's "redeploy WAL-G" reminder fires (the reminder
+  # only checks the file's presence, so an empty marker is enough here).
+  [ "$seed_env" = 1 ] && : > "$fleet/fleet/secrets/web1.env"
   case "$nkeys" in
     0) list='echo ""' ;;
     1) list='echo AKIAOLD1' ;;
@@ -53,9 +56,9 @@ REC
       require_sops()        { :; }   # the sops binary is a converge dep, not needed to unit-test the rotation flow (CI lint stage has no sops)
       write_backup_secret() { echo "WRITE $2" >> "'"$log"'"; return 0; }
       sync_backup_env()     { echo "ENVSYNC $2" >> "'"$log"'"; return 0; }
-      run_apply()           { echo "APPLY $*" >> "'"$log"'"; return '"$apply_rc"'; }
+      run_apply()           { echo "APPLY $* tags=${APPLY_TAGS:-none}" >> "'"$log"'"; return '"$apply_rc"'; }
       cmd_backup_rotate --server web1 --yes
-    ' >/dev/null 2>>"$log" ) || rc=$?
+    ' >>"$log" 2>&1 ) || rc=$?
   rm -rf "$bin"
   printf '%s %s' "$log" "$rc"
 }
@@ -75,7 +78,15 @@ env_at="$(pos_of "$log" ENVSYNC)"; del_at="$(pos_of "$log" DELETE)"
   && ok "WAL-G .env synced before the old key is deleted" \
   || bad "old key deleted before (or without) the .env sync"
 grep -q 'DELETE .*AKIAOLD1' "$log" && ok "deletes the OLD key (AKIAOLD1)" || bad "did not delete the old key"
+# The rotation's converge is scoped to the backup role (a full converge would re-run
+# every role and can hang on an interactive prompt on a not-fully-configured host).
+grep -q 'APPLY .*tags=backup' "$log" \
+  && ok "rotation's apply is scoped to the backup role (--tags backup)" \
+  || bad "rotation's apply is NOT scoped to backup (tags=$(grep -oE 'APPLY .*tags=[a-z]+' "$log" | grep -oE 'tags=[a-z]+'))"
 { [ "$rc" = 0 ]; } && ok "happy path exit 0" || bad "happy path exit $rc"
+# No stack env -> no WAL-G redeploy reminder.
+grep -qi 'redeploy that stack' "$log" && bad "WAL-G reminder shown when the host has no stack env" \
+  || ok "no WAL-G reminder when the host has no stack env"
 rm -rf "$(dirname "$log")"
 
 # 2. apply FAILS -> abort BEFORE delete (old key kept), non-zero exit
@@ -106,6 +117,14 @@ read -r log rc <<< "$(run_rotate 1 0 '{"AccessKey":{}}')"
 { [ "$rc" != 0 ] && grep -q 'CREATE' "$log" && ! grep -qE 'WRITE|ENVSYNC|APPLY|DELETE' "$log"; } \
   && ok "malformed create response: aborts before write/apply/delete (old key untouched)" \
   || bad "malformed create: did not abort cleanly (rc=$rc seq='$(seq_of "$log")')"
+rm -rf "$(dirname "$log")"
+
+# 6. host has a stack env (e.g. WAL-G) -> rotation reminds the operator to redeploy it
+#    so the long-running container reloads the new key (the host volume backup already has it).
+read -r log rc <<< "$(run_rotate 1 0 '' 1)"
+{ [ "$rc" = 0 ] && grep -qi 'redeploy that stack' "$log"; } \
+  && ok "stack env present: reminds to redeploy the WAL-G stack for the new key" \
+  || bad "no WAL-G redeploy reminder when the host has a stack env (rc=$rc)"
 rm -rf "$(dirname "$log")"
 
 echo "== ${pass} passed, ${fail} failed =="


### PR DESCRIPTION
## What

Drives the backup credential lifecycle **end-to-end against a fresh VPS + a throwaway S3 bucket** and asserts each property empirically. The harness (`tests/e2e/backup-lifecycle-acceptance.sh`, operator-local — `tests/e2e/` is gitignored like the existing fleet acceptance harness) proves, on real AWS + a real host:

1. `backup-setup` mints a prefix-scoped key written **SOPS-encrypted** (never printed, never plaintext on disk);
2. the key writes its **own** `<server>/` prefix but is **denied** another server's prefix (negative control) and **denied** Delete;
3. `apply --tags backup` **verify-LOADs** the key into the host `backup.env`;
4. a **real host backup uploads a tarball** under `<bucket>/<server>/vol/`;
5. `backup-rotate` mints a new key, pushes it, and deletes the old one **only after the apply succeeds** — old key gone, new key loaded, backups still work. (The abort-before-delete was also observed live: a failed apply left the old key intact.)

## The fix this surfaced

`backup-rotate`'s internal converge was a **full apply**, which on a host whose non-backup config is incomplete fails — or **blocks on an interactive tunnel-id prompt**, hanging an unattended rotation. A key rotation only needs `backup.env` re-rendered (the new creds pass as extra-vars regardless of tags), so it's now scoped to **`--tags backup`**. `tests/backup_rotate_test.sh` asserts the rotation's apply is backup-scoped (mutation-proven). The `.env`-sync comment is corrected: the sync keeps the fleet's `<host>.env` in sync; the running stack picks it up on its next deploy, not via this apply.

`shellcheck` + `bash -n` clean.

> Stacked on #101.
