### PR TITLE
feat(cli): add miuops backup-verify to integrity-check a backup without restoring

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -41,6 +41,7 @@ jobs:
             tests/backup_setup_script_test.sh \
             tests/backup_rotate_test.sh \
             tests/backup_restore_test.sh \
+            tests/backup_verify_test.sh \
             tests/backup_docs_lint_test.sh \
             tests/backup_config_template_test.sh
           bash tests/cli_test.sh
@@ -79,6 +80,7 @@ jobs:
           bash tests/backup_env_sync_test.sh
           bash tests/backup_setup_write_test.sh
           bash tests/backup_restore_test.sh
+          bash tests/backup_verify_test.sh
 
       - name: Install Ansible
         run: pip install ansible

--- a/docs/DISASTER_RECOVERY.md
+++ b/docs/DISASTER_RECOVERY.md
@@ -184,6 +184,17 @@ directory. The archive is **not gzip-compressed** (extract with `tar -xf`, not
 numbers — deterministic ownership even when the restore host has a different
 `/etc/passwd` than the source.
 
+> **Check a backup is intact without restoring it:**
+> `miuops backup-verify --server SERVER --volume VOLUME_NAME [--at <ts>]` streams the
+> object through an integrity check and exits non-zero on corruption. Run it
+> periodically — `aws s3 cp` already checks the upload, so this confirms a backup is
+> still good (and decryptable with the current key) months later. **Strength depends on
+> the format:** an **age** object is fully byte-level verified (its MAC authenticates
+> every byte); a **plaintext `.tar`** is only structurally verified (`tar -t` — the
+> per-header checksum, catching header damage but **not** a flipped data byte or
+> trailing-data truncation that leaves the headers parseable, as uncompressed tar has no
+> body checksum). For byte-level integrity, set `backup_encryption: age`. *Backups that haven't been verified aren't backups.*
+
 **1. Restore the volume's data to a staging directory.** `miuops backup-restore`
 resolves the bucket from your fleet config, finds the volume's object (the latest, or
 `--at <ts>`), downloads it, decrypts it (age) with your operator identity, and untars

--- a/miuops
+++ b/miuops
@@ -1201,6 +1201,100 @@ cmd_backup_restore() {
     info "Restored volume '${volume}' to ${target} (from ${object})."
 }
 
