### PR TITLE
fix(stack-env): decrypt .env on the control node so YubiKey-only fleets work

### DIFF
--- a/docs/SOPS_SECRETS.md
+++ b/docs/SOPS_SECRETS.md
@@ -125,9 +125,14 @@ matches.
   `0600` (`no_log`). When that variable is empty the role falls back to the legacy
   plaintext `files/<tunnel_id>.json` for backward compatibility.
 
-- **The app `.env`** — if `fleet/secrets/<server>.env` exists, miuops decrypts it
-  locally and provisions it to the host's `/opt/stacks/.env` at mode `0600`
-  (root). Encrypt one yourself with:
+- **The app `.env`** — if `fleet/secrets/<server>.env` exists, a targeted
+  `apply <server>` decrypts it on the control node (where a TTY exists, so an age
+  YubiKey can prompt for its PIN + touch) to a private `0600` temp and provisions it
+  to the host's `/opt/stacks/.env` at mode `0600` (root, `no_log`). Like
+  `<host>.vars.json`, it is provisioned only for a targeted host — a whole-fleet
+  `apply` (no server) cannot (each YubiKey decrypt needs an interactive PIN + touch),
+  so it skips `.env` and prints a warning telling you to target the host. Encrypt one
+  yourself with:
 
   ```bash
   cp my.env fleet/secrets/<server>.env

--- a/miuops
+++ b/miuops
@@ -355,13 +355,6 @@ run_apply() {
     # miuops apply` from outside the tool checkout still resolves cfg, inventory + host_vars.
     export ANSIBLE_CONFIG="${SCRIPT_DIR}/ansible.cfg"
     local cmd=(ansible-playbook -i "${FLEET_DIR}/inventory.ini" "${SCRIPT_DIR}/playbook.yml")
-    # Pass the secrets dir only when it exists, so a fresh fleet (no fleet/secrets/ yet) is a
-    # clean no-op — the stack-env role's "" default + length guard skip — not a hard failure.
-    if [[ -d "${SECRETS_DIR}" ]]; then
-        # Single-quote the value so a fleet path containing a space is not word-split by
-        # Ansible's key=value extra-vars parser (the role decrypts fleet/secrets/<host>.env).
-        cmd+=(--extra-vars "miuops_secrets_dir='${SECRETS_DIR}'")
-    fi
     [[ -n "$host" ]] && cmd+=(--limit "$host")
     [[ -n "${APPLY_TAGS:-}" ]] && cmd+=(--tags "${APPLY_TAGS}")
 
