### PR TITLE
feat: provision /opt/stacks/.env via a stack-env role (sops -> ansible copy)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -30,6 +30,7 @@ jobs:
             tests/sops_test.sh tests/setup_s3_backup_noninteractive_test.sh \
             tests/backup_role_lint_test.sh tests/script_dir_resolution_test.sh \
             tests/observability_role_lint_test.sh \
+            tests/stack_env_role_lint_test.sh \
             tests/config_secret_split_test.sh \
             tests/secrets_docs_lint_test.sh \
             tests/backup_lifecycle_net.sh \
@@ -58,6 +59,7 @@ jobs:
           bash tests/deploy_server_skip_test.sh
           bash tests/backup_role_lint_test.sh
           bash tests/observability_role_lint_test.sh
+          bash tests/stack_env_role_lint_test.sh
           bash tests/config_secret_split_test.sh
           bash tests/secrets_docs_lint_test.sh
           bash tests/ssh_deploy_key_validation_test.sh

--- a/miuops
+++ b/miuops
@@ -42,8 +42,8 @@ FLEET_ROOT="$(dirname "$FLEET_DIR")"
 # disk), so every sops temp is registered here and one trap cleans them up.
 _SOPS_TMPS=()
 _sops_cleanup() { [ "${#_SOPS_TMPS[@]}" -gt 0 ] && rm -f "${_SOPS_TMPS[@]}"; return 0; }
-# The trap is armed INSIDE run_apply / sops_provision_env (the only functions that
-# create plaintext temps), NOT at top level — so sourcing the CLI (--source-only,
+# The trap is armed INSIDE run_apply (the only function that creates plaintext temps),
+# NOT at top level — so sourcing the CLI (--source-only,
 # e.g. from a test) does not clobber the sourcer's own EXIT trap.
 
 RED='\033[0;31m'
@@ -157,30 +157,6 @@ sops_encrypt_tunnel_cred() {  # $1 = tunnel_id
   - See docs/SOPS_SECRETS.md."
     fi
     info "Encrypted tunnel credential -> ${dst} (commit this)"
-}
-
-# The remote command that lands the decrypted .env at /opt/stacks/.env, mode
-# 0600, root-owned, atomically. Kept as a function so the test can assert the
-# mode/path without running ssh. install(1) sets the mode in one step.
-sops_env_install_cmd() {
-    echo "umask 077; install -m 0600 /dev/stdin /opt/stacks/.env"
-}
-
-# Decrypt fleet/secrets/<server>.env LOCALLY and push it to the host's
-# /opt/stacks/.env over SSH at 0600 (root). No plaintext is staged on disk
-# beyond the private temp file, which is shredded on return.
-sops_provision_env() {  # $1 = server (host alias)  $2 = ssh_user@host
-    local server="$1" sshtgt="$2"
-    local enc="${SECRETS_DIR}/${server}.env" tmp   # separate decl: enc needs server set first (set -u)
-    trap _sops_cleanup EXIT INT TERM   # shred the decrypted .env temp on exit/die/signal
-    [[ -f "$enc" ]] || { info "No ${server}.env in fleet/secrets — skipping .env provisioning"; return 0; }
-    if $DRY_RUN; then dry "Would provision /opt/stacks/.env on ${server} (0600, from fleet/secrets/${server}.env)"; return 0; fi
-    tmp="$(sops_decrypt_to_tmp "$enc")"
-    _SOPS_TMPS+=("$tmp")   # shredded by the global EXIT/INT/TERM trap, even on die/signal
-    if ! ssh -o BatchMode=yes "$sshtgt" "$(sops_env_install_cmd)" < "$tmp"; then
-        die "Failed to provision /opt/stacks/.env to ${server}"
-    fi
-    info "Provisioned /opt/stacks/.env on ${server} (0600)"
 }
 
 # ── Config helpers (host_vars + inventory) ──────────────────────────