+# Verify a backup in S3 is INTACT without restoring it to disk. Resolves the bucket +
+# prefix, finds the object (latest or --at), and streams it through an integrity check
+# to /dev/null. The STRENGTH depends on the format: an age object is decrypted (the
+# ChaCha20-Poly1305 MAC authenticates EVERY byte -- a single flipped byte fails it),
+# giving full byte-level integrity; a plaintext .tar is listed with `tar -t`, which
+# validates the per-header checksum (catches header damage + header-region truncation)
+# but has NO body checksum, so a flipped DATA byte -- or trailing-data truncation that
+# leaves the headers parseable -- in a plaintext archive is NOT detected -- set
+# backup_encryption: age for byte-level integrity. `aws s3 cp` already integrity-checks
+# the PUT, so the value here is ongoing integrity -- confirming a backup is still good
+# (and decryptable with the current key) months later.
+cmd_backup_verify() {
+    local host="" volume="" at=""
+    while [[ $# -gt 0 ]]; do
+        case "$1" in
+            --server)    [[ $# -ge 2 ]] || die "backup-verify: --server requires a value"; host="$2"; shift 2 ;;
+            --server=*)  host="${1#*=}"; shift ;;
+            --volume)    [[ $# -ge 2 ]] || die "backup-verify: --volume requires a value"; volume="$2"; shift 2 ;;
+            --volume=*)  volume="${1#*=}"; shift ;;
+            --at)        [[ $# -ge 2 ]] || die "backup-verify: --at requires a value"; at="$2"; shift 2 ;;
+            --at=*)      at="${1#*=}"; shift ;;
+            *)           die "backup-verify: unknown argument '$1'" ;;
+        esac
+    done
+    [[ -n "$host"   ]] || die "backup-verify: --server <name> is required"
+    [[ -n "$volume" ]] || die "backup-verify: --volume <name> is required"
+    valid_host_alias "$host" || die "backup-verify: invalid server name '${host}'."
+    [[ "$volume" =~ ^[A-Za-z0-9][A-Za-z0-9._-]*$ ]] || die "backup-verify: invalid volume name '${volume}' (expected [A-Za-z0-9._-])."
+    if [[ -n "$at" ]]; then
+        [[ "$at" =~ ^[0-9]{8}T[0-9]{6}Z$ ]] || die "backup-verify: --at must be a UTC timestamp YYYYMMDDTHHMMSSZ (e.g. 20260629T030000Z)."
+    fi
+    command -v aws >/dev/null 2>&1 || die "backup-verify: aws CLI not found."
+    command -v tar >/dev/null 2>&1 || die "backup-verify: tar not found."
+
+    local bucket; bucket="$(resolve_backup_bucket "$host")"
+    [[ -n "$bucket" ]] || die "backup-verify: no backup_s3_bucket configured for ${host}. Run 'miuops backup-setup --server ${host}' first."
+    local prefix; prefix="$(resolve_backup_prefix "$host")/${volume}"
+
+    local names object
+    names="$(aws s3 ls "s3://${bucket}/${prefix}/" 2>/dev/null | awk '{print $NF}' | grep -E '^backup-[0-9TZ]+\.tar(\.age)?$' || true)"
+    [[ -n "$names" ]] || die "backup-verify: no backup found for volume '${volume}' on '${host}' (s3://${bucket}/${prefix}/)."
+    if [[ -n "$at" ]]; then
+        object="$(printf '%s\n' "$names" | grep -Fx -e "backup-${at}.tar" -e "backup-${at}.tar.age" | head -1 || true)"
+        [[ -n "$object" ]] || die "backup-verify: no backup at '${at}' for volume '${volume}' on '${host}'."
+    else
+        object="$(printf '%s\n' "$names" | sort | tail -1)"
+    fi
+
+    local encrypted=false
+    [[ "$object" == *.age ]] && encrypted=true
+    if $encrypted; then
+        command -v age >/dev/null 2>&1 || die "backup-verify: ${object} is age-encrypted but 'age' is not installed."
+    fi
+
+    local age_id_args=()
+    if [[ -n "${SOPS_AGE_KEY_FILE:-}" ]]; then
+        age_id_args=(-i "$SOPS_AGE_KEY_FILE")
+    elif [[ -f "$(sops_age_default_keys)" ]]; then
+        age_id_args=(-i "$(sops_age_default_keys)")
+    fi
+
+    info "Verifying s3://${bucket}/${prefix}/${object}"
+
+    # Stream the object through the integrity check to /dev/null -- never to disk.
+    # Capture EVERY stage via PIPESTATUS (suspend errexit only around the pipe; save +
+    # restore it) so a download, age MAC, or tar failure can't hide behind the last
+    # stage. A single flipped byte fails the age MAC (encrypted) or the tar read.
+    local -a statuses
+    local _e=""; [[ $- == *e* ]] && _e=1
+    set +e
+    if $encrypted; then
+        aws s3 cp "s3://${bucket}/${prefix}/${object}" - \
+          | age -d ${age_id_args[@]+"${age_id_args[@]}"} \
+          | tar -tf - >/dev/null
+    else
+        aws s3 cp "s3://${bucket}/${prefix}/${object}" - \
+          | tar -tf - >/dev/null
+    fi
+    statuses=("${PIPESTATUS[@]}")
+    [[ -n "$_e" ]] && set -e
+
+    local idx st
+    for idx in "${!statuses[@]}"; do
+        st="${statuses[$idx]}"
+        [ "$st" -eq 0 ] && continue
+        die "backup-verify: ${object} FAILED its integrity check (pipeline stage ${idx} exit ${st}) -- the backup is corrupt, truncated, or not decryptable with the current key."
+    done
+    if $encrypted; then
+        info "OK: ${object} is intact -- age MAC authenticated every byte."
+    else
+        info "OK: ${object} passed structural checks (valid tar headers -- structure intact). NOTE: a plaintext .tar has no body checksum, so a flipped DATA byte (or trailing-data truncation) is NOT detected here -- set backup_encryption: age for byte-level integrity."
+    fi
+}
+
 # ── Main ───────────────────────────────────────────────────────────
 if [[ "${1:-}" != "--source-only" ]]; then
     case "${1:-}" in
@@ -1211,6 +1305,7 @@ if [[ "${1:-}" != "--source-only" ]]; then
         backup-setup)  shift; cmd_backup_setup "$@" ;;
         backup-rotate) shift; cmd_backup_rotate "$@" ;;
         backup-restore) shift; cmd_backup_restore "$@" ;;
