### PR TITLE
chore(observability): bump pinned Alloy to 1.17.1-1

### DIFF
--- a/roles/observability/defaults/main.yml
+++ b/roles/observability/defaults/main.yml
@@ -15,7 +15,7 @@ observability_active: "{{ observability_enabled | bool and (grafana_cloud_promet
 # switched the default storage driver to overlayfs and dropped the image/<driver>/layerdb/
 # mounts layout the old cAdvisor relied on; older Alloy fails container registration
 # ("failed to identify the read-write layer ID") and silently ships zero per-container metrics.
-observability_alloy_version: "1.17.0-1"
+observability_alloy_version: "1.17.1-1"
 
 observability_scrape_interval: "60s"
 


### PR DESCRIPTION
Rolls the fleet's pinned Alloy from `1.17.0-1` → `1.17.1-1` (the Grafana apt repo's current stable). **Patch release** — config format unchanged; keeps the cAdvisor / Docker-29 overlayfs per-container-metrics fix the pin exists for (1.17.1 > the 1.17.0 threshold).

**Pairs with #108** (`allow_downgrade`): with both merged, the next converge lands every server on `1.17.1-1` regardless of what's installed — upgrades the 1.17.0 servers, and the fresh server already on 1.17.1 becomes a no-op (no more downgrade attempt).

Found bringing up a fresh Ubuntu 26.04 server whose repo served 1.17.1-1, which the stale 1.17.0-1 pin tried to downgrade (the converge abort #108 fixes).