### PR TITLE
feat(deploy): manual redeploy dispatch (force-recreate + server/stack targeting)

### DIFF
--- a/.github/scripts/deploy-server.sh
+++ b/.github/scripts/deploy-server.sh
@@ -13,6 +13,11 @@
 #                      is strict — no MITM window. When absent: accept-new TOFU).
 #   STACKS_DIR         repo path prefix for stacks (default fleet/stacks).
 #   REMOTE_STACKS_DIR  destination on the server (default /opt/stacks).
+#   ONLY_STACK         (manual dispatch) bring up only this stack dir within the
+#                      server; blank = every stack. Validated like SERVER.
+#   FORCE_RECREATE     (manual dispatch) "true" adds `--force-recreate` to
+#                      `docker compose up` so a container is recreated even when
+#                      its image + config are unchanged (re-runs its entrypoint).
 #
 # By design the rsync excludes .env and any *.env: every *.env is treated as a
 # host-provisioned secret (the shared app env is decrypted + placed at setup,
@@ -36,14 +41,35 @@ NAME_RE='^[A-Za-z0-9][A-Za-z0-9._-]*$'
 SERVER="${SERVER:?SERVER is required}"
 [[ "$SERVER" =~ $NAME_RE ]] || err "Refusing to deploy: invalid server name '${SERVER}'"
 
+# Optional manual-dispatch targeting (both empty on a normal push deploy).
+# ONLY_STACK is operator-controlled, so it is validated with the same allowlist
+# as SERVER and only ever compared as data (never concatenated into a command).
+# FORCE_RECREATE is constrained to the two literals it is later tested against.
+ONLY_STACK="${ONLY_STACK:-}"
+if [ -n "$ONLY_STACK" ]; then
+  case "$ONLY_STACK" in .|..) err "Refusing to deploy: invalid stack name '${ONLY_STACK}'";; esac
+  [[ "$ONLY_STACK" =~ $NAME_RE ]] || err "Refusing to deploy: invalid stack name '${ONLY_STACK}'"
+fi
+case "${FORCE_RECREATE:=false}" in true|false) ;; *) err "FORCE_RECREATE must be 'true' or 'false', got '${FORCE_RECREATE}'";; esac
+
 # A server with no stack directory is a clean skip (exit 0) -- check this BEFORE
 # the SSH secrets, so a server removed from the fleet (or one whose Environment
 # has no secrets) is a no-op, not a "No SSH_HOST" failure. discover lists every
 # changed server including deletions, so a removed stack dir would otherwise red
-# the run with a misleading secrets error.
+# the run with a misleading secrets error. EXCEPTION: a targeted single-stack
+# dispatch (ONLY_STACK set) to a serverless server is an operator error, not a
+# removed-server skip -- fail loudly.
 STACKS_DIR="${STACKS_DIR:-fleet/stacks}"; STACKS_DIR="${STACKS_DIR%/}"
 src="${GITHUB_WORKSPACE:-.}/${STACKS_DIR}/${SERVER}"
-[ -d "$src" ] || { note "No stacks for '${SERVER}' (${STACKS_DIR}/${SERVER} absent) — nothing to deploy."; exit 0; }
+if [ ! -d "$src" ]; then
+  [ -z "$ONLY_STACK" ] || err "Cannot target stack '${ONLY_STACK}': server '${SERVER}' has no stacks (${STACKS_DIR}/${SERVER} absent)."
+  note "No stacks for '${SERVER}' (${STACKS_DIR}/${SERVER} absent) — nothing to deploy."; exit 0
+fi
+# A targeted single-stack dispatch must name a stack that exists in the repo; fail
+# fast (before SSH / any host action) rather than syncing nothing and exiting green.
+if [ -n "$ONLY_STACK" ] && [ ! -d "${src}/${ONLY_STACK}" ]; then
+  err "Requested stack '${ONLY_STACK}' does not exist under ${STACKS_DIR}/${SERVER} in the repo."
+fi
 
 # Fail fast on missing secrets BEFORE any network action, naming the server. A
 # typo'd Environment resolves to empty secrets (no cross-server fallback exists),
@@ -81,17 +107,28 @@ note "Deploying '${SERVER}' -> ${dest}:${REMOTE_STACKS_DIR}"
 # Sync this server's stacks to /opt/stacks. --delete prunes removed stacks; the
 # shared, host-provisioned app env (.env or any *.env) is excluded so it is
 # neither shipped from the repo nor deleted on the host (the exclude is
