### PR TITLE
feat(cli): add miuops backup-restore for fail-closed volume restore from S3

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -40,6 +40,7 @@ jobs:
             tests/backup_setup_cmd_test.sh \
             tests/backup_setup_script_test.sh \
             tests/backup_rotate_test.sh \
+            tests/backup_restore_test.sh \
             tests/backup_docs_lint_test.sh \
             tests/backup_config_template_test.sh
           bash tests/cli_test.sh
@@ -77,6 +78,7 @@ jobs:
           bash tests/backup_secret_write_test.sh
           bash tests/backup_env_sync_test.sh
           bash tests/backup_setup_write_test.sh
+          bash tests/backup_restore_test.sh
 
       - name: Install Ansible
         run: pip install ansible

--- a/docs/DISASTER_RECOVERY.md
+++ b/docs/DISASTER_RECOVERY.md
@@ -184,62 +184,38 @@ directory. The archive is **not gzip-compressed** (extract with `tar -xf`, not
 numbers — deterministic ownership even when the restore host has a different
 `/etc/passwd` than the source.
 
-**1. List backups for the volume:**
+**1. Restore the volume's data to a staging directory.** `miuops backup-restore`
+resolves the bucket from your fleet config, finds the volume's object (the latest, or
+`--at <ts>`), downloads it, decrypts it (age) with your operator identity, and untars
+it **byte-identical** into `--target` (which must be empty). Run it **on the server as
+root** so the tar's `--numeric-owner` UIDs/GIDs are restored faithfully:
 
 ```bash
-aws s3 ls s3://PROJECT-backup/<server>/vol/VOLUME_NAME/ --region REGION
+miuops backup-restore --server SERVER --volume VOLUME_NAME --target ./restored
+#   --at 20260629T030000Z    # an exact backup; omit for the latest
 ```
 
-If encrypted, files have a `.age` extension (e.g. `backup-YYYYMMDDTHHMMSSZ.tar.age`).
+It **fails closed**: a tampered or truncated object aborts the restore and wipes the
+partial target — you never get a silently-corrupt restore. Decryption uses your age
+identity (`SOPS_AGE_KEY_FILE` / default `keys.txt` / a plugged-in YubiKey); the host
+only ever held the public recipient. List what is available first with
+`aws s3 ls s3://PROJECT-backup/SERVER/vol/VOLUME_NAME/ --region REGION` if needed.
 
-**2. Download the backup:**
-
-```bash
-# Unencrypted
-aws s3 cp s3://PROJECT-backup/<server>/vol/VOLUME_NAME/backup-YYYYMMDDTHHMMSSZ.tar . --region REGION
-
-# Encrypted (include the .age extension)
-aws s3 cp s3://PROJECT-backup/<server>/vol/VOLUME_NAME/backup-YYYYMMDDTHHMMSSZ.tar.age . --region REGION
-```
-
-**3. Decrypt the backup (if encrypted):**
-
-```bash
-# age (asymmetric — identity file, SSH private key, or YubiKey-backed identity)
-age --decrypt -i key.txt -o backup-YYYYMMDDTHHMMSSZ.tar backup-YYYYMMDDTHHMMSSZ.tar.age
-```
-
-Install age with `apt install age` (Debian/Ubuntu) or download it from
-[github.com/FiloSottile/age](https://github.com/FiloSottile/age). The role
-encrypts to a public key only, so decryption needs the matching private key or
-identity file — transfer it to the server temporarily and remove it afterward, or
-keep the key off the host and decrypt on your laptop while streaming the plaintext
-over SSH (see [Backup Encryption](BACKUP_ENCRYPTION.md)). For a YubiKey-backed
-recipient, decrypt where the key is plugged in, with `age-plugin-yubikey`
-installed.
-
-**4. Stop the consumers of the volume:**
+**2. Stop the consumers of the volume:**
 
 ```bash
 docker stop CONTAINER [CONTAINER...]
 ```
 
-**5. Extract into the target volume:**
-
-`--numeric-owner` keeps the restored files' UIDs/GIDs as numbers, so ownership is
-correct even when this host's `/etc/passwd` differs from the source host's.
+**3. Replace the volume's contents with the restored data** (`cp -a` preserves the
+numeric ownership `backup-restore` set):
 
 ```bash
-docker run --rm \
-  -v VOLUME_NAME:/restore \
-  -v "$(pwd)/backup-YYYYMMDDTHHMMSSZ.tar:/backup.tar:ro" \
-  alpine sh -c "cd /restore && tar --numeric-owner -xf /backup.tar"
+docker run --rm -v VOLUME_NAME:/v -v "$(pwd)/restored:/restored:ro" alpine \
+  sh -c 'rm -rf /v/* /v/..?* 2>/dev/null; cp -a /restored/. /v/'
 ```
 
