### PR TITLE
docs(test): drop the literal 'offen' from a backup-restore test comment

### DIFF
--- a/tests/backup_restore_test.sh
+++ b/tests/backup_restore_test.sh
@@ -8,8 +8,8 @@
 # original volume data.
 #
 # "A backup you cannot restore is not a backup": this is the verification net
-# that lets the home-grown host role replace offen. Every property is paired
-# with a control:
+# that lets the home-grown host role replace an in-stack volume-backup container.
+# Every property is paired with a control:
 #   * POSITIVE control — a clean round-trip restores byte-identical content.
 #   * NEGATIVE fixture  — a tampered .age object MUST fail (age's MAC), never a
 #                         silent partial/garbage restore.


### PR DESCRIPTION
Tiny follow-up to the backup-consolidation work: the only remaining literal `offen` across the three in-scope repos was a design-rationale comment in `tests/backup_restore_test.sh` (explaining that backup-restore lets the host role replace the in-stack volume-backup container). Reworded to name the pattern, not the specific tool — so the retired-artifact grep-clean (`wal-?g|postgres-walg|offen|…/db/`) is now literally zero everywhere. No test-logic change (`backup_restore_test` stays 10/10).