-# unanchored, so it protects matching files at every depth).
+# unanchored, so it protects matching files at every depth). A targeted
+# single-stack dispatch syncs ONLY that stack's subdir (into its own dest subdir),
+# so top-level --delete can never prune a repo-removed sibling's files while its
+# teardown is skipped -- a targeted redeploy touches nothing but the named stack.
+if [ -n "$ONLY_STACK" ]; then
+  rsync_src="${src}/${ONLY_STACK}/"; rsync_dest="${dest}:${REMOTE_STACKS_DIR}/${ONLY_STACK}/"
+else
+  rsync_src="${src}/"; rsync_dest="${dest}:${REMOTE_STACKS_DIR}/"
+fi
 rsync -rlptz --delete --exclude='.env' --exclude='*.env' \
   -e "ssh ${ssh_opts[*]}" \
-  "${src}/" "${dest}:${REMOTE_STACKS_DIR}/"
+  "$rsync_src" "$rsync_dest"
 
 # Bring up each stack on the host using the shared host-provisioned .env, then
-# tear down stacks whose directory was removed. REMOTE_STACKS_DIR is an
-# operator-trusted input; it is passed as a positional arg to the remote shell.
-ssh "${ssh_opts[@]}" "$dest" bash -s -- "$REMOTE_STACKS_DIR" <<'REMOTE'
+# tear down stacks whose directory was removed. The remote heredoc is quoted (no
+# local expansion), so operator-trusted values are passed as positional args:
+# $1 remote dir, $2 force-recreate flag, $3 target stack (blank = all).
+ssh "${ssh_opts[@]}" "$dest" bash -s -- "$REMOTE_STACKS_DIR" "$FORCE_RECREATE" "$ONLY_STACK" <<'REMOTE'
 set -euo pipefail
 REMOTE_DIR="${1:?remote stacks dir}"
+FORCE_RECREATE="${2:-false}"
+ONLY_STACK="${3:-}"
 cd "$REMOTE_DIR"
 
 # --env-file only if a shared .env exists (provisioned at setup, not by deploy).
@@ -120,19 +157,42 @@ fi
 # (compose.yaml / compose.yml / docker-compose.yaml / docker-compose.yml), and
 # the project name defaults to the (normalized) directory basename -- the same
 # name the teardown below compares against.
+stack_matched=0
 for stack in */; do
   stack="${stack%/}"
+  # Targeted manual dispatch: skip every stack except the requested one.
+  [ -z "$ONLY_STACK" ] || [ "$stack" = "$ONLY_STACK" ] || continue
   ( cd "$stack" && docker compose "${compose_env[@]}" config -q ) 2>/dev/null || continue
+  stack_matched=1   # count only a present AND valid compose project as "matched"
   echo "==> up ${stack}"
-  ( cd "$stack" && docker compose "${compose_env[@]}" up -d --pull always --remove-orphans )
+  up_args=(-d --pull always --remove-orphans)
+  # --force-recreate replaces the container even when image + config are
+  # unchanged, so the entrypoint re-runs (needed to restart a service whose fix
+  # lives in a repo it clones/installs at startup, not in its image).
+  [ "$FORCE_RECREATE" = true ] && up_args+=(--force-recreate)
+  ( cd "$stack" && docker compose "${compose_env[@]}" up "${up_args[@]}" )
 done
+
+# A single-stack dispatch that matched NO directory on this server is an operator
+# error (typo / wrong server), not a success -- fail loudly rather than exit green
+# having done nothing. (Empty ONLY_STACK -> stack_matched is set for every dir.)
+if [ -n "$ONLY_STACK" ] && [ "$stack_matched" -eq 0 ]; then
+  echo "::error::requested stack '${ONLY_STACK}' not found or not a valid compose project under ${REMOTE_DIR} on this server"
+  exit 1
+fi
 
 # Tear down stacks whose directory was removed: compare running compose projects
 # (rooted under this dir) against the present directories, normalizing each dir
 # name the way Compose derives a project name (lowercase; drop chars outside
 # [a-z0-9_-]; trim leading separators) so a still-present stack is never flagged.
 # Enumeration is best-effort: a missing python3 (or any error) skips pruning --
-# the deploy already applied -- rather than failing it.
+# the deploy already applied -- rather than failing it. A single-stack manual
+# dispatch (ONLY_STACK set) skips teardown entirely: it must never prune the
+# sibling stacks it was told not to touch. (The `else` body keeps column-0
+# indentation so the <<EOF terminator below stays valid.)
+if [ -n "$ONLY_STACK" ]; then
+  echo "==> single-stack dispatch (${ONLY_STACK}); skipping removed-stack teardown"
+else
 teardown_rc=0
 if removed="$(docker compose ls --format json 2>/dev/null | python3 -c '
 import json, os, re, sys