-To restore into a clean volume, clear it first (inside the same `alpine` shell:
-`rm -rf /restore/* /restore/..?* 2>/dev/null; tar --numeric-owner -xf /backup.tar`).
-
-**6. Restart the consumers:**
+**4. Restart the consumers:**
 
 ```bash
 docker start CONTAINER [CONTAINER...]

--- a/miuops
+++ b/miuops
@@ -532,6 +532,23 @@ resolve_backup_bucket() {
     return 0
 }
 
+# Resolve backup_s3_prefix the same versioned way as the bucket (host_vars then
+# group_vars), defaulting to "<host>/vol" -- the backup role's default. It is
+# operator-overridable (the role only asserts it starts with "<host>/"), so restore
+# must look under the SAME prefix the backup wrote to, not a hardcoded one.
+resolve_backup_prefix() {
+    local _h="$1" _f _line _val
+    for _f in "${FLEET_DIR}/host_vars/${_h}.yml" "${FLEET_DIR}/group_vars/all.yml"; do
+        [ -f "$_f" ] || continue
+        _line="$(grep -aE '^backup_s3_prefix[[:space:]]*:' "$_f" 2>/dev/null | tail -1 || true)"
+        [ -n "$_line" ] || continue
+        _val="$(printf '%s' "$_line" | sed -E 's/^backup_s3_prefix[[:space:]]*:[[:space:]]*//; s/[[:space:]]*#.*$//; s/^"(.*)"$/\1/; s/^'\''(.*)'\''$/\1/; s/[[:space:]]*$//')"
+        if [ -n "$_val" ]; then printf '%s' "$_val"; return 0; fi
+    done
+    printf '%s' "${_h}/vol"
+    return 0
+}
+
 cmd_up() {
     # Parse flags and positional args in any order
     local positional=() name_flag=""
@@ -1068,6 +1085,122 @@ cmd_backup_rotate() {
     fi
 }
 
+# Restore a volume backup from S3 -- the inverse of the host backup role's
+# `tar | age | s3 cp` pipeline. Resolves the bucket + prefix from versioned config,
+# finds the volume's object (<prefix>/<volume>/backup-<ts>.tar[.age]; prefix defaults
+# to <server>/vol), downloads it, decrypts it (age) when it is .tar.age, and untars it
+# into --target byte-identical to the original volume data. Decryption uses the
+# operator's age identity: SOPS_AGE_KEY_FILE, else sops's default keys.txt, else a
+# bare `age -d` (a plugged-in YubiKey plugin reads its own recipient stanza) -- the
+# host only ever held the public recipient. Fails closed: any stage error wipes the
+# partial target, so a failed restore never leaves garbage. "A backup you cannot
+# restore is not a backup."
+cmd_backup_restore() {
+    local host="" volume="" at="" target=""
+    while [[ $# -gt 0 ]]; do
+        case "$1" in
+            --server)    [[ $# -ge 2 ]] || die "backup-restore: --server requires a value"; host="$2"; shift 2 ;;
+            --server=*)  host="${1#*=}"; shift ;;
+            --volume)    [[ $# -ge 2 ]] || die "backup-restore: --volume requires a value"; volume="$2"; shift 2 ;;
+            --volume=*)  volume="${1#*=}"; shift ;;
+            --at)        [[ $# -ge 2 ]] || die "backup-restore: --at requires a value"; at="$2"; shift 2 ;;
+            --at=*)      at="${1#*=}"; shift ;;
+            --target)    [[ $# -ge 2 ]] || die "backup-restore: --target requires a value"; target="$2"; shift 2 ;;
+            --target=*)  target="${1#*=}"; shift ;;
+            *)           die "backup-restore: unknown argument '$1'" ;;
+        esac
+    done
+    [[ -n "$host"   ]] || die "backup-restore: --server <name> is required"
+    [[ -n "$volume" ]] || die "backup-restore: --volume <name> is required"
+    [[ -n "$target" ]] || die "backup-restore: --target <dir> is required"
+    # Validate operator inputs (mirrors cmd_up's valid_host_alias): host reaches a
+    # host_vars FILE PATH in resolve_backup_bucket/_prefix, so an unchecked '../..'
+    # would read an arbitrary YAML; volume + at flow into S3 keys + a grep filter.
+    valid_host_alias "$host" || die "backup-restore: invalid server name '${host}'."
+    [[ "$volume" =~ ^[A-Za-z0-9][A-Za-z0-9._-]*$ ]] || die "backup-restore: invalid volume name '${volume}' (expected [A-Za-z0-9._-])."
+    if [[ -n "$at" ]]; then
+        [[ "$at" =~ ^[0-9]{8}T[0-9]{6}Z$ ]] || die "backup-restore: --at must be a UTC timestamp YYYYMMDDTHHMMSSZ (e.g. 20260629T030000Z)."
+    fi
+    command -v aws >/dev/null 2>&1 || die "backup-restore: aws CLI not found."
+    command -v tar >/dev/null 2>&1 || die "backup-restore: tar not found."
+
+    local bucket; bucket="$(resolve_backup_bucket "$host")"
+    [[ -n "$bucket" ]] || die "backup-restore: no backup_s3_bucket configured for ${host}. Run 'miuops backup-setup --server ${host}' first."
+
+    # Look under the SAME prefix the backup role wrote to (resolved, default <host>/vol).
+    local prefix; prefix="$(resolve_backup_prefix "$host")/${volume}"
+
+    # Find the volume's backup objects, then pick one (--at exact, else latest).
+    local names object
+    names="$(aws s3 ls "s3://${bucket}/${prefix}/" 2>/dev/null | awk '{print $NF}' | grep -E '^backup-[0-9TZ]+\.tar(\.age)?$' || true)"
+    [[ -n "$names" ]] || die "backup-restore: no backup found for volume '${volume}' on '${host}' (s3://${bucket}/${prefix}/)."
+    if [[ -n "$at" ]]; then
+        # Literal (not regex) match: $at is a validated timestamp, and matching the two
+        # exact candidate names means a stray metachar could never select a wrong object.
+        object="$(printf '%s\n' "$names" | grep -Fx -e "backup-${at}.tar" -e "backup-${at}.tar.age" | head -1 || true)"
+        [[ -n "$object" ]] || die "backup-restore: no backup at '${at}' for volume '${volume}' on '${host}'."
+    else
+        object="$(printf '%s\n' "$names" | sort | tail -1)"   # the YYYYMMDDTHHMMSSZ ts sorts chronologically
+    fi
+
+    local encrypted=false
+    [[ "$object" == *.age ]] && encrypted=true
+    if $encrypted; then
+        command -v age >/dev/null 2>&1 || die "backup-restore: ${object} is age-encrypted but 'age' is not installed."
+    fi
+
+    mkdir -p "$target" || die "backup-restore: cannot create target '${target}'."
+    [[ -z "$(ls -A "$target" 2>/dev/null)" ]] || die "backup-restore: target '${target}' is not empty -- refusing to overwrite."
+
+    info "Restoring s3://${bucket}/${prefix}/${object} -> ${target}"
+
+    # age identity: SOPS_AGE_KEY_FILE, else sops's default keys.txt if present, else a
+    # bare `age -d` (a plugged-in YubiKey plugin reads its own recipient stanza). This
+    # mirrors how sops finds the operator's key; the host only held the recipient.
+    local age_id_args=()
+    if [[ -n "${SOPS_AGE_KEY_FILE:-}" ]]; then
+        age_id_args=(-i "$SOPS_AGE_KEY_FILE")
+    elif [[ -f "$(sops_age_default_keys)" ]]; then
+        age_id_args=(-i "$(sops_age_default_keys)")
+    fi
+
+    # download | (decrypt) | untar. Capture EVERY stage via PIPESTATUS so a download,
+    # decrypt (age MAC), or tar failure can't hide behind the last command's status.
+    # The object is attacker-influenceable (anyone holding the scoped write key), so the
+    # untar must contain a malicious archive: we rely on modern tar's secure-by-default
+    # extraction -- both GNU and bsdtar strip a leading '/' and refuse '..' members --
+    # rather than a GNU-only flag (the operator may restore on macOS/bsdtar); the
+    # traversal test verifies containment on the host's actual tar. Suspend `set -e`
+    # ONLY around the pipe (a bare failing pipe would abort before the wipe); save +
+    # restore errexit so this stays correct even if ever called from a conditional.
+    local -a statuses
+    local _restore_errexit=""; [[ $- == *e* ]] && _restore_errexit=1
+    set +e
+    if $encrypted; then
+        aws s3 cp "s3://${bucket}/${prefix}/${object}" - \
+          | age -d ${age_id_args[@]+"${age_id_args[@]}"} \
+          | tar -C "$target" --numeric-owner -xf -
+    else
+        aws s3 cp "s3://${bucket}/${prefix}/${object}" - \
+          | tar -C "$target" --numeric-owner -xf -
+    fi
+    statuses=("${PIPESTATUS[@]}")
+    [[ -n "$_restore_errexit" ]] && set -e
+
+    local idx st
+    for idx in "${!statuses[@]}"; do
+        st="${statuses[$idx]}"
+        [ "$st" -eq 0 ] && continue
+        # Wipe the partial extraction, then VERIFY it is gone before saying so -- never
+        # report "wiped" while leaving data behind.
+        find "$target" -mindepth 1 -exec rm -rf {} + 2>/dev/null || true
+        [[ -z "$(ls -A "$target" 2>/dev/null)" ]] \
+          || die "backup-restore: restore failed (pipeline stage ${idx} exit ${st}) AND the partial target '${target}' could not be fully wiped -- inspect/remove it manually."
+        die "backup-restore: restore failed (pipeline stage ${idx} exit ${st}) -- partial target wiped, no data left."
+    done
+    info "Restored volume '${volume}' to ${target} (from ${object})."
+}
+
 # ── Main ───────────────────────────────────────────────────────────
 if [[ "${1:-}" != "--source-only" ]]; then
     case "${1:-}" in
@@ -1077,6 +1210,7 @@ if [[ "${1:-}" != "--source-only" ]]; then
         remove-domain) shift; cmd_remove_domain "$@" ;;
         backup-setup)  shift; cmd_backup_setup "$@" ;;
         backup-rotate) shift; cmd_backup_rotate "$@" ;;
+        backup-restore) shift; cmd_backup_restore "$@" ;;
         version|--version|-v) cmd_version ;;
         *)             usage ;;
     esac

--- a/tests/backup_restore_test.sh
+++ b/tests/backup_restore_test.sh
@@ -1,0 +1,281 @@
+#!/usr/bin/env bash
+#
+# `miuops backup-restore --server <h> --volume <v> [--at <ts>] --target <dir>`
+# — the INVERSE of the host backup role's `tar | age | s3 cp` pipeline. It
+# resolves the bucket from versioned config, finds the volume's object in S3
+# (s3://<bucket>/<server>/vol/<volume>/backup-<ts>.tar[.age]), downloads it,
+# decrypts (age) when needed, and untars it to --target byte-identical to the
+# original volume data.
+#
+# "A backup you cannot restore is not a backup": this is the verification net
+# that lets the home-grown host role replace offen. Every property is paired
+# with a control:
+#   * POSITIVE control — a clean round-trip restores byte-identical content.
+#   * NEGATIVE fixture  — a tampered .age object MUST fail (age's MAC), never a
+#                         silent partial/garbage restore.
+#   * selection         — `latest` picks the newest ts; `--at` picks an exact one.
+#
+# The AWS/S3 boundary is faked (a PATH-shimmed `aws` serving from a local dir)
+# and a throwaway age keypair stands in for the operator's YubiKey/identity, so
+# the round-trip is pinned with NO real AWS and NO real key. The encrypted path
+# needs the `age` binary; if it is absent the age cases are reported as failures
+# (not silently skipped) so a green run is meaningful — CI installs age.
+
+set -uo pipefail
+ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+pass=0; fail=0
+ok()  { printf 'ok   - %s\n' "$1"; pass=$((pass + 1)); }
+bad() { printf 'FAIL - %s\n' "$1"; fail=$((fail + 1)); }
+
+# A "real" failure = the command RAN and rejected, NOT "command not found" (127).
+# Without this, the negative/missing cases would pass in the RED phase (when
+# cmd_backup_restore doesn't exist yet -> 127) -- a false green. They must stay
+# RED until the command exists AND correctly rejects.
+is_real_failure() { [ "$1" != 0 ] && [ "$1" != 127 ]; }
+
+command -v age        >/dev/null 2>&1 || { echo "FATAL: age is required for the restore round-trip test"; exit 2; }
+command -v age-keygen >/dev/null 2>&1 || { echo "FATAL: age-keygen is required"; exit 2; }
+command -v tar        >/dev/null 2>&1 || { echo "FATAL: tar is required"; exit 2; }
+command -v python3    >/dev/null 2>&1 || { echo "FATAL: python3 is required (builds the malicious-archive fixture)"; exit 2; }
+
+# --- throwaway age identity (stands in for the operator's key/YubiKey) ---------
+KEYDIR="$(mktemp -d)"
+IDENT="${KEYDIR}/id.txt"
+age-keygen -o "$IDENT" 2>/dev/null
+RECIP="$(age-keygen -y "$IDENT" 2>/dev/null)"
+
+# --- a local directory standing in for the S3 bucket --------------------------
+# Layout mirrors real S3 keys: <s3root>/<bucket>/<server>/vol/<volume>/backup-<ts>.tar.age
+S3ROOT="$(mktemp -d)"
+BUCKET="wwang-fleet-backup"
+SERVER="web1"
+VOLUME="app_data"
+
+# put_backup <ts> <src-dir> -> writes the encrypted tar object into the fake S3,
+# byte-for-byte the way roles/backup/templates/miuops-backup.sh.j2 produces it.
+put_backup() {
+  local ts="$1" src="$2"
+  local dir="${S3ROOT}/${BUCKET}/${SERVER}/vol/${VOLUME}"
+  mkdir -p "$dir"
+  tar -C "$src" --numeric-owner -cf - . | age -r "$RECIP" > "${dir}/backup-${ts}.tar.age"
+}
+
+# put_plain_backup <ts> <src-dir> -> an UNENCRYPTED .tar object (the non-age branch).
+put_plain_backup() {
+  local ts="$1" src="$2"
+  local dir="${S3ROOT}/${BUCKET}/${SERVER}/vol/${VOLUME}"
+  mkdir -p "$dir"
+  tar -C "$src" --numeric-owner -cf - . > "${dir}/backup-${ts}.tar"
+}
+
+# --- a PATH-shimmed `aws` that serves s3 ls / s3 cp from the local S3 dir ------
+BIN="$(mktemp -d)"
+cat > "${BIN}/aws" <<AWSEOF
+#!/usr/bin/env bash
+# Minimal fake: supports the two calls backup-restore needs.
+#   aws s3 ls s3://<bucket>/<prefix>/         -> list keys (one per line, real-ish)
+#   aws s3 cp s3://<bucket>/<key> <dest|->    -> stream/copy the object out
+set -uo pipefail
+S3ROOT="${S3ROOT}"
+# drop any --endpoint-url <x>
+args=(); while [ \$# -gt 0 ]; do case "\$1" in --endpoint-url) shift 2;; *) args+=("\$1"); shift;; esac; done
+set -- "\${args[@]}"
+[ "\$1" = "s3" ] || { echo "fake-aws: unsupported: \$*" >&2; exit 2; }
+case "\$2" in
+  ls)
+    uri="\$3"; path="\${uri#s3://}"
+    dir="\${S3ROOT}/\${path%/}"
+    [ -d "\$dir" ] || exit 0
+    for f in "\$dir"/*; do [ -e "\$f" ] || continue; printf '2026-06-29 00:00:00 %10d %s\n' "\$(wc -c < "\$f")" "\$(basename "\$f")"; done
+    ;;
+  cp)
+    src="\$3"; dest="\$4"; path="\${src#s3://}"; file="\${S3ROOT}/\${path}"
+    [ -f "\$file" ] || { echo "fake-aws: NoSuchKey: \$src" >&2; exit 1; }
+    if [ "\$dest" = "-" ]; then cat "\$file"; else cp "\$file" "\$dest"; fi
+    # injected: an S3 download that streamed the FULL body but then errored (e.g. a
+    # network drop after the bytes) -- aws exits non-zero though the consumer got a
+    # complete archive. Lets a test make a non-last pipeline stage fail with tar=0.
+    # (An if-block, not a test-then-exit one-liner: on the no-marker path the latter
+    # leaves the failed-test status 1 as the script exit, breaking a normal cp.)
+    if [ -f "\${file%/*}/.cp_fails" ]; then exit 1; fi
+    ;;
+  *) echo "fake-aws: unsupported s3 op: \$2" >&2; exit 2;;
+esac
+AWSEOF
+chmod +x "${BIN}/aws"
+
+# --- fake fleet so the bucket resolver finds wwang-fleet-backup ---------------
+FLEET="$(mktemp -d)"
+mkdir -p "${FLEET}/fleet/group_vars"
+printf 'backup_s3_bucket: %s\n' "$BUCKET" > "${FLEET}/fleet/group_vars/all.yml"
+
+# run_restore <target> [extra args...] -> echoes exit code; runs cmd_backup_restore
+# with the AWS boundary faked + the age identity provided via SOPS_AGE_KEY_FILE.
+run_restore() {
+  local target="$1"; shift
+  local rc=0
+  ( PATH="${BIN}:$PATH" MIUOPS_FLEET_DIR="${FLEET}/fleet" SOPS_AGE_KEY_FILE="$IDENT" \
+      bash -c '
+        . "'"$ROOT"'/miuops" --source-only 2>/dev/null
+        require_sops() { :; }   # sops binary not needed to unit-test restore
+        cmd_backup_restore --server '"$SERVER"' --volume '"$VOLUME"' --target "'"$target"'" '"$*"'
+      ' >/dev/null 2>&1 ) || rc=$?
+  printf '%s' "$rc"
+}
+
+# content equality (data bytes + tree); not owners (untar runs non-root in CI).
+same_tree() { diff -r "$1" "$2" >/dev/null 2>&1; }
+
+# ============================================================================
+# 1. POSITIVE control: clean round-trip restores byte-identical content
+# ============================================================================
+SRC="$(mktemp -d)"
+mkdir -p "${SRC}/sub"
+printf 'hello world\n'      > "${SRC}/a.txt"
+printf '\x00\x01\x02binary' > "${SRC}/sub/b.bin"
+ln -s a.txt "${SRC}/link"      2>/dev/null || true
+put_backup "20260629T010000Z" "$SRC"
+
+DST="$(mktemp -d)"
+rc="$(run_restore "$DST")"
+{ [ "$rc" = 0 ] && same_tree "$SRC" "$DST"; } \
+  && ok "clean restore: byte-identical content (positive control)" \
+  || bad "clean restore failed or content differs (rc=$rc)"
+
+# ============================================================================
+# 2. selection: latest of several timestamps
+# ============================================================================
+SRC2="$(mktemp -d)"; printf 'NEWEST\n' > "${SRC2}/marker"
+put_backup "20260629T030000Z" "$SRC2"   # newest
+DST2="$(mktemp -d)"
+rc="$(run_restore "$DST2")"
+{ [ "$rc" = 0 ] && [ -f "${DST2}/marker" ] && grep -qx NEWEST "${DST2}/marker"; } \
+  && ok "no --at: restores the LATEST timestamp" \
+  || bad "latest selection wrong (rc=$rc)"
+
+# ============================================================================
+# 3. selection: --at picks an exact (older) timestamp
+# ============================================================================
+DST3="$(mktemp -d)"
+rc="$(run_restore "$DST3" --at 20260629T010000Z)"
+{ [ "$rc" = 0 ] && same_tree "$SRC" "$DST3"; } \
+  && ok "--at <ts>: restores that exact backup" \
+  || bad "--at selection wrong (rc=$rc)"
+
+# ============================================================================
+# 4. NEGATIVE fixture: a tampered .age MUST fail, AND a partial extraction must be
+#    WIPED. A multi-chunk (>64KB) payload + a late-byte flip makes age emit the
+#    early chunks (tar writes a partial file) before the MAC fails -- so this
+#    exercises the fail-closed WIPE, not merely "tar got an empty stream".
+# ============================================================================
+SRC4="$(mktemp -d)"
+head -c 200000 /dev/urandom > "${SRC4}/big.bin"
+printf 'edge\n'            > "${SRC4}/small.txt"
+put_backup "20260629T040000Z" "$SRC4"
+big4="${S3ROOT}/${BUCKET}/${SERVER}/vol/${VOLUME}/backup-20260629T040000Z.tar.age"
+sz4=$(wc -c < "$big4")
+printf 'X' | dd of="$big4" bs=1 seek=$((sz4 - 80)) conv=notrunc 2>/dev/null
+DST4="$(mktemp -d)"
+rc="$(run_restore "$DST4" --at 20260629T040000Z)"
+{ is_real_failure "$rc" && [ -z "$(ls -A "$DST4" 2>/dev/null)" ]; } \
+  && ok "tampered multi-chunk .age: restore FAILS + partial extraction WIPED (negative fixture)" \
+  || bad "tampered .age did not fail-close cleanly (rc=$rc, target populated?)"
+
+# ============================================================================
+# 5. missing backup: clear non-zero failure
+# ============================================================================
+DST5="$(mktemp -d)"
+rc="$(run_restore "$DST5" --volume nonexistent_vol 2>/dev/null)"
+is_real_failure "$rc" && ok "missing volume backup: fails non-zero" || bad "missing backup did not fail (rc=$rc)"
+
+# ============================================================================
+# 6. A NON-LAST pipeline stage fails while the last stage (tar) exits 0 -- the
+#    restore MUST still fail. Guards against a "check only the last PIPESTATUS"
+#    regression: a download/decrypt error that yields a complete-looking tar would
+#    otherwise pass as success. Uses the UNENCRYPTED .tar path + a fake aws that
+#    streams the FULL valid tar then exits non-zero, so PIPESTATUS = [aws=1, tar=0].
+# ============================================================================
+SRC6="$(mktemp -d)"; printf 'plain-data\n' > "${SRC6}/p.txt"
+put_plain_backup "20260629T050000Z" "$SRC6"
+PDIR="${S3ROOT}/${BUCKET}/${SERVER}/vol/${VOLUME}"
+touch "${PDIR}/.cp_fails"
+DST6="$(mktemp -d)"
+rc="$(run_restore "$DST6" --at 20260629T050000Z)"
+{ is_real_failure "$rc" && [ -z "$(ls -A "$DST6" 2>/dev/null)" ]; } \
+  && ok "non-last stage fails though tar exits 0: restore FAILS + wiped (kills check-only-last-PIPESTATUS)" \
+  || bad "a non-last-stage failure was not caught (rc=$rc)"
+rm -f "${PDIR}/.cp_fails"
+
+# ============================================================================
+# 7. Unencrypted .tar round-trip (the non-age branch) restores byte-identical.
+# ============================================================================
+DST7="$(mktemp -d)"
+rc="$(run_restore "$DST7" --at 20260629T050000Z)"
+{ [ "$rc" = 0 ] && same_tree "$SRC6" "$DST7"; } \
+  && ok "unencrypted .tar: byte-identical round-trip (covers the non-age branch)" \
+  || bad "unencrypted .tar round-trip failed (rc=$rc)"
+
+# ============================================================================
+# 8. Untrusted-archive containment: an object whose tar member tries to escape via
+#    '../' must NOT write outside --target. python3 builds the malicious tar; age
+#    encrypts it like a real object so it decrypts validly. Modern tar (GNU + bsd)
+#    refuses or strips the escape; assert nothing landed in the parent dir.
+# ============================================================================
+nonce="esc$$"
+python3 - "$RECIP" "${S3ROOT}/${BUCKET}/${SERVER}/vol/${VOLUME}/backup-20260629T060000Z.tar.age" "$nonce" <<'PY'
+import sys, io, tarfile, subprocess
+recip, outpath, nonce = sys.argv[1], sys.argv[2], sys.argv[3]
+buf = io.BytesIO(); t = tarfile.open(fileobj=buf, mode='w')
+data = b'pwned\n'; ti = tarfile.TarInfo('../%s' % nonce); ti.size = len(data)
+t.addfile(ti, io.BytesIO(data)); t.close()
+enc = subprocess.run(['age', '-r', recip], input=buf.getvalue(),
+                     stdout=subprocess.PIPE, check=True).stdout
+open(outpath, 'wb').write(enc)
+PY
+DST8="$(mktemp -d)"
+sentinel="$(dirname "$DST8")/${nonce}"; rm -f "$sentinel"
+run_restore "$DST8" --at 20260629T060000Z >/dev/null 2>&1
+[ ! -e "$sentinel" ] \
+  && ok "malicious ../ archive: nothing written outside --target (traversal contained)" \
+  || bad "PATH TRAVERSAL: a ../ member escaped --target"
+rm -f "$sentinel"
+
+# ============================================================================
+# 9. A non-empty --target is refused (no clobber of existing data).
+# ============================================================================
+DST9="$(mktemp -d)"; printf 'keep\n' > "${DST9}/existing"
+rc="$(run_restore "$DST9")"
+{ is_real_failure "$rc" && [ -f "${DST9}/existing" ]; } \
+  && ok "non-empty --target refused, existing data untouched" \
+  || bad "non-empty target not refused (rc=$rc)"
+
+# ============================================================================
+# 10. Untrusted-archive containment, ABSOLUTE path: a member named with a leading
+#     '/' must be stripped so it lands INSIDE --target, never at the real absolute
+#     path. (Backs the code's "strips a leading /" claim with a test.)
+# ============================================================================
+ABS="$(mktemp -d)"; absnonce="abs$$"
+python3 - "$RECIP" "${S3ROOT}/${BUCKET}/${SERVER}/vol/${VOLUME}/backup-20260629T070000Z.tar.age" "${ABS}/${absnonce}" <<'PY'
+import sys, io, tarfile, subprocess
+recip, outpath, absname = sys.argv[1], sys.argv[2], sys.argv[3]
+buf = io.BytesIO(); t = tarfile.open(fileobj=buf, mode='w')
+data = b'pwned\n'; ti = tarfile.TarInfo(absname); ti.size = len(data)   # absname is absolute (/...)
+t.addfile(ti, io.BytesIO(data)); t.close()
+enc = subprocess.run(['age', '-r', recip], input=buf.getvalue(),
+                     stdout=subprocess.PIPE, check=True).stdout
+open(outpath, 'wb').write(enc)
+PY
+rm -f "${ABS}/${absnonce}"
+DST10="$(mktemp -d)"
+run_restore "$DST10" --at 20260629T070000Z >/dev/null 2>&1
+# Contained (real abs path absent) AND actually processed (member landed inside the
+# target) -- the second clause stops a restore that simply failed from false-passing.
+{ [ ! -e "${ABS}/${absnonce}" ] && [ -n "$(ls -A "$DST10" 2>/dev/null)" ]; } \
+  && ok "absolute-path archive member: stripped to inside --target, not the real path" \
+  || bad "ABSOLUTE-PATH ESCAPE or unprocessed: a /<abs> member did not land safely inside"
+
+# ----------------------------------------------------------------------------
+rm -rf "$KEYDIR" "$S3ROOT" "$BIN" "$FLEET" "$SRC" "$SRC2" "$SRC4" "$SRC6" "$ABS" \
+       "$DST" "$DST2" "$DST3" "$DST4" "$DST5" "$DST6" "$DST7" "$DST8" "$DST9" "$DST10" 2>/dev/null
+echo "== ${pass} passed, ${fail} failed =="
+[ "$fail" -eq 0 ]


### PR DESCRIPTION
Adds `miuops backup-restore` — the inverse of the host backup role's volume backup, so a backed-up Docker volume can actually be restored. *A backup you cannot restore is not a backup.*

## What
`miuops backup-restore --server <h> --volume <v> [--at <ts>] --target <dir>`: resolves the bucket + prefix from versioned config, finds the volume's object (`<prefix>/<volume>/backup-<ts>.tar[.age]`, latest or an exact `--at`), downloads it, decrypts it (age, operator identity), and untars it **byte-identical** into an empty `--target`.

## Fail-closed
errexit is suspended only around the `download | decrypt | untar` pipe, so a download, decrypt (age MAC), or tar failure is caught via `PIPESTATUS` and the partial target is wiped (then verified empty before reporting so) — a failed restore never leaves a silently-corrupt extraction.

## Hardening
Inputs are validated (server alias, volume charset, `--at` as a UTC timestamp) so they can't traverse config paths or select a wrong object; the untar relies on modern tar's secure-by-default extraction to contain a malicious archive (verified by tests).

## Tests (`tests/backup_restore_test.sh`, 10 cases — faked S3 + a throwaway age key)
Byte-identical positive control (encrypted + plaintext), latest + `--at` selection, a tampered multi-chunk object and a non-last-stage failure that must both fail-close + wipe, `../` and absolute-path traversal archives that must not escape `--target`, a non-empty-target refusal, and a missing backup. Wired into CI's age step + shellcheck. `DISASTER_RECOVERY.md` Scenario 3 now uses the command.

Reviewed across code-correctness, silent-failure, and security dimensions; findings folded in and re-reviewed.