### PR TITLE
fix(observability): allow_downgrade on the pinned Alloy install

### DIFF
--- a/roles/observability/tasks/main.yml
+++ b/roles/observability/tasks/main.yml
@@ -80,6 +80,10 @@
     name: "alloy={{ observability_alloy_version }}"
     state: present
     update_cache: true
+    # The version is a hard pin (fleet-wide reproducibility). Enforce it even when a
+    # newer alloy is already installed -- otherwise apt refuses the implied downgrade
+    # ("Packages were downgraded ... without --allow-downgrades") and the converge fails.
+    allow_downgrade: true
   when: observability_active | bool
   tags: ['observability']
 


### PR DESCRIPTION
The observability role pins Alloy (`alloy={{ observability_alloy_version }}`, currently `1.17.0-1`) for fleet-wide reproducibility. On a host where a **newer** alloy is already installed, `apt` refuses the implied downgrade and the converge fails:

```
E: Packages were downgraded and -y was used without --allow-downgrades.
```

Add `allow_downgrade: true` so the pin is **authoritative** — the converge installs exactly the pinned version even when the installed one drifted newer. No behavior change when the installed version already matches.

Surfaced bringing up a fresh server (Ubuntu 26.04) whose Grafana apt repo served a newer alloy than the fleet pin. (A follow-up will bump the pin itself to a current version — this fix makes that roll-forward apply cleanly too.)