@@ -158,4 +218,5 @@ else
   echo "::warning::Skipped teardown of removed stacks (could not enumerate running projects; is python3 present?)"
 fi
 [ "$teardown_rc" -eq 0 ] || { echo "::error::one or more removed stacks failed to tear down"; exit 1; }
+fi
 REMOTE

--- a/.github/scripts/discover-changed-servers.sh
+++ b/.github/scripts/discover-changed-servers.sh
@@ -45,6 +45,32 @@ ZERO_SHA="0000000000000000000000000000000000000000"
 # (path traversal). This mirrors the CLI's valid_host_alias allowlist.
 NAME_RE='^[A-Za-z0-9][A-Za-z0-9._-]*$'
 
+# --- Manual dispatch override: deploy exactly one named server -------------
+# When ONLY_SERVER is set (a workflow_dispatch input), bypass the git-diff
+# discovery and emit just that one server. It is operator-controlled, so it is
+# held to the same allowlist as a diff-derived name; an invalid value yields []
+# (a fail-safe skip, exactly like the diff path) so a crafted string can never
+# widen the matrix or reach ssh/rsync as anything but an inert JSON string.
+if [ -n "${ONLY_SERVER:-}" ]; then
+  case "$ONLY_SERVER" in
+    .|..) printf '[]\n'; exit 0 ;;
+  esac
+  if [[ "$ONLY_SERVER" =~ $NAME_RE ]]; then
+    # A targeted dispatch to a server with no stack dir is an operator typo, not a
+    # silent whole-run no-op: fail loudly when the checkout is visible. STACKS_DIR
+    # already carries a trailing slash here. Unit tests run without a workspace, so
+    # the check is skipped there and the override/whole-fleet semantics are intact.
+    if [ -n "${GITHUB_WORKSPACE:-}" ] && [ ! -d "${GITHUB_WORKSPACE}/${STACKS_DIR}${ONLY_SERVER}" ]; then
+      printf '::error::only_server %s has no stacks under %s -- check the name.\n' "$ONLY_SERVER" "${STACKS_DIR%/}" >&2
+      exit 1
+    fi
+    jq -cn '$ARGS.positional' --args "$ONLY_SERVER"
+  else
+    printf '[]\n'
+  fi
+  exit 0
+fi
+
 # --- Layer 1: resolve the list of changed paths for this push --------------
 changed_paths() {
   if [ -n "${MIUOPS_CHANGED_PATHS_FILE:-}" ]; then

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -25,7 +25,7 @@ jobs:
           command -v shellcheck >/dev/null 2>&1 || { sudo apt-get update -qq && sudo apt-get install -y shellcheck >/dev/null; }
           shellcheck -S error miuops tests/stack_policy_check_test.sh \
             .github/scripts/discover-changed-servers.sh .github/scripts/deploy-server.sh \
-            tests/ssh_deploy_key_validation_test.sh tests/deploy_server_skip_test.sh \
+            tests/ssh_deploy_key_validation_test.sh tests/deploy_server_skip_test.sh tests/deploy_remote_loop_test.sh \
             scripts/test/iam-policy-check.sh scripts/setup-s3-backup.sh \
             tests/sops_test.sh tests/setup_s3_backup_noninteractive_test.sh \
             tests/backup_role_lint_test.sh tests/script_dir_resolution_test.sh \
@@ -57,6 +57,7 @@ jobs:
           bash tests/discover_changed_servers_test.sh
           bash tests/deploy_workflow_lint_test.sh
           bash tests/deploy_server_skip_test.sh
+          bash tests/deploy_remote_loop_test.sh
           bash tests/backup_role_lint_test.sh
           bash tests/observability_role_lint_test.sh
           bash tests/stack_env_role_lint_test.sh

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -8,6 +8,11 @@ name: Deploy fleet stacks
 #   on:
 #     push:
 #       branches: [main]
+#     workflow_dispatch:          # manual "redeploy / restart" button (optional)
+#       inputs:
+#         server:         { type: string,  default: "" }   # blank = whole fleet on dispatch
+#         stack:          { type: string,  default: "" }   # blank = all its stacks
+#         force_recreate: { type: boolean, default: false }
 #   jobs:
 #     deploy:
 #       # Pin to an immutable ref. This workflow handles per-server SSH keys, so a
@@ -20,6 +25,12 @@ name: Deploy fleet stacks
 #         # workflow. (A reusable workflow can't read its own @ref at run time --
 #         # github.job_workflow_ref is empty on current runners -- so it's passed.)
 #         miuops_ref: v1
+#         # Passthrough is inert on push (github.event.inputs.* are null there,
+#         # so strings resolve to "" and the boolean to false) and only takes
+#         # effect on a manual dispatch:
+#         only_server:    ${{ github.event.inputs.server }}
+#         only_stack:     ${{ github.event.inputs.stack }}
+#         force_recreate: ${{ github.event.inputs.force_recreate == 'true' }}
 #       secrets: inherit
 #
 # Per-server secret isolation: each changed server gets its own matrix job with a
@@ -57,6 +68,28 @@ on:
         type: string
         required: false
         default: /opt/stacks
+      only_server:
+        description: >-
+          Manual dispatch: deploy ONLY this server, bypassing git-diff discovery.
+          Blank (the default, and every push) = normal diff-based discovery.
+        type: string
+        required: false
+        default: ""
+      only_stack:
+        description: >-
+          Manual dispatch: within the targeted server, bring up ONLY this stack
+          directory (requires only_server). Blank = every stack on the server.
+        type: string
+        required: false
+        default: ""
+      force_recreate:
+        description: >-
+          Manual dispatch: pass --force-recreate to `docker compose up`, so a
+          container is recreated even when its image + config are unchanged
+          (re-runs its entrypoint). Blank/false on every push.
+        type: boolean
+        required: false
+        default: false
 
 # Least privilege: read the fleet repo and SSH out. Never write back to the repo.
 permissions:
@@ -76,6 +109,19 @@ jobs:
     outputs:
       servers: ${{ steps.scan.outputs.servers }}
     steps:
+      # Safety rail for the manual dispatch: force_recreate AND only_stack are
+      # both targeted ops. Without only_server, discovery falls back to "all
+      # present stacks" (a dispatch has no diff base), so either one unguarded
+      # would fan across every server at once -- a force_recreate mass-recreate,
+      # or an only_stack redeploy + fleet-wide teardown suppression. Require a
+      # target server for both. Inert on push (both are empty/false there), so
+      # the normal diff-based deploy is unaffected.
+      - name: Guard — force_recreate / only_stack require a target server
+        if: ${{ (inputs.force_recreate || inputs.only_stack != '') && inputs.only_server == '' }}
+        run: |
+          echo "::error::force_recreate or only_stack requires 'only_server' (refusing to fan a targeted redeploy across every server)."
+          exit 1
+
       # fetch-depth: 0 -> full history so a before..after diff is correct for any
       # pushed range (the default depth-1 checkout lacks the base commit).
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
@@ -103,6 +149,10 @@ jobs:
           BEFORE: ${{ github.event.before }}
           AFTER: ${{ github.sha }}
           STACKS_DIR: ${{ inputs.stacks_dir }}
+          # Manual dispatch: when set, the script emits only this server and
+          # ignores the diff. Passed via env (never a run: string) and validated
+          # against the server-name allowlist inside the script.
+          ONLY_SERVER: ${{ inputs.only_server }}
         run: |
           set -euo pipefail
           servers="$(bash "${GITHUB_WORKSPACE}/.miuops-machinery/.github/scripts/discover-changed-servers.sh")"
@@ -155,4 +205,9 @@ jobs:
           SERVER: ${{ matrix.server }}
           STACKS_DIR: ${{ inputs.stacks_dir }}
           REMOTE_STACKS_DIR: ${{ inputs.remote_stacks_dir }}
+          # Manual-dispatch targeting: both empty/false on a normal push. ONLY_STACK
+          # is re-validated against the name allowlist in the script; FORCE_RECREATE
+          # is constrained to true|false. Passed via env, never a run: string.
+          ONLY_STACK: ${{ inputs.only_stack }}
+          FORCE_RECREATE: ${{ inputs.force_recreate }}
         run: bash "${GITHUB_WORKSPACE}/.miuops-machinery/.github/scripts/deploy-server.sh"

--- a/tests/deploy_remote_loop_test.sh
+++ b/tests/deploy_remote_loop_test.sh
@@ -1,0 +1,92 @@
+#!/usr/bin/env bash
+# Empirically exercise the REMOTE half of deploy-server.sh -- the `<<'REMOTE'`
+# heredoc that runs on the host over SSH -- which the other offline tests can't
+# reach. We extract that body verbatim, run it with a stubbed `docker` against
+# fake stack dirs, and assert the ACTUAL compose commands it issues for each
+# (FORCE_RECREATE, ONLY_STACK) combination. No SSH, no real docker, no imagined
+# output: every assertion reads what the code actually did (a recorded log / rc).
+set -euo pipefail
+ROOT="$(cd "$(dirname "$0")/.." && pwd)"
+DS="$ROOT/.github/scripts/deploy-server.sh"
+fail() { echo "FAIL: $1"; exit 1; }
+
+TMP="$(mktemp -d)"; trap 'rm -rf "$TMP"' EXIT
+
+# Extract the remote heredoc body verbatim (between the `<<'REMOTE'` opener and
+# the column-0 `REMOTE` terminator) -- this is exactly what ssh feeds to bash.
+BODY="$TMP/remote-body.sh"
+awk "/<<'REMOTE'/{f=1;next} /^REMOTE\$/{f=0} f" "$DS" > "$BODY"
+[ -s "$BODY" ] || fail "could not extract the remote heredoc body from deploy-server.sh"
+
+# Stubbed docker on PATH: records `compose up` invocations, satisfies `config -q`
+# and `ls`, so the body runs end-to-end without a daemon.
+bin="$TMP/bin"; mkdir -p "$bin"
+cat > "$bin/docker" <<STUB
+#!/usr/bin/env bash
+[ "\$1" = compose ] || exit 0
+shift
+for a in "\$@"; do
+  case "\$a" in
+    config) [ "\$(basename "\$PWD")" = broken ] && exit 2; exit 0 ;;  # 'broken' = invalid compose
+    up)     printf 'UP %s %s\n' "\$(basename "\$PWD")" "\$*" >> "\$STUB_LOG"; exit 0 ;;  # stack = cwd basename
+    ls)     printf '[]\n'; exit 0 ;;                   # no running projects -> no teardown
+    down)   printf 'DOWN %s\n' "\$*" >> "\$STUB_LOG"; exit 0 ;;
+  esac
+done
+exit 0
+STUB
+chmod +x "$bin/docker"
+
+# A remote dir with two stacks (no .env, so no --env-file / registry-login path).
+mkremote() {
+  local d; d="$(mktemp -d)"
+  mkdir -p "$d/app" "$d/web" "$d/broken"
+  printf 'services:\n  x:\n    image: busybox\n' > "$d/app/docker-compose.yml"
+  printf 'services:\n  x:\n    image: busybox\n' > "$d/web/docker-compose.yml"
+  printf 'not: [valid\n' > "$d/broken/docker-compose.yml"    # present dir, invalid compose (stub fails config -q)
+  printf '%s' "$d"
+}
+
+# run_body <FORCE_RECREATE> <ONLY_STACK> -> sets: RC, LOG (path to recorded ups)
+run_body() {
+  local force="$1" only="$2" d log rc=0
+  d="$(mkremote)"; log="$TMP/log.$RANDOM"; : > "$log"
+  STUB_LOG="$log" PATH="$bin:$PATH" bash "$BODY" "$d" "$force" "$only" >"$TMP/out" 2>&1 || rc=$?
+  RC=$rc; LOG="$log"; OUT="$(cat "$TMP/out")"; rm -rf "$d"
+}
+
+# Each log line is `UP <stack> up -d --pull always --remove-orphans [--force-recreate]`,
+# the stack identified by the cwd the compose ran in (not an arg).
+
+# 1) No targeting: both stacks come up, none forced.
+run_body false ''
+[ "$RC" -eq 0 ] || fail "no-target: expected rc0, got $RC: $OUT"
+grep -q '^UP app ' "$LOG" && grep -q '^UP web ' "$LOG" || fail "no-target: both stacks must come up, log: $(cat "$LOG")"
+grep -q -- '--force-recreate' "$LOG" && fail "no-target: must NOT force-recreate, log: $(cat "$LOG")"
+
+# 2) Single-stack target: ONLY that stack comes up (sibling skipped).
+run_body false app
+[ "$RC" -eq 0 ] || fail "target-app: expected rc0, got $RC: $OUT"
+grep -q '^UP app ' "$LOG" || fail "target-app: app must come up, log: $(cat "$LOG")"
+grep -q '^UP web ' "$LOG" && fail "target-app: web must be skipped, log: $(cat "$LOG")"
+
+# 3) force_recreate: the up for the target carries --force-recreate.
+run_body true app
+[ "$RC" -eq 0 ] || fail "force-app: expected rc0, got $RC: $OUT"
+grep -q '^UP app .*--force-recreate' "$LOG" || fail "force-app: app's up must include --force-recreate, log: $(cat "$LOG")"
+
+# 4) Stack not found -> loud failure (rc!=0, clear error), NOT a silent green no-op.
+run_body true nonexistent
+[ "$RC" -ne 0 ] || fail "stack-not-found: must FAIL (rc!=0), got rc0 no-op: $OUT"
+printf '%s' "$OUT" | grep -q "not found" || fail "stack-not-found: must emit a 'not found' error, got: $OUT"
+grep -q '^UP ' "$LOG" && fail "stack-not-found: nothing should have come up, log: $(cat "$LOG")"
+
+# 5) Target a PRESENT but INVALID compose dir -> loud failure too (stack_matched
+#    counts only stacks that pass `config -q`, so a broken target is not a green
+#    no-op). Regression for the Round-3 finding.
+run_body true broken
+[ "$RC" -ne 0 ] || fail "invalid-target: must FAIL (rc!=0), got rc0 no-op: $OUT"
+printf '%s' "$OUT" | grep -q "not a valid compose project" || fail "invalid-target: must emit the not-valid error, got: $OUT"
+grep -q '^UP ' "$LOG" && fail "invalid-target: nothing should have come up, log: $(cat "$LOG")"
+
+echo "ALL REMOTE-LOOP CHECKS PASSED"