@@ -379,6 +355,13 @@ run_apply() {
     # miuops apply` from outside the tool checkout still resolves cfg, inventory + host_vars.
     export ANSIBLE_CONFIG="${SCRIPT_DIR}/ansible.cfg"
     local cmd=(ansible-playbook -i "${FLEET_DIR}/inventory.ini" "${SCRIPT_DIR}/playbook.yml")
+    # Pass the secrets dir only when it exists, so a fresh fleet (no fleet/secrets/ yet) is a
+    # clean no-op — the stack-env role's "" default + length guard skip — not a hard failure.
+    if [[ -d "${SECRETS_DIR}" ]]; then
+        # Single-quote the value so a fleet path containing a space is not word-split by
+        # Ansible's key=value extra-vars parser (the role decrypts fleet/secrets/<host>.env).
+        cmd+=(--extra-vars "miuops_secrets_dir='${SECRETS_DIR}'")
+    fi
     [[ -n "$host" ]] && cmd+=(--limit "$host")
     [[ -n "${APPLY_TAGS:-}" ]] && cmd+=(--tags "${APPLY_TAGS}")
 
@@ -823,15 +806,8 @@ ${existing}
         info "Updating inventory.ini..."
         inventory_upsert "$handle" "$ssh_host" "$ssh_user"
 
-        run_apply "$handle"   # installs Galaxy requirements, then converges
-
-        # Provision the app .env (if present, encrypted under fleet/secrets/) to the
-        # host's /opt/stacks/.env at 0600. Decryption is LOCAL; only the plaintext .env
-        # crosses the wire (over SSH), never the age key. CI deploy rsync excludes .env,
-        # so this operator-set file is authoritative.
-        if [[ -f "${SECRETS_DIR}/${handle}.env" ]]; then
-            sops_provision_env "$handle" "${ssh_user}@${ssh_host}"
-        fi
+        run_apply "$handle"   # installs Galaxy requirements + converges; the stack-env role
+                              # provisions /opt/stacks/.env from fleet/secrets/<handle>.env.
 
         echo ""
         info "${BOLD}Done!${NC} Server bootstrapped."

--- a/playbook.yml
+++ b/playbook.yml
@@ -45,6 +45,8 @@
       tags: ['metadata-block']
     - role: traefik
       tags: ['traefik']
+    - role: stack-env
+      tags: ['stack-env']
     - role: cloudflared
       tags: ['cloudflared']
     - role: observability

--- a/requirements.yml
+++ b/requirements.yml
@@ -6,3 +6,7 @@ collections:
     version: ">=6.0.0" 
   - name: ansible.posix
     version: ">=1.6.0"
+  # Used by the stack-env role to decrypt fleet/secrets/<host>.env on the controller
+  # (a thin wrapper around the `sops` binary -- no new crypto).
+  - name: community.sops
+    version: ">=2.0.0"

--- a/roles/stack-env/defaults/main.yml
+++ b/roles/stack-env/defaults/main.yml
@@ -1,0 +1,6 @@
+---
+# Absolute path to the fleet's secrets dir on the controller; `miuops apply` passes it via
+# --extra-vars. Empty by default so a non-CLI playbook run (e.g. CI's bare ansible-playbook)
+# is a clean no-op rather than a template error -- and a wrong/relative value fails loud via
+# the controller-side assert in tasks/main.yml, never a silent fleet-wide skip.
+miuops_secrets_dir: ""

--- a/roles/stack-env/tasks/main.yml
+++ b/roles/stack-env/tasks/main.yml
@@ -1,0 +1,68 @@
+---
+# Provision the host's /opt/stacks/.env from the fleet's sops-encrypted secret.
+#
+# Decryption happens on the CONTROLLER (community.sops wraps the `sops` binary the CLI
+# already uses -- no new crypto, the age key never leaves the controller). The plaintext is
+# written by `copy`: ATOMIC (temp+rename), IDEMPOTENT (writes only on change), 0600, no_log.
+#
+# The secret is keyed by inventory_hostname, which IS the fleet handle: inventory_upsert
+# writes `<handle> ansible_host=...`, so the inventory key == the handle == the host_vars
+# and secret filename. A host with no secret keeps the empty placeholder below; a
+# present-but-undecryptable secret fails the play (fail-closed).
+- name: Ensure /opt/stacks exists
+  ansible.builtin.file:
+    path: /opt/stacks
+    state: directory
+    owner: root
+    group: root
+    mode: '0755'
+  become: true
+  tags: ['stack-env']
+
+# Every host gets a /opt/stacks/.env so a stack's `env_file:` never points at a missing
+# file. force: false -> the real secret below is never clobbered by this placeholder.
+- name: Ensure /opt/stacks/.env exists (empty placeholder)
+  ansible.builtin.copy:
+    content: ""
+    dest: /opt/stacks/.env
+    owner: root
+    group: root
+    mode: '0600'
+    force: false
+  become: true
+  tags: ['stack-env']
+
+# A named-but-wrong secrets dir, or a missing `sops`, must fail LOUD on the controller --
+# not skip the whole fleet silently and not surface as a redacted no_log error. Both checks
+# are controller-side and run once per play.
+- name: Verify the fleet secrets dir + sops are usable on the controller
+  delegate_to: localhost
+  run_once: true
+  become: false   # controller-side checks; become here would try to sudo on the control node
+  when: miuops_secrets_dir | length > 0
+  tags: ['stack-env']
+  block:
+    - name: Assert miuops_secrets_dir exists
+      ansible.builtin.assert:
+        that: miuops_secrets_dir is exists
+        fail_msg: "miuops_secrets_dir='{{ miuops_secrets_dir }}' does not exist on the controller"
+        quiet: true
+    - name: Assert the sops binary is available (community.sops shells out to it)
+      ansible.builtin.command: sops --version
+      changed_when: false
+
+- name: Provision /opt/stacks/.env from the fleet secret
+  ansible.builtin.copy:
+    content: "{{ lookup('community.sops.sops', _stack_env_secret) }}"
+    dest: /opt/stacks/.env
+    owner: root
+    group: root
+    mode: '0600'
+  vars:
+    _stack_env_secret: "{{ miuops_secrets_dir }}/{{ inventory_hostname }}.env"
+  when:
+    - miuops_secrets_dir | length > 0
+    - _stack_env_secret is exists
+  become: true
+  no_log: true
+  tags: ['stack-env']

--- a/roles/traefik/tasks/main.yml
+++ b/roles/traefik/tasks/main.yml
@@ -112,11 +112,4 @@
     state: directory
     mode: '0755'
   become: true
-
-- name: Create stacks .env file
-  ansible.builtin.copy:
-    content: ""
-    dest: /opt/stacks/.env
-    mode: '0600'
-    force: false
-  become: true
+# /opt/stacks/.env is provisioned from the fleet's sops secret by the stack-env role.

--- a/tests/cli_test.sh
+++ b/tests/cli_test.sh
@@ -81,8 +81,8 @@ grep -qF '"${ssh_user}@${ssh_host}" true' "$ROOT/miuops"         || fail "the SS
 grep -qF '"$owner" != "$handle"' "$ROOT/miuops"                  || fail "domain-owner check must compare to the handle"
 grep -qF 'hv_tunnel "$handle"' "$ROOT/miuops"                    || fail "tunnel reuse must look up the handle"
 grep -qF 'hv_domains "$handle"' "$ROOT/miuops"                   || fail "domain merge must look up the handle"
-grep -qF '"${SECRETS_DIR}/${handle}.env"' "$ROOT/miuops"         || fail "the app .env path must be keyed by the handle"
-grep -qF 'sops_provision_env "$handle"' "$ROOT/miuops"           || fail "the app .env must be provisioned under the handle"
+grep -qF 'miuops_secrets_dir=' "$ROOT/miuops"                    || fail "apply/up must pass miuops_secrets_dir so the stack-env role provisions /opt/stacks/.env"
+grep -qF 'if [[ -d "${SECRETS_DIR}" ]]; then' "$ROOT/miuops"     || fail "miuops_secrets_dir must be passed only when fleet/secrets/ exists (fresh fleet = clean no-op, not an assert failure)"
 
 # --- Task 8: apply targets --limit; --no-apply skips converge ---
 out="$(cd "$ROOT" && ./miuops apply --dry-run server-a 2>&1 || true)"

--- a/tests/sops_test.sh
+++ b/tests/sops_test.sh
@@ -148,13 +148,6 @@ perm="$(stat -c '%a' "$plain" 2>/dev/null || stat -f '%Lp' "$plain")"
 rm -f "$plain"
 echo "ok: sops_decrypt_to_tmp round-trips to a 0600 temp file"
 
-# The .env provisioning command targets /opt/stacks/.env at mode 0600, root-owned.
-type sops_env_install_cmd >/dev/null 2>&1 || fail "sops_env_install_cmd helper is missing"
-cmd="$(sops_env_install_cmd)"
-echo "$cmd" | grep -q '/opt/stacks/.env'      || fail "env provision must target /opt/stacks/.env (got: $cmd)"
-echo "$cmd" | grep -qE '0600|install -m 0600' || fail "env provision must enforce mode 0600 (got: $cmd)"
-echo "ok: env provisioning targets /opt/stacks/.env at mode 0600"
-
 # CLI source must wire the decrypted cred into the playbook via cloudflared_credentials_src.
 grep -q 'cloudflared_credentials_src=' "$ROOT/miuops" \
     || fail "CLI must pass -e cloudflared_credentials_src=<decrypted temp> to the playbook"
@@ -217,13 +210,7 @@ t6="$TMP/setu.out"
   sops_encrypt_tunnel_cred no-such-tunnel-id ) >"$t6" 2>&1 || true
 grep -qi 'unbound variable' "$t6"        && fail "sops_encrypt_tunnel_cred dies under set -u (local-order bug)"
 grep -qi 'Tunnel credential not found' "$t6" || fail "sops_encrypt_tunnel_cred didn't reach its precondition: $(cat "$t6")"
