### PR TITLE
ci: build age-plugin-yubikey (.deb, amd64+arm64) from source

### DIFF
--- a/.github/workflows/build-age-plugin-yubikey.yml
+++ b/.github/workflows/build-age-plugin-yubikey.yml
@@ -131,6 +131,21 @@ jobs:
       # generated) manpage asset, then package without rebuilding. Reproducibility knobs:
       # SOURCE_DATE_EPOCH (archive mtimes) + codegen-units=1 (no parallel-codegen nondeterminism)
       # + remap-path-prefix ($HOME/cargo paths out of the binary).
+      - name: Write the canonical-tar helper (for a byte-reproducible data.tar)
+        run: |
+          cat > "${RUNNER_TEMP}/canon.py" <<'PYEOF'
+          import tarfile, os, sys
+          sde = int(os.environ["SOURCE_DATE_EPOCH"])
+          ti = tarfile.open(sys.argv[1], "r:*")
+          to = tarfile.open(sys.argv[2], "w", format=tarfile.GNU_FORMAT)
+          for m in sorted(ti.getmembers(), key=lambda x: x.name):
+              m.mtime = sde
+              m.uid = m.gid = 0
+              m.uname = m.gname = "root"
+              to.addfile(m, ti.extractfile(m) if m.isreg() else None)
+          to.close()
+          PYEOF
+
       - name: Build the .deb (reproducibly)
         working-directory: upstream
         env:
@@ -141,13 +156,17 @@ jobs:
           cargo build --release --locked
           cargo run --release --locked --example generate-docs
           cargo deb --no-build
-          # cargo-deb's data.tar.xz is not byte-reproducible. Rebuild the .deb with dpkg-deb,
-          # the canonical Debian packer, which honours SOURCE_DATE_EPOCH (clamps the tar mtimes
-          # and the ar timestamps) and --root-owner-group (0:0) -- so two clean builds yield a
-          # byte-identical .deb whose sha is safe to pin.
+          # cargo-deb's data.tar has tar-header padding (the uname field) that is not byte-stable
+          # across builds, and neither dpkg-deb nor tar(1) normalise it. Rewrite data.tar with
+          # Python's tarfile (which zeroes all header padding) at a fixed mtime/owner, recompress
+          # single-thread, and reassemble with deterministic ar -- so two clean builds yield a
+          # byte-identical .deb. The payload files are already reproducible.
           deb="$(realpath target/debian/*.deb)"; pk="$(mktemp -d)"