--- a/tests/deploy_server_skip_test.sh
+++ b/tests/deploy_server_skip_test.sh
@@ -28,4 +28,47 @@ out="$(SERVER=has-stacks GITHUB_WORKSPACE="$ws" SSH_HOST='' SSH_USER='' SSH_PRIV
 [ "$rc" -ne 0 ] || fail "stacks present + no-SSH must FAIL the SSH check, but exited 0: $out"
 printf '%s' "$out" | grep -q 'No SSH_HOST' || fail "stacks + no-SSH must err 'No SSH_HOST', got: $out"
 
+# Case 3: an invalid ONLY_STACK (dispatch input) must be rejected up front, BEFORE
+# any SSH/network action -- the operator-controlled target is held to the same
+# name allowlist as SERVER so it can never reach the remote as a shell token.
+for bad in 'e;vil' '-x' '../etc' '.' 'a b'; do
+  rc=0
+  out="$(SERVER=has-stacks ONLY_STACK="$bad" GITHUB_WORKSPACE="$ws" SSH_HOST='' SSH_USER='' SSH_PRIVATE_KEY='' \
+         bash "$DS" 2>&1)" || rc=$?
+  [ "$rc" -ne 0 ] || fail "invalid ONLY_STACK '$bad' must FAIL, got rc=0: $out"
+  printf '%s' "$out" | grep -q 'invalid stack name' || fail "invalid ONLY_STACK '$bad' must err 'invalid stack name', got: $out"
+done
+
+# Case 4: FORCE_RECREATE must be exactly true|false (never an arbitrary string
+# that could imply an unintended flag). A junk value fails closed.
+rc=0
+out="$(SERVER=has-stacks FORCE_RECREATE='yes' GITHUB_WORKSPACE="$ws" SSH_HOST='' SSH_USER='' SSH_PRIVATE_KEY='' \
+       bash "$DS" 2>&1)" || rc=$?
+[ "$rc" -ne 0 ] || fail "invalid FORCE_RECREATE must FAIL, got rc=0: $out"
+printf '%s' "$out" | grep -q 'FORCE_RECREATE must be' || fail "invalid FORCE_RECREATE must err, got: $out"
+
+# Case 5 (positive control): a VALID ONLY_STACK + force_recreate passes validation
+# and proceeds to the SSH check (proving the guards don't reject good input).
+rc=0
+out="$(SERVER=has-stacks ONLY_STACK=app FORCE_RECREATE=true GITHUB_WORKSPACE="$ws" SSH_HOST='' SSH_USER='' SSH_PRIVATE_KEY='' \
+       bash "$DS" 2>&1)" || rc=$?
+[ "$rc" -ne 0 ] || fail "valid targeting + no-SSH must still reach the SSH check, got rc=0: $out"
+printf '%s' "$out" | grep -q 'No SSH_HOST' || fail "valid targeting must pass validation and hit SSH check, got: $out"
+
+# Case 6: a targeted stack that does NOT exist in the repo fails fast (before SSH),
+# not a silent sync-nothing. (has-stacks has 'app'; 'nope' is absent.)
+rc=0
+out="$(SERVER=has-stacks ONLY_STACK=nope GITHUB_WORKSPACE="$ws" SSH_HOST='' SSH_USER='' SSH_PRIVATE_KEY='' \
+       bash "$DS" 2>&1)" || rc=$?
+[ "$rc" -ne 0 ] || fail "missing target stack must FAIL before SSH, got rc=0: $out"
+printf '%s' "$out" | grep -q 'does not exist' || fail "missing target stack must err 'does not exist', got: $out"
+
+# Case 7: targeting a stack on a server with NO stacks dir is an error, not the
+# removed-server exit-0 skip (that skip still applies only when ONLY_STACK empty).
+rc=0
+out="$(SERVER=no-stacks ONLY_STACK=app GITHUB_WORKSPACE="$ws" SSH_HOST='' SSH_USER='' SSH_PRIVATE_KEY='' \
+       bash "$DS" 2>&1)" || rc=$?
+[ "$rc" -ne 0 ] || fail "targeting a stack on a serverless server must FAIL, got rc=0: $out"
+printf '%s' "$out" | grep -q 'Cannot target stack' || fail "serverless targeted dispatch must err 'Cannot target stack', got: $out"
+
 echo "ALL DEPLOY-SERVER SKIP CHECKS PASSED"