-( # provision helper under set -u
-  # shellcheck source=/dev/null
-  source "$ROOT/miuops" --source-only; set +e +o pipefail
-  sops_provision_env no-such-server user@host ) >"$t6" 2>&1 || true
-grep -qi 'unbound variable' "$t6"         && fail "sops_provision_env dies under set -u (local-order bug)"
-grep -qi 'skipping .env provisioning' "$t6" || fail "sops_provision_env didn't reach its skip path: $(cat "$t6")"
-echo "ok: sops helpers are set -u safe (reach own preconditions, never 'unbound variable')"
+echo "ok: sops_encrypt_tunnel_cred is set -u safe (reaches its own precondition, never 'unbound variable')"
 
 # ── 7. leak hygiene: NO per-function RETURN trap (never fires on die/set -e); the
 # cleanup is NOT armed at top level (so sourcing the CLI can't clobber the sourcer's

--- a/tests/stack_env_role_lint_test.sh
+++ b/tests/stack_env_role_lint_test.sh
@@ -1,0 +1,30 @@
+#!/usr/bin/env bash
+# Tripwire for the stack-env role's security-critical properties, so a future edit that
+# weakens the secret handling fails CI. Pure structural assertions over the YAML text --
+# the role is a no-op in the CI converge (no secret present), so nothing else exercises it.
+# The behavioural guarantees (byte-identical, idempotent, fail-closed) are proven by the
+# real-aarch64 e2e at PR time; this catches the realistic regressions.
+set -euo pipefail
+ROOT="$(cd "$(dirname "$0")/.." && pwd)"
+T="$ROOT/roles/stack-env/tasks/main.yml"
+fail() { echo "FAIL: $1"; exit 1; }
+
+# Decryption stays on the CONTROLLER via community.sops (a thin sops wrapper -- no new
+# crypto, age key never leaves the controller); the plaintext is written by `copy`, which
+# is atomic (temp+rename) and idempotent (writes only on change).
+grep -qF "community.sops.sops" "$T" \
+    || fail "must decrypt via community.sops.sops (controller-side; wraps the sops binary)"
+grep -qF "ansible.builtin.copy" "$T" \
+    || fail "must write the .env via ansible.builtin.copy (atomic + idempotent), not a shell write"
+
+# The .env is a secret: 0600 + no_log so the plaintext never lands in logs.
+grep -qF "mode: '0600'" "$T" || fail ".env must be written 0600"
+grep -qF "no_log: true"  "$T" || fail "the secret-bearing task must set no_log: true"
+grep -qF "become: true"  "$T" || fail "tasks must escalate (become: true) to write root-owned /opt/stacks/.env"
+
+# Provision ONLY when the host actually has a secret (a host with none is left untouched),
+# and only when the secrets dir was handed in (fail-closed against an unset path).
+grep -qF "is exists"          "$T" || fail "must provision only when fleet/secrets/<host>.env exists"
+grep -qF "miuops_secrets_dir | length > 0" "$T" || fail "must guard on miuops_secrets_dir being non-empty (a default + length check, fail-closed against an unset/empty path)"
+
+echo "ALL STACK-ENV ROLE LINT CHECKS PASSED"


