### PR TITLE
feat(backup): install the CI-built age-plugin-yubikey binary (per-arch, sha-pinned)

### DIFF
--- a/roles/backup/README.md
+++ b/roles/backup/README.md
@@ -117,8 +117,10 @@ way they are rendered on the host into `/etc/miuops-backup/backup.env` (mode `06
 root) and sourced by the script, so they never appear in `ps` / the process table.
 
 When `backup_age_recipients` includes a YubiKey identity (`age1yubikey1...`), the
-role installs **age-plugin-yubikey** on the host automatically (pinned `.deb` +
-checksum; amd64 only — `age` cannot encrypt to a plugin recipient without it).
+role installs **age-plugin-yubikey** on the host automatically (a CI-built binary
+from the `age-plugin-yubikey-v<ver>` miuOps release, per-arch for **amd64 + arm64**,
+installed to `/usr/local/bin` and pinned by sha256 — `age` cannot encrypt to a
+plugin recipient without it).
 Encryption uses only the public key, so the host needs no YubiKey and the daily
 backup runs unattended — the YubiKey is required only to *decrypt* at restore
 time, on the operator's machine.

--- a/roles/backup/defaults/main.yml
+++ b/roles/backup/defaults/main.yml
@@ -70,8 +70,8 @@ backup_age_plugin_yubikey_repo: "tianshanghong/miuops"
 # Pin after dispatching the build workflow; read each from the published `.sha256` sidecar
 # (e.g. `gh release download age-plugin-yubikey-v0.5.0 -R tianshanghong/miuops -p '*.sha256' -D -`).
 backup_age_plugin_yubikey_sha256:
-  amd64: ""   # TODO: pin from the CI release (see above)
-  arm64: ""   # TODO: pin from the CI release (see above)
+  amd64: "66eeb1f692b7b5ea5ae4f095a2c77454a167f24ef16170cc7bc5434330d114e5"
+  arm64: "05db8aef927502fbef18f0f542d67b938e44b1d4792ebc24f61d6ba526b20ba9"
 
 # --- AWS credentials --------------------------------------------------------
 # config/secret split. The ACCESS KEY + SECRET are SECRETS: `miuops backup-setup`

--- a/roles/backup/defaults/main.yml
+++ b/roles/backup/defaults/main.yml
@@ -61,14 +61,17 @@ backup_age_recipients: []
 # without it. The role installs it automatically in that case. Encryption uses
 # only the public key, so NO YubiKey is needed on the server (the daily backup
 # runs unattended); the YubiKey is required only to DECRYPT at restore time, on
-# the operator's machine. Pinned to the last release that ships a Linux .deb:
-# v0.5.1 DROPPED the Linux build, and the binary is amd64-only (no arm64 Linux
-# build) -- this release is effectively frozen upstream. For a newer build use a
-# distro package or `cargo install age-plugin-yubikey`. A version bump must change
-# version + deb_revision + sha256 TOGETHER (the .deb filename embeds the revision).
+# the operator's machine. The binary is built in transparent CI for amd64 + arm64
+# (.github/workflows/build-age-plugin-yubikey.yml) and installed on PATH, pinned by sha256
+# below. A version bump must update the version + BOTH per-arch shas together.
 backup_age_plugin_yubikey_version: "0.5.0"
-backup_age_plugin_yubikey_deb_revision: "1"
-backup_age_plugin_yubikey_deb_sha256: "bf7a02418de04b3d3df9791e185d493eb344829bca4009247a41bc4d7630b47f"
+backup_age_plugin_yubikey_repo: "tianshanghong/miuops"
+# Per-arch sha256 of the CI-built binary, from the `age-plugin-yubikey-v<version>` release.
+# Pin after dispatching the build workflow; read each from the published `.sha256` sidecar
+# (e.g. `gh release download age-plugin-yubikey-v0.5.0 -R tianshanghong/miuops -p '*.sha256' -D -`).
+backup_age_plugin_yubikey_sha256:
+  amd64: ""   # TODO: pin from the CI release (see above)
+  arm64: ""   # TODO: pin from the CI release (see above)
 
 # --- AWS credentials --------------------------------------------------------
 # config/secret split. The ACCESS KEY + SECRET are SECRETS: `miuops backup-setup`

--- a/roles/backup/tasks/main.yml
+++ b/roles/backup/tasks/main.yml
@@ -90,28 +90,45 @@
     - backup_encryption == 'age'
     - backup_age_recipients | select('match', '^age1yubikey') | list | length > 0
   tags: ['backup']
+  vars:
+    # miuOps builds the plugin in transparent CI for both arches; the release names binaries by
+    # Debian arch (amd64/arm64), so map the kernel arch (x86_64/aarch64) to it.
+    _apy_arch: "{{ {'x86_64': 'amd64', 'amd64': 'amd64', 'aarch64': 'arm64', 'arm64': 'arm64'}.get(ansible_facts['architecture'], '') }}"
+    _apy_sha: "{{ backup_age_plugin_yubikey_sha256.get(_apy_arch, '') }}"
   block:
-    - name: Assert a prebuilt age-plugin-yubikey exists for this architecture
+    - name: Assert a CI-built age-plugin-yubikey is pinned for this architecture
       ansible.builtin.assert:
-        that: ansible_facts['architecture'] in ['x86_64', 'amd64']
+        that:
+          - _apy_arch in ['amd64', 'arm64']
+          - _apy_sha | length == 64
         fail_msg: >-
-          A YubiKey backup recipient (age1yubikey1...) needs age-plugin-yubikey,
-          which upstream ships for amd64 Linux only (this host is
-          {{ ansible_facts['architecture'] }}). Use a native age recipient, or
-          install age-plugin-yubikey for this architecture yourself.
+          A YubiKey backup recipient (age1yubikey1...) needs age-plugin-yubikey. miuOps builds it
+          in transparent CI for amd64 + arm64; this host is {{ ansible_facts['architecture'] }}
+          (arch '{{ _apy_arch }}'). Pin its sha256 in
+          backup_age_plugin_yubikey_sha256['{{ _apy_arch | default('<arch>') }}'].
         quiet: true
 
-    - name: Download age-plugin-yubikey .deb (pinned + checksum)
-      ansible.builtin.get_url:
-        url: "https://github.com/str4d/age-plugin-yubikey/releases/download/v{{ backup_age_plugin_yubikey_version }}/age-plugin-yubikey_{{ backup_age_plugin_yubikey_version }}-{{ backup_age_plugin_yubikey_deb_revision }}_amd64.deb"
-        dest: "/tmp/age-plugin-yubikey_{{ backup_age_plugin_yubikey_version }}-{{ backup_age_plugin_yubikey_deb_revision }}_amd64.deb"
-        checksum: "sha256:{{ backup_age_plugin_yubikey_deb_sha256 }}"
-        mode: '0644'
-      register: _apy_deb
-
-    - name: Install age-plugin-yubikey (apt resolves the libpcsclite dependency)
+    # The CI binary is dynamically linked against libpcsclite.so.1 (the .deb used to pull this
+    # in). Without it `age` fails when it invokes the plugin -- i.e. at restore time, the worst
+    # moment -- so install it now and verify the plugin runs at deploy time.
+    - name: Ensure libpcsclite1 (age-plugin-yubikey's runtime dependency)
       ansible.builtin.apt:
-        deb: "{{ _apy_deb.dest }}"
+        name: libpcsclite1
+        state: present
+        update_cache: true
+
+    - name: Install age-plugin-yubikey binary (pinned by sha256) on PATH
+      ansible.builtin.get_url:
+        url: "https://github.com/{{ backup_age_plugin_yubikey_repo }}/releases/download/age-plugin-yubikey-v{{ backup_age_plugin_yubikey_version }}/age-plugin-yubikey_{{ backup_age_plugin_yubikey_version }}_{{ _apy_arch }}"
+        dest: /usr/local/bin/age-plugin-yubikey
+        checksum: "sha256:{{ _apy_sha }}"
+        owner: root
+        group: root
+        mode: '0755'
+
+    - name: Verify the plugin runs (fails loudly here at deploy, not at restore time)
+      ansible.builtin.command: age-plugin-yubikey --version
+      changed_when: false
 
 # ---- Config + secrets --------------------------------------------------------
 - name: Create backup config directory

--- a/tests/backup_role_lint_test.sh
+++ b/tests/backup_role_lint_test.sh
@@ -46,8 +46,10 @@ grep -qF "dest: /usr/local/bin/age-plugin-yubikey" "$T" \
     || fail "plugin binary must install to /usr/local/bin/age-plugin-yubikey (on PATH)"
 # root-owned (context-scoped to the get_url task: a bare `grep owner: root` would match any
 # of the other tasks and pass even if this one dropped root ownership).
-awk '/dest: \/usr\/local\/bin\/age-plugin-yubikey/{f=1} f&&/owner:/{print;exit}' "$T" | grep -qF "owner: root" \
-    || fail "plugin binary (get_url) must be owner: root"
+awk '/dest: \/usr\/local\/bin\/age-plugin-yubikey/{f=1}
+     f&&/^[[:space:]]*- name:/{exit 1}
+     f&&/owner:/{print;exit}' "$T" | grep -qF "owner: root" \
+    || fail "plugin binary (get_url) must be owner: root (present + root, before the next task)"
 grep -qF "mode: '0755'" "$T" \
     || fail "plugin binary must be installed executable (0755)"
 grep -qF "name: libpcsclite1" "$T" \

--- a/tests/backup_role_lint_test.sh
+++ b/tests/backup_role_lint_test.sh
@@ -34,22 +34,33 @@ grep -qF "select('match', '^age1yubikey') | list | length > 0" "$T" \
 grep -qF "backup_encryption == 'age'" "$T" \
     || fail "plugin install must be gated on backup_encryption == 'age'"
 
-# Supply chain: the .deb comes from the PINNED upstream repo, is sha256-verified
-# (fail-closed), and the version var is the single source of truth (interpolated
-# into BOTH url and dest -- no drift).
-grep -qF 'https://github.com/str4d/age-plugin-yubikey/releases/download/' "$T" \
-    || fail "plugin .deb must download from the pinned upstream repo (github.com/str4d/age-plugin-yubikey)"
+# Supply chain: the binary comes from the PINNED miuops CI release (transparent CI build,
+# amd64 + arm64), is sha256-verified (fail-closed), and installed executable on PATH.
+grep -qF '/releases/download/age-plugin-yubikey-v' "$T" \
+    || fail "plugin binary must download from the miuops CI release (age-plugin-yubikey-v<ver>)"
+grep -qF "{{ backup_age_plugin_yubikey_repo }}" "$T" \
+    || fail "plugin binary URL must use the pinned repo var (backup_age_plugin_yubikey_repo)"
 grep -qE 'checksum:[[:space:]]*"sha256:' "$T" \
-    || fail "plugin .deb must be sha256-verified"
-ver_uses=$(grep -c 'backup_age_plugin_yubikey_version' "$T" || true)
-[ "${ver_uses:-0}" -ge 2 ] \
-    || fail "url + dest must both interpolate backup_age_plugin_yubikey_version (found ${ver_uses})"
-grep -qE 'backup_age_plugin_yubikey_deb_sha256:[[:space:]]*"[0-9a-f]{64}"' "$D" \
-    || fail "backup_age_plugin_yubikey_deb_sha256 must be a 64-hex sha256"
+    || fail "plugin binary must be sha256-verified"
+grep -qF "dest: /usr/local/bin/age-plugin-yubikey" "$T" \
+    || fail "plugin binary must install to /usr/local/bin/age-plugin-yubikey (on PATH)"
+grep -qF "mode: '0755'" "$T" \
+    || fail "plugin binary must be installed executable (0755)"
+grep -qF "name: libpcsclite1" "$T" \
+    || fail "must install libpcsclite1 (the plugin's runtime .so dependency)"
+grep -qF "age-plugin-yubikey --version" "$T" \
+    || fail "must verify the plugin runs post-install (--version), not at restore time"
 
-# Architecture guard: upstream ships an amd64 Linux build only; a YubiKey
-# recipient on another arch must fail fast, not 404 mid-download.
-grep -qF "'x86_64'" "$T" \
-    || fail "plugin install must assert the host architecture (x86_64)"
+# Architecture: the CI build covers amd64 + arm64; the role maps the kernel arch and must
+# accept aarch64/arm64 (the old amd64-only guard would reject ARM fleet hosts).
+grep -qF "'aarch64': 'arm64'" "$T" \
+    || fail "plugin install must map aarch64 -> arm64 (accept ARM fleet hosts)"
+
+# Per-arch sha256: BOTH arches must be pinned (64-hex), fail-closed. The role asserts the
+# sha is present before download, so a forgotten pin fails fast at apply (not at restore).
+grep -qE 'amd64:[[:space:]]*"[0-9a-f]{64}"' "$D" \
+    || fail "backup_age_plugin_yubikey_sha256.amd64 must be a pinned 64-hex sha256"
+grep -qE 'arm64:[[:space:]]*"[0-9a-f]{64}"' "$D" \
+    || fail "backup_age_plugin_yubikey_sha256.arm64 must be a pinned 64-hex sha256"
 
 echo "ALL BACKUP ROLE LINT CHECKS PASSED"

--- a/tests/backup_role_lint_test.sh
+++ b/tests/backup_role_lint_test.sh
@@ -44,6 +44,10 @@ grep -qE 'checksum:[[:space:]]*"sha256:' "$T" \
     || fail "plugin binary must be sha256-verified"
 grep -qF "dest: /usr/local/bin/age-plugin-yubikey" "$T" \
     || fail "plugin binary must install to /usr/local/bin/age-plugin-yubikey (on PATH)"
+# root-owned (context-scoped to the get_url task: a bare `grep owner: root` would match any
+# of the other tasks and pass even if this one dropped root ownership).
+awk '/dest: \/usr\/local\/bin\/age-plugin-yubikey/{f=1} f&&/owner:/{print;exit}' "$T" | grep -qF "owner: root" \
+    || fail "plugin binary (get_url) must be owner: root"
 grep -qF "mode: '0755'" "$T" \
     || fail "plugin binary must be installed executable (0755)"
 grep -qF "name: libpcsclite1" "$T" \


### PR DESCRIPTION
Consumes the transparent-CI binary from #111 (now merged): the backup role installs the arch-appropriate **age-plugin-yubikey binary** (not the upstream .deb) so YubiKey-encrypted volume backups work on **both amd64 and aarch64** fleet hosts.

## What changed (roles/backup)
- **Per-arch, from our CI release**: map the kernel arch (`x86_64`→amd64, `aarch64`→arm64) and download the sha256-pinned binary from the `age-plugin-yubikey-v<ver>` miuOps release to `/usr/local/bin/age-plugin-yubikey` (0755, on PATH).
- **Accept BOTH arches**: dropped the old amd64-only `assert` that rejected ARM hosts; now asserts a CI-built binary is *pinned* for the host's arch (fail-closed if not).
- **Runtime dependency**: install `libpcsclite1` explicitly (the `.deb` used to pull it in). Without it `age` fails when it invokes the plugin — i.e. at *restore* time.
- **Post-install check**: run `age-plugin-yubikey --version` so a missing dep or bad binary fails at **deploy**, not at restore.
- **Pinned shas** (from the real v0.5.0 CI build, #111): amd64 `66eeb1f6…`, arm64 `05db8aef…`.
- Lint tripwire rewritten for the binary shape (download-from-CI-release, `/usr/local/bin`, 0755, libpcsclite1, post-install `--version`, aarch64→arm64 map, both per-arch shas 64-hex).

## Verification (static; real-aarch64 e2e is the next gate)
- backup role lint **green** (the "not yet pinned" sentinel now passes with real shas).
- stack policy-check **green**; the full existing backup test net intact (bucket_resolve 14, setup_script 17, rotate 12, restore 10, verify 7, …); yaml + ansible syntax clean.

The **real aarch64 backup e2e** (backup role applied → plugin installs, no assert → YubiKey-encrypted backup lands S3 → byte-identical restore) is the acceptance gate; it needs a real aarch64 VPS + AWS auth and runs after merge.