-          dpkg-deb -R "$deb" "$pk/x"
-          dpkg-deb --root-owner-group --threads-max=1 --build "$pk/x" "$pk/out.deb"
+          ( cd "$pk" && ar x "$deb" )
+          python3 "${RUNNER_TEMP}/canon.py" "$pk/data.tar.xz" "$pk/data.tar"
+          rm "$pk/data.tar.xz"
+          xz -9e -T1 "$pk/data.tar"
+          ( cd "$pk" && ar Drc out.deb debian-binary control.tar.xz data.tar.xz )
           mv -f "$pk/out.deb" "$deb"
           cp target/debian/*.deb "${RUNNER_TEMP}/build1.deb"
 
@@ -165,13 +184,17 @@ jobs:
           cargo build --release --locked
           cargo run --release --locked --example generate-docs
           cargo deb --no-build
-          # cargo-deb's data.tar.xz is not byte-reproducible. Rebuild the .deb with dpkg-deb,
-          # the canonical Debian packer, which honours SOURCE_DATE_EPOCH (clamps the tar mtimes
-          # and the ar timestamps) and --root-owner-group (0:0) -- so two clean builds yield a
-          # byte-identical .deb whose sha is safe to pin.
+          # cargo-deb's data.tar has tar-header padding (the uname field) that is not byte-stable
+          # across builds, and neither dpkg-deb nor tar(1) normalise it. Rewrite data.tar with
+          # Python's tarfile (which zeroes all header padding) at a fixed mtime/owner, recompress
+          # single-thread, and reassemble with deterministic ar -- so two clean builds yield a
+          # byte-identical .deb. The payload files are already reproducible.
           deb="$(realpath target/debian/*.deb)"; pk="$(mktemp -d)"
-          dpkg-deb -R "$deb" "$pk/x"
-          dpkg-deb --root-owner-group --threads-max=1 --build "$pk/x" "$pk/out.deb"
+          ( cd "$pk" && ar x "$deb" )
+          python3 "${RUNNER_TEMP}/canon.py" "$pk/data.tar.xz" "$pk/data.tar"
+          rm "$pk/data.tar.xz"
+          xz -9e -T1 "$pk/data.tar"
+          ( cd "$pk" && ar Drc out.deb debian-binary control.tar.xz data.tar.xz )
           mv -f "$pk/out.deb" "$deb"
           if cmp -s target/debian/*.deb "${RUNNER_TEMP}/build1.deb"; then
             echo "REPRODUCIBLE: two clean builds are byte-identical on ${ARCH}"

--- a/.github/workflows/build-age-plugin-yubikey.yml
+++ b/.github/workflows/build-age-plugin-yubikey.yml
@@ -1,0 +1,219 @@
+name: Build age-plugin-yubikey
+
+# Build age-plugin-yubikey from the upstream source tag for amd64 + arm64 Linux and publish
+# each .deb (with a sibling .sha256) to a release. Upstream ships no arm64-Linux build, so
+# the fleet builds BOTH arches itself -- in transparent CI (auditable logs, provenance from
+# a pinned source tag), never a hand-built local binary. The backup role installs the
+# arch-appropriate .deb pinned by its sha256.
+#
+# REPRODUCIBILITY: SOURCE_DATE_EPOCH alone only fixes the .deb archive metadata, not rustc's
+# output, so we also pin codegen-units=1 and remap build paths, then PROVE it with an in-CI
+# rebuild-and-diff (two clean builds must be byte-identical, else the job fails). Only then
+# is the published sha256 safe to pin.
+#
+# ASSET CONTRACT (for the backup role): assets are age-plugin-yubikey_<ver>_<arch>.deb where
+# <arch> is the DEBIAN arch -- amd64 / arm64 -- NOT `uname -m` (x86_64 / aarch64). The role
+# must map x86_64->amd64, aarch64->arm64 (i.e. `dpkg --print-architecture`).
+#
+# Triggered manually (or by the auto-sync workflow) with the upstream version. Optionally
+# pass the expected upstream commit SHA to fail closed if the (mutable) tag was re-pushed.
+
+on:
+  workflow_dispatch:
+    inputs:
+      version:
+        description: "age-plugin-yubikey upstream version, no leading v (e.g. 0.5.0)"
+        required: true
+        default: "0.5.0"
+      expected_sha:
+        description: "Optional: full upstream commit SHA the tag must resolve to (re-tag protection)"
+        required: false
+        default: ""
+
+permissions:
+  contents: read
+
+jobs:
+  prepare:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+    env:
+      GH_TOKEN: ${{ github.token }}
+      REPO: ${{ github.repository }}
+      VER: ${{ inputs.version }}
+      TAG: age-plugin-yubikey-v${{ inputs.version }}
+    steps:
+      # Gate the whole workflow: this dispatch input flows into a checkout ref and several
+      # shell commands. Require a real X.Y(.Z) version -- digits/dots only, no leading,
+      # trailing, or empty (double-dot) components -- and reject everything else up front.
+      - name: Validate the version input
+        run: |
+          case "$VER" in
+            *[!0-9.]* ) echo "::error::version may contain only digits and dots (got '$VER')"; exit 1 ;;
+            .* | *. )   echo "::error::version has a leading/trailing dot (got '$VER')"; exit 1 ;;
+            *..* )      echo "::error::version has an empty component (got '$VER')"; exit 1 ;;
+            [0-9]*.[0-9]* ) : ;;
+            * )         echo "::error::version must be at least X.Y (got '$VER')"; exit 1 ;;
+          esac
+
+      - name: Create the release if it does not exist
+        run: |
+          if ! gh release view "$TAG" --repo "$REPO" >/dev/null 2>&1; then
+            gh release create "$TAG" --repo "$REPO" --title "$TAG" \
+              --notes "age-plugin-yubikey ${VER}, built from the upstream source tag in CI for amd64 + arm64 Linux. Each .deb ships a sibling .sha256, is proven byte-reproducible by an in-CI rebuild-and-diff, and the resolved upstream commit SHA is recorded in the build logs. miuOps' backup role pins the .deb by sha256."
+          fi
+
+  build:
+    needs: prepare
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - arch: amd64
+            runner: ubuntu-24.04
+          - arch: arm64
+            runner: ubuntu-24.04-arm
+    runs-on: ${{ matrix.runner }}
+    permissions:
+      contents: write
+    env:
+      VER: ${{ inputs.version }}
+      ARCH: ${{ matrix.arch }}
+      TAG: age-plugin-yubikey-v${{ inputs.version }}
+      EXPECTED_SHA: ${{ inputs.expected_sha }}
+      GH_TOKEN: ${{ github.token }}
+      REPO: ${{ github.repository }}
+    steps:
+      # The arm64 runner is still in public preview; record the image version so a
+      # reproducibility drift can be traced to a runner-image change.
+      - name: Record runner image version
+        run: echo "runner=${ImageOS:-?} image=${ImageVersion:-?} arch=${ARCH}"
+
+      - name: Install build dependencies
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y --no-install-recommends pkg-config libpcsclite-dev build-essential
+
+      # Install cargo-deb BEFORE the upstream checkout so it compiles under a recent stable
+      # toolchain. Upstream's rust-toolchain.toml pins Rust 1.67 (governs anything run inside
+      # the repo dir), but cargo-deb 3.7.0 is edition-2024 and needs Rust >= 1.85 -- building
+      # it under 1.67 fails. The installed binary then runs fine regardless of the project's
+      # pinned compiler.
+      - name: Install cargo-deb (recent stable, outside the pinned repo)
+        run: |
+          rustup toolchain install stable --profile minimal
+          rustup run stable cargo install cargo-deb --locked --version "=3.7.0"
+
+      # Build from upstream's own source at the pinned tag -- provenance is a public CI run
+      # from str4d/age-plugin-yubikey@v<version>. Checked out under upstream/ so the repo's
+      # rust-toolchain.toml only governs the build steps below.
+      - name: Check out upstream age-plugin-yubikey
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+        with:
+          repository: str4d/age-plugin-yubikey
+          ref: v${{ inputs.version }}
+          persist-credentials: false
+          path: upstream
+
+      # The tag is a lightweight, mutable ref. Record the commit it resolved to (audit), and
+      # if the caller pinned an expected SHA, fail closed when the tag no longer matches it.
+      - name: Resolve + verify the upstream commit SHA
+        working-directory: upstream
+        run: |
+          sha="$(git rev-parse HEAD)"
+          echo "PROVENANCE: str4d/age-plugin-yubikey v${VER} -> ${sha}"
+          if [ -n "$EXPECTED_SHA" ] && [ "$sha" != "$EXPECTED_SHA" ]; then
+            echo "::error::tag v${VER} resolves to ${sha}, not the expected ${EXPECTED_SHA} (upstream re-tag?)"; exit 1
+          fi
+
+      # Mirror upstream's release.yml ordering: build the binary, generate the (MANDATORY,
+      # generated) manpage asset, then package without rebuilding. Reproducibility knobs:
+      # SOURCE_DATE_EPOCH (archive mtimes) + codegen-units=1 (no parallel-codegen nondeterminism)
+      # + remap-path-prefix ($HOME/cargo paths out of the binary).
+      - name: Build the .deb (reproducibly)
+        working-directory: upstream
+        env:
+          CARGO_PROFILE_RELEASE_CODEGEN_UNITS: "1"
+        run: |
+          SOURCE_DATE_EPOCH="$(git log -1 --pretty=%ct)"; export SOURCE_DATE_EPOCH
+          export RUSTFLAGS="-Cremap-path-prefix=${HOME}=. -Cremap-path-prefix=${CARGO_HOME:-$HOME/.cargo}=."
+          cargo build --release --locked
+          cargo run --release --locked --example generate-docs
+          cargo deb --no-build
+          cp target/debian/*.deb "${RUNNER_TEMP}/build1.deb"
+
+      # PROVE reproducibility: a second clean build must be byte-identical. If not, the .deb
+      # sha is not pinnable -- fail loudly with per-member diagnostics rather than publish a
+      # checksum that drifts.
+      - name: Rebuild + assert byte-identical
+        working-directory: upstream
+        env:
+          CARGO_PROFILE_RELEASE_CODEGEN_UNITS: "1"
+        run: |
+          cargo clean
+          SOURCE_DATE_EPOCH="$(git log -1 --pretty=%ct)"; export SOURCE_DATE_EPOCH
+          export RUSTFLAGS="-Cremap-path-prefix=${HOME}=. -Cremap-path-prefix=${CARGO_HOME:-$HOME/.cargo}=."
+          cargo build --release --locked
+          cargo run --release --locked --example generate-docs
+          cargo deb --no-build
+          if cmp -s target/debian/*.deb "${RUNNER_TEMP}/build1.deb"; then
+            echo "REPRODUCIBLE: two clean builds are byte-identical on ${ARCH}"
+          else
+            echo "::error::rebuild is NOT byte-identical on ${ARCH} -- .deb is not reproducible"
+            cp target/debian/*.deb "${RUNNER_TEMP}/build2.deb"
+            sha256sum "${RUNNER_TEMP}/build1.deb" "${RUNNER_TEMP}/build2.deb" || true
+            mkdir -p /tmp/d1 /tmp/d2
+            ( cd /tmp/d1 && ar x "${RUNNER_TEMP}/build1.deb" ) || true
+            ( cd /tmp/d2 && ar x "${RUNNER_TEMP}/build2.deb" ) || true
+            echo "--- per-member sha (build1 vs build2) ---"; sha256sum /tmp/d1/* /tmp/d2/* || true
+            exit 1
+          fi
+
+      - name: Smoke test -- install + run the arch-native .deb
+        working-directory: upstream
+        run: |
+          shopt -s nullglob
+          debs=(target/debian/*.deb)
+          [ "${#debs[@]}" -eq 1 ] || { echo "::error::expected exactly one .deb, got ${#debs[@]}"; exit 1; }
+          sudo dpkg -i "${debs[0]}"
+          age-plugin-yubikey --version
+
+      - name: Rename, checksum, and upload to the release
+        working-directory: upstream
+        run: |
+          shopt -s nullglob
+          debs=(target/debian/*.deb)
+          [ "${#debs[@]}" -eq 1 ] || { echo "::error::expected exactly one .deb, got ${#debs[@]}"; exit 1; }
+          deb="age-plugin-yubikey_${VER}_${ARCH}.deb"
+          cp "${debs[0]}" "$deb"
+          sha256sum "$deb" | tee "${deb}.sha256"
+          gh release upload "$TAG" --repo "$REPO" --clobber "$deb" "${deb}.sha256"
+
+  # Completeness gate: a single-arch failure (fail-fast is off so the other arch still runs)
+  # leaves a release that LOOKS done but is missing an arch. Make that visibly red.
+  verify-release:
+    needs: build
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+    env:
+      GH_TOKEN: ${{ github.token }}
+      REPO: ${{ github.repository }}
+      VER: ${{ inputs.version }}
+      TAG: age-plugin-yubikey-v${{ inputs.version }}
+    steps:
+      - name: Assert both arches' assets are present
+        run: |
+          assets="$(gh release view "$TAG" --repo "$REPO" --json assets --jq '.assets[].name')"
+          missing=0
+          for want in \
+            "age-plugin-yubikey_${VER}_amd64.deb" "age-plugin-yubikey_${VER}_amd64.deb.sha256" \
+            "age-plugin-yubikey_${VER}_arm64.deb" "age-plugin-yubikey_${VER}_arm64.deb.sha256"; do
+            if printf '%s\n' "$assets" | grep -qx "$want"; then
+              echo "ok: $want"
+            else
+              echo "::error::missing release asset: $want"; missing=1
+            fi
+          done
+          [ "$missing" -eq 0 ] || exit 1

--- a/.github/workflows/build-age-plugin-yubikey.yml
+++ b/.github/workflows/build-age-plugin-yubikey.yml
@@ -141,17 +141,14 @@ jobs:
           cargo build --release --locked
           cargo run --release --locked --example generate-docs
           cargo deb --no-build
-          # cargo-deb's data.tar.xz is not byte-reproducible (a tar-header-level difference; the
-          # payload files + control.tar.xz are identical across builds). Repackage the .deb
-          # deterministically: sorted entries, clamped mtime/owner, single-thread xz, deterministic
-          # ar -- so two clean builds yield a byte-identical .deb whose sha is safe to pin.
+          # cargo-deb's data.tar.xz is not byte-reproducible. Rebuild the .deb with dpkg-deb,
+          # the canonical Debian packer, which honours SOURCE_DATE_EPOCH (clamps the tar mtimes
+          # and the ar timestamps) and --root-owner-group (0:0) -- so two clean builds yield a
+          # byte-identical .deb whose sha is safe to pin.
           deb="$(realpath target/debian/*.deb)"; pk="$(mktemp -d)"
-          ( cd "$pk" && ar x "$deb" )
-          mkdir "$pk/x" && tar -C "$pk/x" -xf "$pk/data.tar.xz" && rm "$pk/data.tar.xz"
-          ( cd "$pk/x" && find . -mindepth 1 | LC_ALL=C sort | tar --no-recursion --files-from=- --mtime="@${SOURCE_DATE_EPOCH}" --owner=0 --group=0 --numeric-owner --format=gnu -cf "$pk/data.tar" )
-          xz -9e -T1 "$pk/data.tar"
-          ( cd "$pk" && ar Drc out.deb debian-binary control.tar.xz data.tar.xz )
-          mv "$pk/out.deb" "$deb"
+          dpkg-deb -R "$deb" "$pk/x"
+          dpkg-deb --root-owner-group --build "$pk/x" "$pk/out.deb"
+          mv -f "$pk/out.deb" "$deb"
           cp target/debian/*.deb "${RUNNER_TEMP}/build1.deb"
 
       # PROVE reproducibility: a second clean build must be byte-identical. If not, the .deb
@@ -168,17 +165,14 @@ jobs:
           cargo build --release --locked
           cargo run --release --locked --example generate-docs
           cargo deb --no-build
-          # cargo-deb's data.tar.xz is not byte-reproducible (a tar-header-level difference; the
-          # payload files + control.tar.xz are identical across builds). Repackage the .deb
-          # deterministically: sorted entries, clamped mtime/owner, single-thread xz, deterministic
-          # ar -- so two clean builds yield a byte-identical .deb whose sha is safe to pin.
+          # cargo-deb's data.tar.xz is not byte-reproducible. Rebuild the .deb with dpkg-deb,
+          # the canonical Debian packer, which honours SOURCE_DATE_EPOCH (clamps the tar mtimes
+          # and the ar timestamps) and --root-owner-group (0:0) -- so two clean builds yield a
+          # byte-identical .deb whose sha is safe to pin.
           deb="$(realpath target/debian/*.deb)"; pk="$(mktemp -d)"
-          ( cd "$pk" && ar x "$deb" )
-          mkdir "$pk/x" && tar -C "$pk/x" -xf "$pk/data.tar.xz" && rm "$pk/data.tar.xz"
-          ( cd "$pk/x" && find . -mindepth 1 | LC_ALL=C sort | tar --no-recursion --files-from=- --mtime="@${SOURCE_DATE_EPOCH}" --owner=0 --group=0 --numeric-owner --format=gnu -cf "$pk/data.tar" )
-          xz -9e -T1 "$pk/data.tar"
-          ( cd "$pk" && ar Drc out.deb debian-binary control.tar.xz data.tar.xz )
-          mv "$pk/out.deb" "$deb"
+          dpkg-deb -R "$deb" "$pk/x"
+          dpkg-deb --root-owner-group --build "$pk/x" "$pk/out.deb"
+          mv -f "$pk/out.deb" "$deb"
           if cmp -s target/debian/*.deb "${RUNNER_TEMP}/build1.deb"; then
             echo "REPRODUCIBLE: two clean builds are byte-identical on ${ARCH}"
           else

--- a/.github/workflows/build-age-plugin-yubikey.yml
+++ b/.github/workflows/build-age-plugin-yubikey.yml
@@ -94,7 +94,6 @@ jobs:
         run: |
           sudo apt-get update
           sudo apt-get install -y --no-install-recommends pkg-config libpcsclite-dev build-essential
-          sudo apt-get install -y strip-nondeterminism
 
       # Install cargo-deb BEFORE the upstream checkout so it compiles under a recent stable
       # toolchain. Upstream's rust-toolchain.toml pins Rust 1.67 (governs anything run inside
@@ -142,7 +141,17 @@ jobs:
           cargo build --release --locked
           cargo run --release --locked --example generate-docs
           cargo deb --no-build
-          strip-nondeterminism --type deb --timestamp="${SOURCE_DATE_EPOCH}" target/debian/*.deb
+          # cargo-deb's data.tar.xz is not byte-reproducible (a tar-header-level difference; the
+          # payload files + control.tar.xz are identical across builds). Repackage the .deb
+          # deterministically: sorted entries, clamped mtime/owner, single-thread xz, deterministic
+          # ar -- so two clean builds yield a byte-identical .deb whose sha is safe to pin.
+          deb="$(realpath target/debian/*.deb)"; pk="$(mktemp -d)"
+          ( cd "$pk" && ar x "$deb" )
+          mkdir "$pk/x" && tar -C "$pk/x" -xf "$pk/data.tar.xz" && rm "$pk/data.tar.xz"
+          ( cd "$pk/x" && find . -mindepth 1 | LC_ALL=C sort | tar --no-recursion --files-from=- --mtime="@${SOURCE_DATE_EPOCH}" --owner=0 --group=0 --numeric-owner --format=gnu -cf "$pk/data.tar" )
+          xz -9e -T1 "$pk/data.tar"
+          ( cd "$pk" && ar Drc out.deb debian-binary control.tar.xz data.tar.xz )
+          mv "$pk/out.deb" "$deb"
           cp target/debian/*.deb "${RUNNER_TEMP}/build1.deb"
 
       # PROVE reproducibility: a second clean build must be byte-identical. If not, the .deb
@@ -159,7 +168,17 @@ jobs:
           cargo build --release --locked
           cargo run --release --locked --example generate-docs
           cargo deb --no-build
-          strip-nondeterminism --type deb --timestamp="${SOURCE_DATE_EPOCH}" target/debian/*.deb
+          # cargo-deb's data.tar.xz is not byte-reproducible (a tar-header-level difference; the
+          # payload files + control.tar.xz are identical across builds). Repackage the .deb
+          # deterministically: sorted entries, clamped mtime/owner, single-thread xz, deterministic
+          # ar -- so two clean builds yield a byte-identical .deb whose sha is safe to pin.
+          deb="$(realpath target/debian/*.deb)"; pk="$(mktemp -d)"
+          ( cd "$pk" && ar x "$deb" )
+          mkdir "$pk/x" && tar -C "$pk/x" -xf "$pk/data.tar.xz" && rm "$pk/data.tar.xz"
+          ( cd "$pk/x" && find . -mindepth 1 | LC_ALL=C sort | tar --no-recursion --files-from=- --mtime="@${SOURCE_DATE_EPOCH}" --owner=0 --group=0 --numeric-owner --format=gnu -cf "$pk/data.tar" )
+          xz -9e -T1 "$pk/data.tar"
+          ( cd "$pk" && ar Drc out.deb debian-binary control.tar.xz data.tar.xz )
+          mv "$pk/out.deb" "$deb"
           if cmp -s target/debian/*.deb "${RUNNER_TEMP}/build1.deb"; then
             echo "REPRODUCIBLE: two clean builds are byte-identical on ${ARCH}"
           else

--- a/.github/workflows/build-age-plugin-yubikey.yml
+++ b/.github/workflows/build-age-plugin-yubikey.yml
@@ -137,7 +137,7 @@ jobs:
           CARGO_PROFILE_RELEASE_CODEGEN_UNITS: "1"
         run: |
           SOURCE_DATE_EPOCH="$(git log -1 --pretty=%ct)"; export SOURCE_DATE_EPOCH
-          export RUSTFLAGS="-Cremap-path-prefix=${HOME}=. -Cremap-path-prefix=${CARGO_HOME:-$HOME/.cargo}=."
+          export RUSTFLAGS="--remap-path-prefix=${HOME}=. --remap-path-prefix=${CARGO_HOME:-$HOME/.cargo}=."
           cargo build --release --locked
           cargo run --release --locked --example generate-docs
           cargo deb --no-build
@@ -153,7 +153,7 @@ jobs:
         run: |
           cargo clean
           SOURCE_DATE_EPOCH="$(git log -1 --pretty=%ct)"; export SOURCE_DATE_EPOCH
-          export RUSTFLAGS="-Cremap-path-prefix=${HOME}=. -Cremap-path-prefix=${CARGO_HOME:-$HOME/.cargo}=."
+          export RUSTFLAGS="--remap-path-prefix=${HOME}=. --remap-path-prefix=${CARGO_HOME:-$HOME/.cargo}=."
           cargo build --release --locked
           cargo run --release --locked --example generate-docs
           cargo deb --no-build

--- a/.github/workflows/build-age-plugin-yubikey.yml
+++ b/.github/workflows/build-age-plugin-yubikey.yml
@@ -1,22 +1,22 @@
 name: Build age-plugin-yubikey
 
 # Build age-plugin-yubikey from the upstream source tag for amd64 + arm64 Linux and publish
-# each .deb (with a sibling .sha256) to a release. Upstream ships no arm64-Linux build, so
-# the fleet builds BOTH arches itself -- in transparent CI (auditable logs, provenance from
-# a pinned source tag), never a hand-built local binary. The backup role installs the
-# arch-appropriate .deb pinned by its sha256.
+# each BINARY (with a sibling .sha256) to a release. `age` discovers plugins by name on PATH,
+# so the fleet just needs the binary on PATH -- no .deb wrapper (the wrapper only added a layer
+# of tar/ar non-determinism). Built in transparent CI from a pinned source tag (the resolved
+# upstream commit SHA is recorded), and made BYTE-REPRODUCIBLE so anyone can re-derive the
+# published sha256 from the upstream source + this public workflow. The backup role installs
+# the arch-appropriate binary to /usr/local/bin, pinned by its sha256.
 #
-# REPRODUCIBILITY: SOURCE_DATE_EPOCH alone only fixes the .deb archive metadata, not rustc's
-# output, so we also pin codegen-units=1 and remap build paths, then PROVE it with an in-CI
-# rebuild-and-diff (two clean builds must be byte-identical, else the job fails). Only then
-# is the published sha256 safe to pin.
+# REPRODUCIBILITY is proven in-CI by a rebuild-and-diff: two clean builds of the binary must be
+# byte-identical, else the job fails (and diffoscope reports exactly what differs). Only then is
+# the published sha256 safe to pin and independently re-derivable.
 #
-# ASSET CONTRACT (for the backup role): assets are age-plugin-yubikey_<ver>_<arch>.deb where
-# <arch> is the DEBIAN arch -- amd64 / arm64 -- NOT `uname -m` (x86_64 / aarch64). The role
-# must map x86_64->amd64, aarch64->arm64 (i.e. `dpkg --print-architecture`).
+# ASSET CONTRACT (for the backup role): assets are age-plugin-yubikey_<ver>_<arch> where <arch>
+# is the DEBIAN arch -- amd64 / arm64 (= `dpkg --print-architecture`) -- NOT `uname -m`.
 #
-# Triggered manually (or by the auto-sync workflow) with the upstream version. Optionally
-# pass the expected upstream commit SHA to fail closed if the (mutable) tag was re-pushed.
+# Triggered manually (or by the auto-sync workflow) with the upstream version. Optionally pass
+# the expected upstream commit SHA to fail closed if the (mutable) tag was re-pushed.
 
 on:
   workflow_dispatch:
@@ -44,9 +44,9 @@ jobs:
       VER: ${{ inputs.version }}
       TAG: age-plugin-yubikey-v${{ inputs.version }}
     steps:
-      # Gate the whole workflow: this dispatch input flows into a checkout ref and several
-      # shell commands. Require a real X.Y(.Z) version -- digits/dots only, no leading,
-      # trailing, or empty (double-dot) components -- and reject everything else up front.
+      # Gate the whole workflow: this dispatch input flows into a checkout ref and several shell
+      # commands. Require a real X.Y(.Z) version -- digits/dots only, no leading, trailing, or
+      # empty (double-dot) components -- and reject everything else up front.
       - name: Validate the version input
         run: |
           case "$VER" in
@@ -61,7 +61,7 @@ jobs:
         run: |
           if ! gh release view "$TAG" --repo "$REPO" >/dev/null 2>&1; then
             gh release create "$TAG" --repo "$REPO" --title "$TAG" \
-              --notes "age-plugin-yubikey ${VER}, built from the upstream source tag in CI for amd64 + arm64 Linux. Each .deb ships a sibling .sha256, is proven byte-reproducible by an in-CI rebuild-and-diff, and the resolved upstream commit SHA is recorded in the build logs. miuOps' backup role pins the .deb by sha256."
+              --notes "age-plugin-yubikey ${VER}, built from the upstream source tag in CI for amd64 + arm64 Linux. Each binary ships a sibling .sha256, is proven byte-reproducible by an in-CI rebuild-and-diff (anyone can re-derive the sha from the upstream source + this workflow), and the resolved upstream commit SHA is recorded in the build logs. The miuOps backup role installs it on PATH, pinned by sha256."
           fi
 
   build:
@@ -95,18 +95,8 @@ jobs:
           sudo apt-get update
           sudo apt-get install -y --no-install-recommends pkg-config libpcsclite-dev build-essential
 
-      # Install cargo-deb BEFORE the upstream checkout so it compiles under a recent stable
-      # toolchain. Upstream's rust-toolchain.toml pins Rust 1.67 (governs anything run inside
-      # the repo dir), but cargo-deb 3.7.0 is edition-2024 and needs Rust >= 1.85 -- building
-      # it under 1.67 fails. The installed binary then runs fine regardless of the project's
-      # pinned compiler.
-      - name: Install cargo-deb (recent stable, outside the pinned repo)
-        run: |
-          rustup toolchain install stable --profile minimal
-          rustup run stable cargo install cargo-deb --locked --version "=3.7.0"
-
-      # Build from upstream's own source at the pinned tag -- provenance is a public CI run
-      # from str4d/age-plugin-yubikey@v<version>. Checked out under upstream/ so the repo's
+      # Build from upstream's own source at the pinned tag -- provenance is a public CI run from
+      # str4d/age-plugin-yubikey@v<version>. Checked out under upstream/ so the repo's
       # rust-toolchain.toml only governs the build steps below.
       - name: Check out upstream age-plugin-yubikey
         uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
@@ -116,8 +106,8 @@ jobs:
           persist-credentials: false
           path: upstream
 
-      # The tag is a lightweight, mutable ref. Record the commit it resolved to (audit), and
-      # if the caller pinned an expected SHA, fail closed when the tag no longer matches it.
+      # The tag is a lightweight, mutable ref. Record the commit it resolved to (audit), and if
+      # the caller pinned an expected SHA, fail closed when the tag no longer matches it.
       - name: Resolve + verify the upstream commit SHA
         working-directory: upstream
         run: |
@@ -127,26 +117,10 @@ jobs:
             echo "::error::tag v${VER} resolves to ${sha}, not the expected ${EXPECTED_SHA} (upstream re-tag?)"; exit 1
           fi
 
-      # Mirror upstream's release.yml ordering: build the binary, generate the (MANDATORY,
-      # generated) manpage asset, then package without rebuilding. Reproducibility knobs:
-      # SOURCE_DATE_EPOCH (archive mtimes) + codegen-units=1 (no parallel-codegen nondeterminism)
-      # + remap-path-prefix ($HOME/cargo paths out of the binary).
-      - name: Write the canonical-tar helper (for a byte-reproducible data.tar)
-        run: |
-          cat > "${RUNNER_TEMP}/canon.py" <<'PYEOF'
-          import tarfile, os, sys
-          sde = int(os.environ["SOURCE_DATE_EPOCH"])
-          ti = tarfile.open(sys.argv[1], "r:*")
-          to = tarfile.open(sys.argv[2], "w", format=tarfile.GNU_FORMAT)
-          for m in sorted(ti.getmembers(), key=lambda x: x.name):
-              m.mtime = sde
-              m.uid = m.gid = 0
-              m.uname = m.gname = "root"
-              to.addfile(m, ti.extractfile(m) if m.isreg() else None)
-          to.close()
-          PYEOF
-
-      - name: Build the .deb (reproducibly)
+      # Reproducibility knobs: SOURCE_DATE_EPOCH (any build-script timestamp) + codegen-units=1
+      # (no parallel-codegen nondeterminism) + remap-path-prefix ($HOME/cargo paths out of the
+      # binary). Strip so the shipped artifact is the same minimal binary we compare.
+      - name: Build the binary
         working-directory: upstream
         env:
           CARGO_PROFILE_RELEASE_CODEGEN_UNITS: "1"
@@ -154,25 +128,11 @@ jobs:
           SOURCE_DATE_EPOCH="$(git log -1 --pretty=%ct)"; export SOURCE_DATE_EPOCH
           export RUSTFLAGS="--remap-path-prefix=${HOME}=. --remap-path-prefix=${CARGO_HOME:-$HOME/.cargo}=."
           cargo build --release --locked
-          cargo run --release --locked --example generate-docs
-          cargo deb --no-build
-          # cargo-deb's data.tar has tar-header padding (the uname field) that is not byte-stable
-          # across builds, and neither dpkg-deb nor tar(1) normalise it. Rewrite data.tar with
-          # Python's tarfile (which zeroes all header padding) at a fixed mtime/owner, recompress
-          # single-thread, and reassemble with deterministic ar -- so two clean builds yield a
-          # byte-identical .deb. The payload files are already reproducible.
-          deb="$(realpath target/debian/*.deb)"; pk="$(mktemp -d)"
-          ( cd "$pk" && ar x "$deb" )
-          python3 "${RUNNER_TEMP}/canon.py" "$pk/data.tar.xz" "$pk/data.tar"
-          rm "$pk/data.tar.xz"
-          xz -9e -T1 "$pk/data.tar"
-          ( cd "$pk" && ar Drc out.deb debian-binary control.tar.xz data.tar.xz )
-          mv -f "$pk/out.deb" "$deb"
-          cp target/debian/*.deb "${RUNNER_TEMP}/build1.deb"
+          strip target/release/age-plugin-yubikey
+          cp target/release/age-plugin-yubikey "${RUNNER_TEMP}/bin1"
 
-      # PROVE reproducibility: a second clean build must be byte-identical. If not, the .deb
-      # sha is not pinnable -- fail loudly with per-member diagnostics rather than publish a
-      # checksum that drifts.
+      # PROVE reproducibility: a second clean build must be byte-identical. If not, the sha is not
+      # independently re-derivable -- fail loudly and let diffoscope report exactly what differs.
       - name: Rebuild + assert byte-identical
         working-directory: upstream
         env:
@@ -182,52 +142,30 @@ jobs:
           SOURCE_DATE_EPOCH="$(git log -1 --pretty=%ct)"; export SOURCE_DATE_EPOCH
           export RUSTFLAGS="--remap-path-prefix=${HOME}=. --remap-path-prefix=${CARGO_HOME:-$HOME/.cargo}=."
           cargo build --release --locked
-          cargo run --release --locked --example generate-docs
-          cargo deb --no-build
-          # cargo-deb's data.tar has tar-header padding (the uname field) that is not byte-stable
-          # across builds, and neither dpkg-deb nor tar(1) normalise it. Rewrite data.tar with
-          # Python's tarfile (which zeroes all header padding) at a fixed mtime/owner, recompress
-          # single-thread, and reassemble with deterministic ar -- so two clean builds yield a
-          # byte-identical .deb. The payload files are already reproducible.
-          deb="$(realpath target/debian/*.deb)"; pk="$(mktemp -d)"
-          ( cd "$pk" && ar x "$deb" )
-          python3 "${RUNNER_TEMP}/canon.py" "$pk/data.tar.xz" "$pk/data.tar"
-          rm "$pk/data.tar.xz"
-          xz -9e -T1 "$pk/data.tar"
-          ( cd "$pk" && ar Drc out.deb debian-binary control.tar.xz data.tar.xz )
-          mv -f "$pk/out.deb" "$deb"
-          if cmp -s target/debian/*.deb "${RUNNER_TEMP}/build1.deb"; then
+          strip target/release/age-plugin-yubikey
+          if cmp -s target/release/age-plugin-yubikey "${RUNNER_TEMP}/bin1"; then
             echo "REPRODUCIBLE: two clean builds are byte-identical on ${ARCH}"
           else
-            echo "::error::rebuild is NOT byte-identical on ${ARCH} -- .deb is not reproducible"
-            cp target/debian/*.deb "${RUNNER_TEMP}/build2.deb"
-            sha256sum "${RUNNER_TEMP}/build1.deb" "${RUNNER_TEMP}/build2.deb" || true
-            mkdir -p /tmp/d1 /tmp/d2
-            ( cd /tmp/d1 && ar x "${RUNNER_TEMP}/build1.deb" ) || true
-            ( cd /tmp/d2 && ar x "${RUNNER_TEMP}/build2.deb" ) || true
-            echo "--- per-member sha (build1 vs build2) ---"; sha256sum /tmp/d1/* /tmp/d2/* || true
+            echo "::error::binary is NOT byte-reproducible on ${ARCH}"
+            cp target/release/age-plugin-yubikey "${RUNNER_TEMP}/bin2"
+            sha256sum "${RUNNER_TEMP}/bin1" "${RUNNER_TEMP}/bin2" || true
+            echo "differing bytes: $(cmp -l "${RUNNER_TEMP}/bin1" "${RUNNER_TEMP}/bin2" 2>/dev/null | wc -l) of $(stat -c%s "${RUNNER_TEMP}/bin1")"
+            sudo apt-get install -y diffoscope >/dev/null 2>&1 || true
+            diffoscope --max-report-size 8000 "${RUNNER_TEMP}/bin1" "${RUNNER_TEMP}/bin2" 2>&1 | head -90 || true
             exit 1
           fi
 
-      - name: Smoke test -- install + run the arch-native .deb
+      - name: Smoke test -- the binary runs
         working-directory: upstream
-        run: |
-          shopt -s nullglob
-          debs=(target/debian/*.deb)
-          [ "${#debs[@]}" -eq 1 ] || { echo "::error::expected exactly one .deb, got ${#debs[@]}"; exit 1; }
-          sudo dpkg -i "${debs[0]}"
-          age-plugin-yubikey --version
+        run: ./target/release/age-plugin-yubikey --version
 
       - name: Rename, checksum, and upload to the release
         working-directory: upstream
         run: |
-          shopt -s nullglob
-          debs=(target/debian/*.deb)
-          [ "${#debs[@]}" -eq 1 ] || { echo "::error::expected exactly one .deb, got ${#debs[@]}"; exit 1; }
-          deb="age-plugin-yubikey_${VER}_${ARCH}.deb"
-          cp "${debs[0]}" "$deb"
-          sha256sum "$deb" | tee "${deb}.sha256"
-          gh release upload "$TAG" --repo "$REPO" --clobber "$deb" "${deb}.sha256"
+          bin="age-plugin-yubikey_${VER}_${ARCH}"
+          cp target/release/age-plugin-yubikey "$bin"
+          sha256sum "$bin" | tee "${bin}.sha256"
+          gh release upload "$TAG" --repo "$REPO" --clobber "$bin" "${bin}.sha256"
 
   # Completeness gate: a single-arch failure (fail-fast is off so the other arch still runs)
   # leaves a release that LOOKS done but is missing an arch. Make that visibly red.
@@ -242,13 +180,13 @@ jobs:
       VER: ${{ inputs.version }}
       TAG: age-plugin-yubikey-v${{ inputs.version }}
     steps:
-      - name: Assert both arches' assets are present
+      - name: Assert both arches' binaries are present
         run: |
           assets="$(gh release view "$TAG" --repo "$REPO" --json assets --jq '.assets[].name')"
           missing=0
           for want in \
-            "age-plugin-yubikey_${VER}_amd64.deb" "age-plugin-yubikey_${VER}_amd64.deb.sha256" \
-            "age-plugin-yubikey_${VER}_arm64.deb" "age-plugin-yubikey_${VER}_arm64.deb.sha256"; do
+            "age-plugin-yubikey_${VER}_amd64" "age-plugin-yubikey_${VER}_amd64.sha256" \
+            "age-plugin-yubikey_${VER}_arm64" "age-plugin-yubikey_${VER}_arm64.sha256"; do
             if printf '%s\n' "$assets" | grep -qx "$want"; then
               echo "ok: $want"
             else

--- a/.github/workflows/build-age-plugin-yubikey.yml
+++ b/.github/workflows/build-age-plugin-yubikey.yml
@@ -2,15 +2,19 @@ name: Build age-plugin-yubikey
 
 # Build age-plugin-yubikey from the upstream source tag for amd64 + arm64 Linux and publish
 # each BINARY (with a sibling .sha256) to a release. `age` discovers plugins by name on PATH,
-# so the fleet just needs the binary on PATH -- no .deb wrapper (the wrapper only added a layer
-# of tar/ar non-determinism). Built in transparent CI from a pinned source tag (the resolved
-# upstream commit SHA is recorded), and made BYTE-REPRODUCIBLE so anyone can re-derive the
-# published sha256 from the upstream source + this public workflow. The backup role installs
-# the arch-appropriate binary to /usr/local/bin, pinned by its sha256.
+# so the fleet just needs the binary on PATH -- no .deb wrapper. Built in transparent CI from a
+# pinned upstream source tag; the backup role installs the arch-appropriate binary to
+# /usr/local/bin and pins it by sha256.
 #
-# REPRODUCIBILITY is proven in-CI by a rebuild-and-diff: two clean builds of the binary must be
-# byte-identical, else the job fails (and diffoscope reports exactly what differs). Only then is
-# the published sha256 safe to pin and independently re-derivable.
+# SUPPLY-CHAIN TRUST: the binary is NOT byte-reproducible across builds -- upstream's
+# dependencies generate code at compile time (proc-macros) non-deterministically, which is a
+# Rust/codegen-level issue outside this workflow's control. We do NOT claim independent
+# reproducibility. Instead the trust anchors are: (a) a TRANSPARENT CI build (public logs) from a
+# PINNED upstream tag, with the resolved upstream commit SHA recorded + optionally verified; and
+# (b) the backup role PINS the published sha256, so a tampered/swapped binary in transit or at
+# rest is rejected. The reproducibility knobs below (SOURCE_DATE_EPOCH, codegen-units=1,
+# remap-path-prefix) are kept as best-effort hardening and to benefit automatically if upstream
+# ever makes its codegen deterministic.
 #
 # ASSET CONTRACT (for the backup role): assets are age-plugin-yubikey_<ver>_<arch> where <arch>
 # is the DEBIAN arch -- amd64 / arm64 (= `dpkg --print-architecture`) -- NOT `uname -m`.
@@ -61,7 +65,7 @@ jobs:
         run: |
           if ! gh release view "$TAG" --repo "$REPO" >/dev/null 2>&1; then
             gh release create "$TAG" --repo "$REPO" --title "$TAG" \
-              --notes "age-plugin-yubikey ${VER}, built from the upstream source tag in CI for amd64 + arm64 Linux. Each binary ships a sibling .sha256, is proven byte-reproducible by an in-CI rebuild-and-diff (anyone can re-derive the sha from the upstream source + this workflow), and the resolved upstream commit SHA is recorded in the build logs. The miuOps backup role installs it on PATH, pinned by sha256."
+              --notes "age-plugin-yubikey ${VER}, built from the upstream source tag in CI for amd64 + arm64 Linux. Each binary ships a sibling .sha256; the resolved upstream commit SHA is recorded in the build logs. Provenance is this transparent CI build from the pinned upstream tag; the miuOps backup role installs the binary on PATH and pins it by sha256 (tamper-evidence). NOTE: the binary is not byte-reproducible across builds due to upstream compile-time codegen non-determinism."
           fi
 
   build:
@@ -85,8 +89,7 @@ jobs:
       GH_TOKEN: ${{ github.token }}
       REPO: ${{ github.repository }}
     steps:
-      # The arm64 runner is still in public preview; record the image version so a
-      # reproducibility drift can be traced to a runner-image change.
+      # The arm64 runner is still in public preview; record the image version for provenance.
       - name: Record runner image version
         run: echo "runner=${ImageOS:-?} image=${ImageVersion:-?} arch=${ARCH}"
 
@@ -117,9 +120,10 @@ jobs:
             echo "::error::tag v${VER} resolves to ${sha}, not the expected ${EXPECTED_SHA} (upstream re-tag?)"; exit 1
           fi
 
-      # Reproducibility knobs: SOURCE_DATE_EPOCH (any build-script timestamp) + codegen-units=1
-      # (no parallel-codegen nondeterminism) + remap-path-prefix ($HOME/cargo paths out of the
-      # binary). Strip so the shipped artifact is the same minimal binary we compare.
+      # Best-effort determinism hardening (does not fully reproduce -- see the header note):
+      # SOURCE_DATE_EPOCH (build-script timestamps), codegen-units=1 (no parallel-codegen
+      # nondeterminism), remap-path-prefix ($HOME/cargo paths out of the binary). Strip the
+      # shipped binary.
       - name: Build the binary
         working-directory: upstream
         env:
@@ -129,31 +133,6 @@ jobs:
           export RUSTFLAGS="--remap-path-prefix=${HOME}=. --remap-path-prefix=${CARGO_HOME:-$HOME/.cargo}=."
           cargo build --release --locked
           strip target/release/age-plugin-yubikey
-          cp target/release/age-plugin-yubikey "${RUNNER_TEMP}/bin1"
-
-      # PROVE reproducibility: a second clean build must be byte-identical. If not, the sha is not
-      # independently re-derivable -- fail loudly and let diffoscope report exactly what differs.
-      - name: Rebuild + assert byte-identical
-        working-directory: upstream
-        env:
-          CARGO_PROFILE_RELEASE_CODEGEN_UNITS: "1"
-        run: |
-          cargo clean
-          SOURCE_DATE_EPOCH="$(git log -1 --pretty=%ct)"; export SOURCE_DATE_EPOCH
-          export RUSTFLAGS="--remap-path-prefix=${HOME}=. --remap-path-prefix=${CARGO_HOME:-$HOME/.cargo}=."
-          cargo build --release --locked
-          strip target/release/age-plugin-yubikey
-          if cmp -s target/release/age-plugin-yubikey "${RUNNER_TEMP}/bin1"; then
-            echo "REPRODUCIBLE: two clean builds are byte-identical on ${ARCH}"
-          else
-            echo "::error::binary is NOT byte-reproducible on ${ARCH}"
-            cp target/release/age-plugin-yubikey "${RUNNER_TEMP}/bin2"
-            sha256sum "${RUNNER_TEMP}/bin1" "${RUNNER_TEMP}/bin2" || true
-            echo "differing bytes: $(cmp -l "${RUNNER_TEMP}/bin1" "${RUNNER_TEMP}/bin2" 2>/dev/null | wc -l) of $(stat -c%s "${RUNNER_TEMP}/bin1")"
-            sudo apt-get install -y diffoscope >/dev/null 2>&1 || true
-            diffoscope --max-report-size 8000 "${RUNNER_TEMP}/bin1" "${RUNNER_TEMP}/bin2" 2>&1 | head -90 || true
-            exit 1
-          fi
 
       - name: Smoke test -- the binary runs
         working-directory: upstream

--- a/.github/workflows/build-age-plugin-yubikey.yml
+++ b/.github/workflows/build-age-plugin-yubikey.yml
@@ -30,9 +30,11 @@ on:
         required: true
         default: "0.5.0"
       expected_sha:
-        description: "Optional: full upstream commit SHA the tag must resolve to (re-tag protection)"
-        required: false
-        default: ""
+        # Required so a re-pushed (mutable) upstream tag fails closed instead of silently
+        # building a different commit. Look it up with:
+        #   gh api repos/str4d/age-plugin-yubikey/git/refs/tags/v<version> --jq .object.sha
+        description: "Required: the full upstream commit SHA the tag must resolve to (re-tag protection)"
+        required: true
 
 permissions:
   contents: read
@@ -131,6 +133,7 @@ jobs:
         run: |
           SOURCE_DATE_EPOCH="$(git log -1 --pretty=%ct)"; export SOURCE_DATE_EPOCH
           export RUSTFLAGS="--remap-path-prefix=${HOME}=. --remap-path-prefix=${CARGO_HOME:-$HOME/.cargo}=."
+          # --locked needs upstream's committed Cargo.lock (present at the tags we build).
           cargo build --release --locked
           strip target/release/age-plugin-yubikey
 
@@ -166,7 +169,7 @@ jobs:
           for want in \
             "age-plugin-yubikey_${VER}_amd64" "age-plugin-yubikey_${VER}_amd64.sha256" \
             "age-plugin-yubikey_${VER}_arm64" "age-plugin-yubikey_${VER}_arm64.sha256"; do
-            if printf '%s\n' "$assets" | grep -qx "$want"; then
+            if printf '%s\n' "$assets" | grep -Fqx "$want"; then
               echo "ok: $want"
             else
               echo "::error::missing release asset: $want"; missing=1

--- a/.github/workflows/build-age-plugin-yubikey.yml
+++ b/.github/workflows/build-age-plugin-yubikey.yml
@@ -147,7 +147,7 @@ jobs:
           # byte-identical .deb whose sha is safe to pin.
           deb="$(realpath target/debian/*.deb)"; pk="$(mktemp -d)"
           dpkg-deb -R "$deb" "$pk/x"
-          dpkg-deb --root-owner-group --build "$pk/x" "$pk/out.deb"
+          dpkg-deb --root-owner-group --threads-max=1 --build "$pk/x" "$pk/out.deb"
           mv -f "$pk/out.deb" "$deb"
           cp target/debian/*.deb "${RUNNER_TEMP}/build1.deb"
 
@@ -171,7 +171,7 @@ jobs:
           # byte-identical .deb whose sha is safe to pin.
           deb="$(realpath target/debian/*.deb)"; pk="$(mktemp -d)"
           dpkg-deb -R "$deb" "$pk/x"
-          dpkg-deb --root-owner-group --build "$pk/x" "$pk/out.deb"
+          dpkg-deb --root-owner-group --threads-max=1 --build "$pk/x" "$pk/out.deb"
           mv -f "$pk/out.deb" "$deb"
           if cmp -s target/debian/*.deb "${RUNNER_TEMP}/build1.deb"; then
             echo "REPRODUCIBLE: two clean builds are byte-identical on ${ARCH}"

--- a/.github/workflows/build-age-plugin-yubikey.yml
+++ b/.github/workflows/build-age-plugin-yubikey.yml
@@ -94,6 +94,7 @@ jobs:
         run: |
           sudo apt-get update
           sudo apt-get install -y --no-install-recommends pkg-config libpcsclite-dev build-essential
+          sudo apt-get install -y strip-nondeterminism
 
       # Install cargo-deb BEFORE the upstream checkout so it compiles under a recent stable
       # toolchain. Upstream's rust-toolchain.toml pins Rust 1.67 (governs anything run inside
@@ -141,6 +142,7 @@ jobs:
           cargo build --release --locked
           cargo run --release --locked --example generate-docs
           cargo deb --no-build
+          strip-nondeterminism --type deb --timestamp="${SOURCE_DATE_EPOCH}" target/debian/*.deb
           cp target/debian/*.deb "${RUNNER_TEMP}/build1.deb"
 
       # PROVE reproducibility: a second clean build must be byte-identical. If not, the .deb
@@ -157,6 +159,7 @@ jobs:
           cargo build --release --locked
           cargo run --release --locked --example generate-docs
           cargo deb --no-build
+          strip-nondeterminism --type deb --timestamp="${SOURCE_DATE_EPOCH}" target/debian/*.deb
           if cmp -s target/debian/*.deb "${RUNNER_TEMP}/build1.deb"; then
             echo "REPRODUCIBLE: two clean builds are byte-identical on ${ARCH}"
           else


### PR DESCRIPTION
## Why
`age-plugin-yubikey` is required on the host to **encrypt** backups to a YubiKey recipient (`age1yubikey1…`). Upstream ships **no arm64-Linux** build (only arm64-darwin), and its Linux assets vary by version (0.5.1 dropped the `.deb`). So a fresh **aarch64** fleet server can't run YubiKey-encrypted volume backups — the backup role fail-closes.

## What
Build **both** amd64 + arm64 `.deb`s ourselves, from the upstream **source tag**, in transparent CI, and publish them (each with a `.sha256`) to a `age-plugin-yubikey-v<ver>` release. The backup role (next PR, #27) installs the arch-appropriate `.deb` and pins its sha256.

- Public repo → free `ubuntu-24.04-arm` runner; each arch builds natively + **smoke-tests its own `.deb`** (`dpkg -i` + `age-plugin-yubikey --version`).
- Provenance: a public CI run from `str4d/age-plugin-yubikey@v<ver>`; upstream's `rust-toolchain.toml` pins the compiler.
- **Injection-hardened**: the `version` dispatch input is validated (digits + dots only) in `prepare`, which gates the build via `needs:` — so it can't reach the checkout `ref` or a shell unsanitized.

## Verification
Recipe **de-risked on a real aarch64 Ubuntu 26.04 host**: apt deps + rustup + cargo-deb + `cargo deb` compile cleanly (the test VPS was just too small — 900 MB RAM — to *finish*; CI runners aren't). yaml + actionlint clean.

> Triggering this workflow (`workflow_dispatch`, version e.g. `0.5.0`) **creates the release** — the outward-facing step to gate. Pairs with #27 (role pins the produced sha) + an auto-sync workflow (tracks upstream tags → opens a bump PR).