@@ -379,6 +372,32 @@ run_apply() {
             _SOPS_TMPS+=("$_cred_tmp")   # shredded by the global EXIT/INT/TERM trap, even on die/signal
             cmd+=(-e "cloudflared_credentials_src=${_cred_tmp}")
         fi
+    fi
+
+    # The targeted host's /opt/stacks/.env is provisioned from fleet/secrets/<host>.env.
+    # Decrypt it HERE, on the control node (which has a TTY -- so an age YubiKey can prompt for
+    # PIN + touch, unlike an in-play lookup's TTY-less subprocess), to a private 0600 temp, and
+    # hand the stack-env role the path via stack_env_content_src. The plaintext lives only on
+    # this control node, is shredded on return, and the server just receives the file over SSH.
+    # Per-host, like the tunnel cred: a whole-fleet apply provisions no .env (each YubiKey
+    # decrypt needs an interactive PIN+touch -- target a host). A present-but-undecryptable
+    # secret fails here (fail-closed) before Ansible runs.
+    local _env_tmp=""
+    if [[ -n "$host" && -f "${SECRETS_DIR}/${host}.env" ]]; then
+        require_sops
+        _env_tmp="$(sops_decrypt_to_tmp "${SECRETS_DIR}/${host}.env")"
+        _SOPS_TMPS+=("$_env_tmp")   # shredded by the global EXIT/INT/TERM trap
+        # Single-quote the value: Ansible's key=value extra-vars parser splits on whitespace,
+        # so a TMPDIR-derived temp path containing a space would otherwise mis-parse.
+        cmd+=(-e "stack_env_content_src='${_env_tmp}'")
+    elif [[ -z "$host" ]]; then
+        # A whole-fleet apply cannot provision per-host .env secrets — each YubiKey decrypt
+        # needs an interactive PIN + touch, so N hosts would mean N prompts. Warn rather than
+        # silently skip, so an operator rolling out a rotated secret is told to target the
+        # host (the fail-loud stance the removed controller-side assert used to enforce).
+        local _n_env=0 _envf
+        for _envf in "${SECRETS_DIR}"/*.env; do [[ -e "$_envf" ]] && _n_env=$((_n_env + 1)); done
+        [[ "$_n_env" -gt 0 ]] && warn "${_n_env} host .env secret(s) under ${SECRETS_DIR} not provisioned by a whole-fleet apply — run 'miuops apply <host>' to provision each host's /opt/stacks/.env."
     fi
 
     # Deployed secrets (SOPS-in-fleet): decrypt the fleet-wide secrets (all.vars.json --

--- a/requirements.yml
+++ b/requirements.yml
@@ -6,7 +6,3 @@ collections:
     version: ">=6.0.0" 
   - name: ansible.posix
     version: ">=1.6.0"
-  # Used by the stack-env role to decrypt fleet/secrets/<host>.env on the controller
-  # (a thin wrapper around the `sops` binary -- no new crypto).
-  - name: community.sops
-    version: ">=2.0.0"

--- a/roles/stack-env/defaults/main.yml
+++ b/roles/stack-env/defaults/main.yml
@@ -1,6 +1,8 @@
 ---
-# Absolute path to the fleet's secrets dir on the controller; `miuops apply` passes it via
-# --extra-vars. Empty by default so a non-CLI playbook run (e.g. CI's bare ansible-playbook)
-# is a clean no-op rather than a template error -- and a wrong/relative value fails loud via
-# the controller-side assert in tasks/main.yml, never a silent fleet-wide skip.
-miuops_secrets_dir: ""
+# Absolute path, on the controller, to the ALREADY-DECRYPTED /opt/stacks/.env plaintext.
+# `miuops apply` decrypts fleet/secrets/<host>.env on the control node (where a TTY exists, so
+# an age YubiKey can prompt for PIN + touch) to a private 0600 temp and passes that path here
+# via --extra-vars. Empty by default so a non-CLI playbook run (e.g. CI's bare
+# ansible-playbook) or a host with no secret is a clean no-op -- the provision task's length
+# guard skips and the empty placeholder .env is left in place, never an empty/rogue write.
+stack_env_content_src: ""

--- a/roles/stack-env/tasks/main.yml
+++ b/roles/stack-env/tasks/main.yml
@@ -1,14 +1,13 @@
 ---
 # Provision the host's /opt/stacks/.env from the fleet's sops-encrypted secret.
 #
-# Decryption happens on the CONTROLLER (community.sops wraps the `sops` binary the CLI
-# already uses -- no new crypto, the age key never leaves the controller). The plaintext is
-# written by `copy`: ATOMIC (temp+rename), IDEMPOTENT (writes only on change), 0600, no_log.
-#
-# The secret is keyed by inventory_hostname, which IS the fleet handle: inventory_upsert
-# writes `<handle> ansible_host=...`, so the inventory key == the handle == the host_vars
-# and secret filename. A host with no secret keeps the empty placeholder below; a
-# present-but-undecryptable secret fails the play (fail-closed).
+# Decryption does NOT happen here. `miuops apply` decrypts fleet/secrets/<host>.env on the
+# CONTROL NODE -- where a TTY exists, so an age YubiKey can prompt for its PIN + touch, which
+# an in-play lookup's TTY-less subprocess cannot -- to a private 0600 temp, and hands this role
+# the path via stack_env_content_src. This task just COPIES that plaintext to the host:
+# ATOMIC (temp+rename), IDEMPOTENT (writes only on checksum change -> byte-identical), 0600,
+# no_log. A present-but-undecryptable secret already fails the CLI (fail-closed) before Ansible
+# runs; a host with no secret gets nothing (the length guard skips) and keeps the placeholder.
 - name: Ensure /opt/stacks exists
   ansible.builtin.file:
     path: /opt/stacks
@@ -32,37 +31,14 @@
   become: true
   tags: ['stack-env']
 
-# A named-but-wrong secrets dir, or a missing `sops`, must fail LOUD on the controller --
-# not skip the whole fleet silently and not surface as a redacted no_log error. Both checks
-# are controller-side and run once per play.
-- name: Verify the fleet secrets dir + sops are usable on the controller
-  delegate_to: localhost
-  run_once: true
-  become: false   # controller-side checks; become here would try to sudo on the control node
-  when: miuops_secrets_dir | length > 0
-  tags: ['stack-env']
-  block:
-    - name: Assert miuops_secrets_dir exists
-      ansible.builtin.assert:
-        that: miuops_secrets_dir is exists
-        fail_msg: "miuops_secrets_dir='{{ miuops_secrets_dir }}' does not exist on the controller"
-        quiet: true
-    - name: Assert the sops binary is available (community.sops shells out to it)
-      ansible.builtin.command: sops --version
-      changed_when: false
-
 - name: Provision /opt/stacks/.env from the fleet secret
   ansible.builtin.copy:
-    content: "{{ lookup('community.sops.sops', _stack_env_secret) }}"
+    src: "{{ stack_env_content_src }}"
     dest: /opt/stacks/.env
     owner: root
     group: root
     mode: '0600'
-  vars:
-    _stack_env_secret: "{{ miuops_secrets_dir }}/{{ inventory_hostname }}.env"
-  when:
-    - miuops_secrets_dir | length > 0
-    - _stack_env_secret is exists
+  when: stack_env_content_src | length > 0
   become: true
   no_log: true
   tags: ['stack-env']

--- a/tests/cli_test.sh
+++ b/tests/cli_test.sh
@@ -81,8 +81,8 @@ grep -qF '"${ssh_user}@${ssh_host}" true' "$ROOT/miuops"         || fail "the SS
 grep -qF '"$owner" != "$handle"' "$ROOT/miuops"                  || fail "domain-owner check must compare to the handle"
 grep -qF 'hv_tunnel "$handle"' "$ROOT/miuops"                    || fail "tunnel reuse must look up the handle"
 grep -qF 'hv_domains "$handle"' "$ROOT/miuops"                   || fail "domain merge must look up the handle"
-grep -qF 'miuops_secrets_dir=' "$ROOT/miuops"                    || fail "apply/up must pass miuops_secrets_dir so the stack-env role provisions /opt/stacks/.env"
-grep -qF 'if [[ -d "${SECRETS_DIR}" ]]; then' "$ROOT/miuops"     || fail "miuops_secrets_dir must be passed only when fleet/secrets/ exists (fresh fleet = clean no-op, not an assert failure)"
+grep -qF 'stack_env_content_src=' "$ROOT/miuops"                 || fail "apply/up must pass the CLI-decrypted path via stack_env_content_src so the stack-env role provisions /opt/stacks/.env (decrypt runs on the control node WITH a TTY, so an age YubiKey can prompt for PIN+touch)"
+grep -qF '${SECRETS_DIR}/${host}.env' "$ROOT/miuops"             || fail "stack-env .env must be decrypted only when the targeted host has a fleet/secrets/<host>.env (a host with none / fresh fleet = clean no-op)"
 
 # --- Task 8: apply targets --limit; --no-apply skips converge ---
 out="$(cd "$ROOT" && ./miuops apply --dry-run server-a 2>&1 || true)"

--- a/tests/sops_test.sh
+++ b/tests/sops_test.sh
@@ -180,6 +180,43 @@ printf '%s' "$u6tags" | grep -q -- '--tags observability,backup' \
     || fail "apply must parse --tags through to the converge (got: $u6tags)"
 echo "ok: apply --tags passthrough reaches the converge cmd"
 
+# ── 4c. stack-env: run_apply decrypts fleet/secrets/<host>.env on the CONTROL NODE (where a
+# TTY exists, so an age YubiKey can prompt for PIN+touch) and wires the plaintext temp into
+# the stack-env role via -e stack_env_content_src=<tmp>. This is the exact path an in-play
+# community.sops lookup could NOT serve on a YubiKey-only fleet (no TTY in the subprocess).
+# Behavioral, not a string tripwire: it SOPS-encrypts a real .env and drives run_apply. ─────
+printf 'APP_SECRET=s3cr3t-u6\nDB_URL=postgres://u:p@h/db\n' > "$TMP/fleet/secrets/u6host.env"
+( cd "$TMP" && sops --encrypt --input-type dotenv --output-type dotenv --in-place "fleet/secrets/u6host.env" ) \
+    || fail "could not SOPS-encrypt the stack-env .env"
+# (b)+(c): the CLI primitive decrypts <host>.env to a 0600 temp with the exact values.
+# shellcheck disable=SC1090
+envplain="$( source "$ROOT/miuops" --source-only; sops_decrypt_to_tmp "${MIUOPS_FLEET_DIR}/secrets/u6host.env" )" \
+    || fail "sops_decrypt_to_tmp failed on a valid encrypted .env"
+grep -q '^APP_SECRET=s3cr3t-u6$'          "$envplain" || fail "decrypted .env lost APP_SECRET"
+grep -q '^DB_URL=postgres://u:p@h/db$'    "$envplain" || fail "decrypted .env lost DB_URL"
+envperm="$(stat -c '%a' "$envplain" 2>/dev/null || stat -f '%Lp' "$envplain")"
+[ "$envperm" = "600" ] || fail ".env decrypt temp not 0600 (got $envperm)"
+rm -f "$envplain"
+# (a) WIRING: a targeted apply with a present <host>.env passes -e stack_env_content_src=<tmp>
+# (the value is single-quoted, so match an optional quote before the leading /).
+# shellcheck disable=SC1090
+envout="$( source "$ROOT/miuops" --source-only; DRY_RUN=true APPLY_TAGS="" run_apply u6host 2>&1 )" \
+    || fail "run_apply dry-run failed with a stack-env .env present"
+printf '%s' "$envout" | grep -qE "stack_env_content_src='?/" \
+    || fail "run_apply must pass -e stack_env_content_src=<tmp> when fleet/secrets/<host>.env exists: $envout"
+echo "ok: run_apply wires <host>.env into stack_env_content_src (control-node decrypt)"
+# (d) NEGATIVE: a whole-fleet apply (no host) provisions no per-host .env and WARNS rather
+# than silently skipping — the operational gap the security review flagged.
+# shellcheck disable=SC1090
+fleetout="$( source "$ROOT/miuops" --source-only; DRY_RUN=true APPLY_TAGS="" run_apply 2>&1 )" \
+    || fail "run_apply dry-run (whole fleet) failed"
+if printf '%s' "$fleetout" | grep -q 'stack_env_content_src='; then
+    fail "a whole-fleet apply must NOT wire any per-host stack_env_content_src: $fleetout"
+fi
+printf '%s' "$fleetout" | grep -qi 'not provisioned' \
+    || fail "a whole-fleet apply with .env secrets present must WARN, not silently skip: $fleetout"
+echo "ok: whole-fleet apply skips per-host .env and warns (no silent omission)"
+
 # ── 5. cloudflared role consumes a local decrypted source, legacy fallback ───
 ROLE="$ROOT/roles/cloudflared/tasks/main.yml"
 DEFAULTS="$ROOT/roles/cloudflared/defaults/main.yml"

--- a/tests/stack_env_role_lint_test.sh
+++ b/tests/stack_env_role_lint_test.sh
@@ -9,22 +9,30 @@ ROOT="$(cd "$(dirname "$0")/.." && pwd)"
 T="$ROOT/roles/stack-env/tasks/main.yml"
 fail() { echo "FAIL: $1"; exit 1; }
 
-# Decryption stays on the CONTROLLER via community.sops (a thin sops wrapper -- no new
-# crypto, age key never leaves the controller); the plaintext is written by `copy`, which
-# is atomic (temp+rename) and idempotent (writes only on change).
-grep -qF "community.sops.sops" "$T" \
-    || fail "must decrypt via community.sops.sops (controller-side; wraps the sops binary)"
+# Decryption must NOT happen in-play. A community.sops lookup runs in a TTY-less subprocess
+# that cannot obtain an age YubiKey's PIN, so it fails fail-closed on a YubiKey-only fleet.
+# The miuops CLI decrypts on the control node (with a TTY) and passes the plaintext path;
+# this task only copies it. Fail if a future edit reintroduces in-play decryption.
+if grep -qF "community.sops" "$T"; then
+    fail "the role must NOT decrypt in-play (community.sops) -- a TTY-less lookup cannot get a YubiKey PIN; the CLI decrypts with a TTY and passes stack_env_content_src"
+fi
+
+# The .env is written from the CLI-decrypted plaintext (a controller-local path in
+# stack_env_content_src) via copy: atomic (temp+rename) + idempotent (writes only on change).
 grep -qF "ansible.builtin.copy" "$T" \
     || fail "must write the .env via ansible.builtin.copy (atomic + idempotent), not a shell write"
+grep -qE 'src:[[:space:]]+"\{\{[[:space:]]*stack_env_content_src' "$T" \
+    || fail "the provision task must copy FROM stack_env_content_src (src:), i.e. the CLI-decrypted path, not an in-play lookup"
 
 # The .env is a secret: 0600 + no_log so the plaintext never lands in logs.
 grep -qF "mode: '0600'" "$T" || fail ".env must be written 0600"
 grep -qF "no_log: true"  "$T" || fail "the secret-bearing task must set no_log: true"
 grep -qF "become: true"  "$T" || fail "tasks must escalate (become: true) to write root-owned /opt/stacks/.env"
 
-# Provision ONLY when the host actually has a secret (a host with none is left untouched),
-# and only when the secrets dir was handed in (fail-closed against an unset path).
-grep -qF "is exists"          "$T" || fail "must provision only when fleet/secrets/<host>.env exists"
-grep -qF "miuops_secrets_dir | length > 0" "$T" || fail "must guard on miuops_secrets_dir being non-empty (a default + length check, fail-closed against an unset/empty path)"
+# Provision ONLY when the CLI handed in a decrypted path. A host with no secret, or a
+# whole-fleet apply, passes nothing -> the guard skips and the empty placeholder is kept
+# (never an empty/rogue .env write). Fail-closed against an unset/empty path.
+grep -qF "stack_env_content_src | length > 0" "$T" \
+    || fail "must guard on stack_env_content_src being non-empty (fail-closed against an unset/empty path)"
 
 echo "ALL STACK-ENV ROLE LINT CHECKS PASSED"


### PR DESCRIPTION
## Problem
The `stack-env` role decrypted the per-server `.env` (`fleet/secrets/<host>.env`) in-play via a `community.sops` lookup. That lookup runs in a TTY-less subprocess, so a PIN-protected age YubiKey can't prompt for its PIN — `miuops apply` fails closed on any YubiKey-only fleet. `.env` was the last secret still decrypted in-play; the tunnel credential, `all.vars.json` and `<host>.vars.json` already decrypt on the control node.

## Change
Move the `.env` decrypt into `miuops apply`, mirroring the existing tunnel-credential path:
- Decrypt `fleet/secrets/<host>.env` to a private `0600` temp on the control node (which has a TTY, so the YubiKey can prompt for PIN + touch), registered for shredding by the existing EXIT/INT/TERM trap.
- Pass the path to the role via `stack_env_content_src`; the role now just `copy`s that plaintext — atomic + idempotent (byte-identical), `0600`, `no_log`.
- A present-but-undecryptable secret fails the CLI before Ansible runs (fail-closed); a host with no secret keeps the empty placeholder.
- `.env` is provisioned only for a targeted `apply <host>` (each YubiKey decrypt needs an interactive PIN + touch). A whole-fleet apply warns instead of silently skipping.
- `community.sops` was used only by this in-play lookup → dropped from `requirements.yml`. The role-lint tripwire now fails if in-play decryption is reintroduced.

The GitOps SSH-push deploy path is unaffected — it already excludes `*.env` and treats `.env` as host-provisioned.

## Tests
- `tests/sops_test.sh` gains a behavioral round-trip: SOPS-encrypt a real `.env`, drive `run_apply`, assert it wires `-e stack_env_content_src=<tmp>` for a targeted host and warns + wires nothing for a whole-fleet apply. Proven able to fail via a negative control.
- Existing static tripwires updated (`tests/stack_env_role_lint_test.sh`, `tests/cli_test.sh`).
- Verified end-to-end on aarch64 with a hardware YubiKey: `apply` provisions `/opt/stacks/.env` byte-identical to `sops -d`, idempotent on re-apply.