--- a/tests/deploy_workflow_lint_test.sh
+++ b/tests/deploy_workflow_lint_test.sh
@@ -51,4 +51,19 @@ grep -qF 'def norm' "$S"                || fail "teardown must normalize dir nam
 grep -qE 'SSH_PORT.*=~.*0-9' "$S"       || fail "SSH_PORT must be validated numeric"
 grep -qF 'Skipped teardown' "$S"        || fail "teardown enumeration must be best-effort (non-fatal on missing python3)"
 
+# Manual-dispatch targeting/force-recreate: the inputs must reach the scripts via
+# env (never a run: string), and the operator-controlled stack target must be
+# validated with the same allowlist as SERVER before it can reach the remote.
+grep -qF 'ONLY_SERVER: ${{ inputs.only_server }}' "$Y"       || fail "discover must pass ONLY_SERVER from inputs.only_server via env"
+grep -qF 'ONLY_STACK: ${{ inputs.only_stack }}' "$Y"         || fail "deploy must pass ONLY_STACK from inputs.only_stack via env"
+grep -qF 'FORCE_RECREATE: ${{ inputs.force_recreate }}' "$Y" || fail "deploy must pass FORCE_RECREATE from inputs.force_recreate via env"
+grep -qF 'invalid stack name' "$S"                           || fail "deploy-server.sh must reject an invalid ONLY_STACK (name allowlist)"
+grep -qF -- '--force-recreate' "$S"                          || fail "deploy-server.sh must support --force-recreate when FORCE_RECREATE=true"
+# The safety guard must require only_server for BOTH targeted knobs (force_recreate
+# and only_stack), else a stack-targeted dispatch fans out across the whole fleet.
+grep -qF "inputs.only_stack != ''" "$Y"                      || fail "guard must also require only_server when only_stack is set (documented precondition)"
+# A single-stack dispatch that matches no valid stack must fail loudly, not
+# silently succeed (covers both a missing dir and a present-but-invalid compose).
+grep -qF 'not a valid compose project' "$S"                  || fail "deploy-server.sh must fail a single-stack dispatch that matches no valid stack"
+
 echo "ALL DEPLOY WORKFLOW LINT CHECKS PASSED"