+        backup-verify) shift; cmd_backup_verify "$@" ;;
         version|--version|-v) cmd_version ;;
         *)             usage ;;
     esac

--- a/tests/backup_verify_test.sh
+++ b/tests/backup_verify_test.sh
@@ -1,0 +1,128 @@
+#!/usr/bin/env bash
+#
+# `miuops backup-verify --server <h> --volume <v> [--at <ts>]` -- confirm a backup
+# in S3 is INTACT (catches a single flipped byte) WITHOUT a full restore to disk.
+# It resolves the bucket + prefix, finds the object (latest or --at), downloads it,
+# and verifies integrity end to end: an age object is decrypted to /dev/null (the
+# ChaCha20-Poly1305 MAC authenticates every byte -- a flip fails it), a plaintext
+# .tar is streamed through `tar -t` (structural check). This covers ongoing integrity
+# (bit-rot, tamper) -- `aws s3 cp` already integrity-checks the PUT, so the value here
+# is verifying a backup is still good months later.
+#
+# Every property is paired with a control:
+#   * POSITIVE control -- an intact object verifies (exit 0).
+#   * NEGATIVE fixture -- a single flipped byte MUST fail (never a silent pass).
+# The AWS/S3 boundary is faked (a PATH-shimmed `aws`) and a throwaway age keypair
+# stands in for the operator's identity. `is_real_failure` rejects exit 127 so the
+# negatives stay RED before the command exists (no false green).
+
+set -uo pipefail
+ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+pass=0; fail=0
+ok()  { printf 'ok   - %s\n' "$1"; pass=$((pass + 1)); }
+bad() { printf 'FAIL - %s\n' "$1"; fail=$((fail + 1)); }
+is_real_failure() { [ "$1" != 0 ] && [ "$1" != 127 ]; }   # ran-and-rejected, not command-not-found
+
+command -v age        >/dev/null 2>&1 || { echo "FATAL: age is required"; exit 2; }
+command -v age-keygen >/dev/null 2>&1 || { echo "FATAL: age-keygen is required"; exit 2; }
+command -v tar        >/dev/null 2>&1 || { echo "FATAL: tar is required"; exit 2; }
+
+KEYDIR="$(mktemp -d)"; IDENT="${KEYDIR}/id.txt"
+age-keygen -o "$IDENT" 2>/dev/null
+RECIP="$(age-keygen -y "$IDENT" 2>/dev/null)"
+
+S3ROOT="$(mktemp -d)"; BUCKET="wwang-fleet-backup"; SERVER="web1"; VOLUME="app_data"
+VDIR="${S3ROOT}/${BUCKET}/${SERVER}/vol/${VOLUME}"; mkdir -p "$VDIR"
+
+put_backup()       { tar -C "$2" --numeric-owner -cf - . | age -r "$RECIP" > "${VDIR}/backup-${1}.tar.age"; }
+put_plain_backup() { tar -C "$2" --numeric-owner -cf - . > "${VDIR}/backup-${1}.tar"; }
+
+BIN="$(mktemp -d)"
+cat > "${BIN}/aws" <<AWSEOF
+#!/usr/bin/env bash
+set -uo pipefail
+S3ROOT="${S3ROOT}"
+args=(); while [ \$# -gt 0 ]; do case "\$1" in --endpoint-url) shift 2;; *) args+=("\$1"); shift;; esac; done
+set -- "\${args[@]}"
+[ "\$1" = "s3" ] || { echo "fake-aws: unsupported: \$*" >&2; exit 2; }
+case "\$2" in
+  ls)  d="\${S3ROOT}/\${3#s3://}"; d="\${d%/}"; [ -d "\$d" ] || exit 0
+       for f in "\$d"/*; do [ -e "\$f" ] && printf '2026-06-29 00:00:00 %10d %s\n' "\$(wc -c < "\$f")" "\$(basename "\$f")"; done ;;
+  cp)  f="\${S3ROOT}/\${3#s3://}"; [ -f "\$f" ] || { echo "fake-aws: NoSuchKey: \$3" >&2; exit 1; }
+       if [ "\$4" = "-" ]; then cat "\$f"; else cp "\$f" "\$4"; fi
+       # injected: the download streamed the FULL body then errored -- a non-last
+       # pipeline stage fails while the consumer still got a complete object.
+       if [ -f "\${f%/*}/.cp_fails" ]; then exit 1; fi ;;
+  *)   echo "fake-aws: unsupported s3 op: \$2" >&2; exit 2 ;;
+esac
+AWSEOF
+chmod +x "${BIN}/aws"
+
+FLEET="$(mktemp -d)"; mkdir -p "${FLEET}/fleet/group_vars"
+printf 'backup_s3_bucket: %s\n' "$BUCKET" > "${FLEET}/fleet/group_vars/all.yml"
+
+run_verify() {  # [extra args...] -> echoes exit code
+  local rc=0
+  ( PATH="${BIN}:$PATH" MIUOPS_FLEET_DIR="${FLEET}/fleet" SOPS_AGE_KEY_FILE="$IDENT" \
+      bash -c '
+        . "'"$ROOT"'/miuops" --source-only 2>/dev/null
+        require_sops() { :; }
+        cmd_backup_verify --server '"$SERVER"' --volume '"$VOLUME"' '"$*"'
+      ' >/dev/null 2>&1 ) || rc=$?
+  printf '%s' "$rc"
+}
+
+# a source with a >64KB body so a flipped byte lands in the encrypted PAYLOAD (a late
+# age chunk), not only the header -- proves the MAC authenticates the data, not just
+# the header.
+SRC="$(mktemp -d)"; head -c 200000 /dev/urandom > "${SRC}/big.bin"; printf 'hello\n' > "${SRC}/a.txt"
+put_backup "20260629T010000Z" "$SRC"
+put_backup "20260629T030000Z" "$SRC"   # a newer one for latest-selection
+
+# 1. POSITIVE control -- an intact object verifies clean.
+rc="$(run_verify --at 20260629T010000Z)"
+[ "$rc" = 0 ] && ok "intact backup verifies (exit 0, positive control)" || bad "intact backup failed to verify (rc=$rc)"
+
+# 2. NEGATIVE fixture -- a single flipped byte in the payload MUST fail (age MAC).
+cp "${VDIR}/backup-20260629T010000Z.tar.age" "${VDIR}/backup-20260629T020000Z.tar.age"
+flip="${VDIR}/backup-20260629T020000Z.tar.age"
+sz=$(wc -c < "$flip"); printf 'X' | dd of="$flip" bs=1 seek=$((sz / 2)) conv=notrunc 2>/dev/null
+rc="$(run_verify --at 20260629T020000Z)"
+is_real_failure "$rc" && ok "single flipped byte: verify FAILS (negative fixture)" || bad "a flipped byte was not caught (rc=$rc)"
+
+# 3. latest selection (no --at).
+rc="$(run_verify)"
+[ "$rc" = 0 ] && ok "no --at: verifies the latest backup" || bad "latest verify failed (rc=$rc)"
+
+# 4. plaintext .tar passes the structural check (positive control). NOTE: tar -t
+#    validates headers + completeness, NOT data bodies -- a flipped *body* byte in a
+#    plaintext .tar is knowingly NOT caught (no body checksum); byte-level integrity
+#    is the age path (case 2). So this is intentionally a structural positive only.
+SRC2="$(mktemp -d)"; printf 'plain\n' > "${SRC2}/p.txt"
+put_plain_backup "20260629T040000Z" "$SRC2"
+rc="$(run_verify --at 20260629T040000Z)"
+[ "$rc" = 0 ] && ok "unencrypted .tar passes the structural check (positive control)" || bad "plaintext structural verify failed (rc=$rc)"
+
+# 4b. A plaintext .tar with a corrupted HEADER IS caught (tar -t validates the per-
+#     header checksum), so the structural guarantee we DO claim for plaintext holds.
+cp "${VDIR}/backup-20260629T040000Z.tar" "${VDIR}/backup-20260629T045000Z.tar"
+printf 'X' | dd of="${VDIR}/backup-20260629T045000Z.tar" bs=1 seek=8 conv=notrunc 2>/dev/null   # flip in the first header's name field
+rc="$(run_verify --at 20260629T045000Z)"
+is_real_failure "$rc" && ok "plaintext .tar header corruption: verify FAILS (structural check works)" || bad "plaintext header corruption not caught (rc=$rc)"
+
+# 5. missing backup -> clear failure.
+rc="$(run_verify --volume nonexistent 2>/dev/null)"
+is_real_failure "$rc" && ok "missing backup: fails non-zero" || bad "missing backup did not fail (rc=$rc)"
+
+# 6. A NON-LAST stage fails while the last (tar) exits 0 -- verify MUST still fail.
+#    Kills a "check only the last PIPESTATUS" regression: a download error that still
+#    delivered a complete object would otherwise pass. The fake aws streams the full
+#    valid object then exits non-zero, so PIPESTATUS = [aws=1, age=0, tar=0].
+touch "${VDIR}/.cp_fails"
+rc="$(run_verify --at 20260629T010000Z)"
+is_real_failure "$rc" && ok "non-last stage fails though tar exits 0: verify FAILS (kills check-only-last-PIPESTATUS)" || bad "a non-last-stage failure was not caught (rc=$rc)"
+rm -f "${VDIR}/.cp_fails"
+
+rm -rf "$KEYDIR" "$S3ROOT" "$BIN" "$FLEET" "$SRC" "$SRC2" 2>/dev/null
+echo "== ${pass} passed, ${fail} failed =="
+[ "$fail" -eq 0 ]


### PR DESCRIPTION
Adds `miuops backup-verify` — confirm a backup in S3 is intact **without** restoring it to disk. Builds on `backup-restore` (#104).

## What
`miuops backup-verify --server <h> --volume <v> [--at <ts>]` resolves the bucket + prefix, finds the object (latest or `--at`), and streams it through an integrity check to `/dev/null` — never to disk.

## Format-scoped strength (stated honestly)
- **age** object → decrypted; the ChaCha20-Poly1305 MAC authenticates **every byte** (a single flipped byte fails) — full byte-level integrity.
- **plaintext `.tar`** → `tar -t` validates headers + completeness (truncation, header damage) but has **no body checksum**, so a flipped data byte is **not** detected. Set `backup_encryption: age` for byte-level integrity.

Fail-closed via `PIPESTATUS` (errexit suspended only around the pipe). `aws s3 cp` already integrity-checks the PUT, so this covers ongoing integrity — confirming a backup is still good + decryptable months later.

## Tests (`tests/backup_verify_test.sh`, 7 cases)
Intact positive control, a single flipped byte that must fail (age MAC), latest selection, a plaintext structural positive + a plaintext header-corruption negative (documenting the structural boundary), a missing backup, and a non-last-pipeline-stage failure that must still fail (kills a check-only-last-`PIPESTATUS` regression). Wired into CI's age step + shellcheck; `DISASTER_RECOVERY.md` documents the per-format strength.

Reviewed across code + silent-failure dimensions; the plaintext-integrity claims were scoped honestly per the review.

> Stacked on #104 (backup-restore) — base retargets to `main` after #104 merges.