### PR DESCRIPTION
Automates **sops → `/opt/stacks/.env`** the right way, and **supersedes #110** (the bash-CLI approach).

## Why supersede #110
#110 (bash in the CLI) got two independent reviews that found real bugs: a **silent partial rollout** (a host with a secret but an unresolvable inventory line → `warn`+`continue` → `apply` exits 0), **no aggregate failure status**, a **non-atomic in-place remote write** (truncation window on an SSH drop), and a **fragile inventory parser**. These are exactly what `ansible.builtin.copy` handles natively.

## What this does (approach B)
A dedicated **`stack-env`** role:
- decrypts `fleet/secrets/<host>.env` **on the controller** via `community.sops` (a thin wrapper around the `sops` binary the CLI already uses — **no new crypto**, the age key never leaves the controller);
- writes `/opt/stacks/.env` via `ansible.builtin.copy` → **atomic** (temp+rename), **idempotent** (rewrites *only when the content changes*), `0600`, `no_log`, **fail-closed**;
- a host with no secret is left untouched.

Also: removes the empty-`.env` scaffold from the **traefik** role (provisioning now lives in its own role), wires the role into the playbook, passes `miuops_secrets_dir`, adds `community.sops` to `requirements.yml`, and adds `tests/stack_env_role_lint_test.sh` (tripwire) to CI.

## Verification — real aarch64 hardware (7/7)
`miuops apply <host> --tags stack-env` against a real aarch64 Ubuntu 26.04 VPS (throwaway age key):
```
ok - /opt/stacks/.env BYTE-IDENTICAL to sops -d
ok - 0600
ok - IDEMPOTENT: 2nd apply did NOT rewrite (changed=0 + mtime unchanged)
ok - change propagated (apply pushed the updated secret)
ok - badhost (undecryptable secret) FAILS CLOSED
ok - fail-closed left the good .env intact (no partial/empty)
== 7 passed, 0 failed ==
```
The idempotency case directly answers the "why re-push every time?" concern: it **doesn't** — it writes only on change. yaml + shellcheck + ansible syntax-check clean; lint tripwire green.

## On the dependency
`community.sops` 2.x, from the official `ansible-collections` org (GPL/BSD), shells out to `sops` (its docs: *requires the `sops` executable in PATH*) — so the crypto trust root is unchanged (`sops`); it adds only a small, reviewable invocation wrapper. No known independent third-party audit.