--- a/tests/discover_changed_servers_test.sh
+++ b/tests/discover_changed_servers_test.sh
@@ -6,6 +6,11 @@
 #       base / force-push), via throwaway real git repos.
 # Every assertion is paired with the bad input it must reject, so it can FAIL.
 set -euo pipefail
+# Hermetic env: the GitHub runner sets GITHUB_WORKSPACE to the miuops checkout,
+# which has no fleet/stacks -- that would misfire the ONLY_SERVER dir-existence
+# check for the no-workspace cases below. Unset it here; the cases that exercise
+# that check set GITHUB_WORKSPACE explicitly per-command.
+unset GITHUB_WORKSPACE
 ROOT="$(cd "$(dirname "$0")/.." && pwd)"
 SCRIPT="$ROOT/.github/scripts/discover-changed-servers.sh"
 TMP="$(mktemp -d)"; trap 'rm -rf "$TMP"' EXIT
@@ -75,5 +80,34 @@ got="$(cd "$GR" && BEFORE="deadbeefdeadbeefdeadbeefdeadbeefdeadbeef" AFTER="$C3"
 ( cd "$GR" && git checkout -q -b div "$C1" && mkdir -p fleet/stacks/divsrv && echo x > fleet/stacks/divsrv/c.yml && git add -A && git commit -qm div ); CDIV="$(gsha)"
 got="$(cd "$GR" && BEFORE="$CDIV" AFTER="$C3" bash "$SCRIPT")"
 [ "$got" = '["gamma"]' ] || fail "non-ancestor(merge-base C1..C3): expected [gamma], got $got"
