### PR TITLE
feat(cli): apply (re)provisions /opt/stacks/.env from sops, like up

### DIFF
--- a/miuops
+++ b/miuops
@@ -183,6 +183,48 @@ sops_provision_env() {  # $1 = server (host alias)  $2 = ssh_user@host
     info "Provisioned /opt/stacks/.env on ${server} (0600)"
 }
 
+# Resolve a host's SSH target ("<ansible_user>@<ansible_host>") from inventory.ini;
+# echoes nothing if the host or either field is absent.
+inventory_ssh_target() {
+    local host="$1" inv="${FLEET_DIR}/inventory.ini"
+    [[ -f "$inv" ]] || return 0
+    awk -v h="$host" '
+        $1==h {
+            ah=""; au="";
+            for (i=2; i<=NF; i++) {
+                if ($i ~ /^ansible_host=/) { sub(/^ansible_host=/, "", $i); ah=$i }
+                if ($i ~ /^ansible_user=/) { sub(/^ansible_user=/, "", $i); au=$i }
+            }
+            if (ah!="" && au!="") print au"@"ah
+            exit
+        }' "$inv"
+}
+
+# Echo every host alias in inventory.ini (first field of non-group, non-comment lines).
+inventory_hosts() {
+    local inv="${FLEET_DIR}/inventory.ini"
+    [[ -f "$inv" ]] || return 0
+    awk '!/^[[:space:]]*#/ && !/^[[:space:]]*\[/ && NF>0 { print $1 }' "$inv"
+}
+
+# After a converge, (re)provision /opt/stacks/.env from fleet/secrets/<host>.env for the
+# applied host(s) -- mirrors `up`, so a secret change lands on `apply` too (idempotent
+# day-2), not only on first bootstrap. Hosts with no secret file are skipped by
+# sops_provision_env. $1 = host ("" = whole fleet).
+provision_env_after_apply() {
+    local only="$1" hosts h target
+    if [[ -n "$only" ]]; then hosts="$only"; else hosts="$(inventory_hosts)"; fi
+    for h in $hosts; do
+        [[ -f "${SECRETS_DIR}/${h}.env" ]] || continue
+        target="$(inventory_ssh_target "$h")"
+        if [[ -z "$target" ]]; then
+            warn "No inventory SSH target for '${h}'; cannot provision /opt/stacks/.env"
+            continue
+        fi
+        sops_provision_env "$h" "$target"
+    done
+}
+
 # ── Config helpers (host_vars + inventory) ──────────────────────────
 hv_path() { echo "${FLEET_DIR}/host_vars/$1.yml"; }
 
@@ -441,6 +483,10 @@ cmd_apply() {
     done
     [[ -z "$host" ]] || valid_host_alias "$host" || die "Invalid host '${host}'"
     run_apply "$host"
+    # Idempotently (re)push /opt/stacks/.env from sops (mirrors `up`). Skip under
+    # --no-apply, which means "no host changes" (sops_provision_env honours --dry-run
+    # itself, but not --no-apply).
+    [[ "${NO_APPLY:-false}" == true ]] || provision_env_after_apply "$host"
 }
 
 usage() {

--- a/tests/cli_test.sh
+++ b/tests/cli_test.sh
@@ -37,6 +37,16 @@ inventory_upsert server-a 198.51.100.9 admin   # update in place
 [ "$(grep -c '^server-a ' "$TMP/fleet/inventory.ini")" = "1" ] || fail "server-a duplicated"
 grep -q 'ansible_host=198.51.100.9' "$TMP/fleet/inventory.ini" || fail "server-a not updated"
 
+# --- inventory_ssh_target / inventory_hosts read the SSH target back from inventory ---
+[ "$(inventory_ssh_target server-a)" = "admin@198.51.100.9" ] || fail "inventory_ssh_target wrong for server-a"
+[ "$(inventory_ssh_target server-b)" = "root@198.51.100.2" ]  || fail "inventory_ssh_target wrong for server-b"
+[ -z "$(inventory_ssh_target ghost)" ]                         || fail "inventory_ssh_target must be empty for an unknown host"
+[ "$(inventory_hosts | sort | tr '\n' ',')" = "server-a,server-b," ] || fail "inventory_hosts must list every host alias"
+
+# --- apply (re)provisions the app .env from sops, mirroring up (idempotent day-2) ---
+grep -qF '[[ "${NO_APPLY:-false}" == true ]] || provision_env_after_apply "$host"' "$ROOT/miuops" || fail "cmd_apply must provision /opt/stacks/.env after the converge, skipped under --no-apply"
+grep -qF 'sops_provision_env "$h" "$target"' "$ROOT/miuops"  || fail "provision_env_after_apply must provision via sops_provision_env"
+
 # --- domain_owner finds the owning host ---
 [ "$(domain_owner example.com)" = "server-a" ] || fail "domain_owner wrong"
 [ -z "$(domain_owner unowned.example)" ]        || fail "domain_owner false positive"


### PR DESCRIPTION
## Gap
`miuops up` provisions the app `.env` to `/opt/stacks/.env` (via `sops_provision_env`), but `miuops apply` did **not**. So a change to `fleet/secrets/<host>.env` only reached the host on a full re-bootstrap or a manual `sops -d | ssh`. It also fails **silently** when a fresh server's secret is briefly misnamed: `up` sees no `<host>.env`, skips provisioning, and leaves an empty `/opt/stacks/.env`.

## Fix
Two small inventory readers + wire the existing provisioner into `cmd_apply`:
- `inventory_ssh_target <host>` → `<user>@<host>` from inventory.ini
- `inventory_hosts` → every host alias
- `provision_env_after_apply` (after `run_apply`) → (re)provision `/opt/stacks/.env` from sops for the applied host(s); single host or whole fleet; hosts without a secret are skipped.

So a secret change now lands on every `apply` (idempotent day-2), reusing the same SSH-only, age-key-never-leaves-the-controller path as `up`.

## Verification
- RED→GREEN unit tests (`tests/cli_test.sh`): `inventory_ssh_target`/`inventory_hosts` parsing + the `cmd_apply` wiring assertion. shellcheck-clean (no new findings).
- Integration (apply against a real host → `/opt/stacks/.env` byte-matches `sops -d`) pending on the aarch64 test VPS.