+
+# --- Layer C: ONLY_SERVER manual-dispatch override ------------------------
+# A valid name emits just that server, needing NO git range (short-circuits
+# before AFTER is required).
+got="$(ONLY_SERVER=web bash "$SCRIPT")"
+[ "$got" = '["web"]' ] || fail "only_server valid: expected [web], got $got"
+# The override wins over a real diff that would otherwise yield [gamma].
+got="$(cd "$GR" && ONLY_SERVER=web BEFORE="$C1" AFTER="$C2" bash "$SCRIPT")"
+[ "$got" = '["web"]' ] || fail "only_server overrides diff: expected [web], got $got"
+# Valid dotted/underscore/upper name accepted verbatim.
+got="$(ONLY_SERVER='db.1_node' bash "$SCRIPT")"
+[ "$got" = '["db.1_node"]' ] || fail "only_server dotted: expected [db.1_node], got $got"
+# Invalid / injection / traversal names fail SAFE to [] (never widen the matrix,
+# never reach ssh/rsync as anything but an inert string). Each paired with [].
+for bad in 'a;rm -rf ~' '-evil' '.' '..' '.hidden' '$(id)' 'a b' 'a/b'; do
+  got="$(ONLY_SERVER="$bad" bash "$SCRIPT")"
+  [ "$got" = '[]' ] || fail "only_server invalid '$bad': expected [], got $got"
+done
+
+# With a visible checkout (GITHUB_WORKSPACE), a well-formed but NONEXISTENT
+# only_server is an operator typo -> loud error, not a silent whole-run no-op.
+# (Without a workspace, above, the name is emitted as-is; both paths matter.)
+WS="$TMP/ws"; mkdir -p "$WS/fleet/stacks/web"
+got="$(ONLY_SERVER=web GITHUB_WORKSPACE="$WS" STACKS_DIR=fleet/stacks bash "$SCRIPT")"
+[ "$got" = '["web"]' ] || fail "only_server existing dir: expected [web], got $got"
+rc=0
+got="$(ONLY_SERVER=webb GITHUB_WORKSPACE="$WS" STACKS_DIR=fleet/stacks bash "$SCRIPT" 2>&1)" || rc=$?
+[ "$rc" -ne 0 ] || fail "only_server typo with a visible checkout must FAIL, got rc=0: $got"
+printf '%s' "$got" | grep -q 'has no stacks' || fail "only_server typo must err 'has no stacks', got: $got"
 
 echo "ALL DISCOVER TESTS PASSED"


### PR DESCRIPTION
## What

Adds a manual **redeploy/restart** capability to the reusable deploy workflow so an operator can trigger a *targeted* container recreate via GitHub Actions dispatch (no SSH). Motivating case: make a service re-run its entrypoint (re-pull a data repo / reinstall deps at boot) when the fix lives in a repo it clones at startup, not in its image.

## New `workflow_call` inputs (all inert on a normal push)
- `only_server` — deploy just one server, bypassing git-diff discovery.
- `only_stack` — within that server, bring up just one stack.
- `force_recreate` — add `docker compose up --force-recreate`.

## Safety / correctness
- A **discover guard** requires `only_server` whenever `force_recreate` **or** `only_stack` is set, so a targeted op can never fan across the whole fleet (a dispatch has no diff base → discovery would otherwise deploy everything).
- Targeting **fails loudly** on operator error instead of a silent green no-op: a typo'd `only_server`, a repo-absent `only_stack`, or a present-but-**invalid** compose target all error.
- A single-stack dispatch **scopes the rsync** to that stack's own subdir (no sibling `--delete`) and skips removed-stack teardown — it touches nothing but the named stack.
- All operator-controlled inputs are validated against the existing name allowlist and passed only as data / positional args, never concatenated into a command. Per-server Environment isolation, SHA-pinned actions, secret hygiene, and `contents: read` are all preserved.

## Tests
Extends the discover / deploy-server / workflow-lint suites and adds `deploy_remote_loop_test.sh`, which **extracts and executes** the SSH heredoc body against a stubbed `docker` (the remote up-loop had no offline coverage before).

## Review
Reviewed across **4 independent audit rounds** (code + security + secret-leak, each finding adversarially verified). Rounds 1–3 surfaced 7 issues (guard gaps, silent no-op paths, an rsync-orphan edge, a misleading input description) — all fixed with regression tests. Round 4 came back clean. Secret-leak audits were clean every round.